### PR TITLE
Removed 2.0.0-dev sdk

### DIFF
--- a/chopper/pubspec.yaml
+++ b/chopper/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/lejard-h/chopper
 author: Hadrien Lejard <hadrien.lejard@gmail.com>
 
 environment:
-  sdk: '>=2.0.0-dev <3.0.0'
+  sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
   http: "^0.11.0"

--- a/chopper_generator/pubspec.yaml
+++ b/chopper_generator/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/lejard-h/chopper
 author: Hadrien Lejard <hadrien.lejard@gmail.com>
 
 environment:
-  sdk: '>=2.0.0-dev <3.0.0'
+  sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
   meta: ^1.1.2

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 author: Hadrien Lejard <hadrien.lejard@gmail.com>
 
 environment:
-  sdk: '>=2.0.0-dev <3.0.0'
+  sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
   angular: ^5.0.0


### PR DESCRIPTION
Removed 2.0.0-dev sdk since dart 2.0.0 is at stable now (so is flutter)