### PR TITLE
Allow fully-specific URLs to be provided

### DIFF
--- a/chopper/lib/src/request.dart
+++ b/chopper/lib/src/request.dart
@@ -69,10 +69,16 @@ class Request {
 
   Uri _buildUri() {
     var uri;
-    if (!baseUrl.endsWith('/') && !url.startsWith('/')) {
-      uri = Uri.parse("$baseUrl/$url");
+    if (url.startsWith('http://') || url.startsWith('https://')) {
+      // if the request's url is already a fully qualified URL, we can use
+      // as-is and ignore the baseUrl
+      uri = Uri.parse(url);
     } else {
-      uri = Uri.parse("$baseUrl$url");
+      if (!baseUrl.endsWith('/') && !url.startsWith('/')) {
+        uri = Uri.parse("$baseUrl/$url");
+      } else {
+        uri = Uri.parse("$baseUrl$url");
+      }
     }
 
     if (parameters.isNotEmpty) {


### PR DESCRIPTION
At the moment, if you provide a fully-qualified URL in the `url` parameter for a request, it gets concatenated to the `baseUrl` (which is not correct). No matter what value you set `baseUrl` to, you just can't prevent it from concatening both `baseUrl` and `url`.

This change changes the logic so that if the `url` parameter is a fully formed URL, we can just use it directly instead of trying to combine it with the `baseUrl`.