### PR TITLE
Decode json using utf-8

### DIFF
--- a/chopper/lib/src/base.dart
+++ b/chopper/lib/src/base.dart
@@ -163,7 +163,21 @@ class ChopperClient {
 
     final response = await http.Response.fromStream(stream);
 
-    Response res = Response(response, response.body);
+    String responseBody;
+    var contentType = response.headers['content-type'];
+    if (contentType != null && contentType.contains("application/json")) {
+      // If we're decoding JSON, there's some ambiguity in https://tools.ietf.org/html/rfc2616
+      // about what encoding should be used if the content-type doesn't contain a 'charset'
+      // parameter. See https://github.com/dart-lang/http/issues/186. In a nutshell, without
+      // an explicit charset, the Dart http library will fall back to using ISO-8859-1, however,
+      // https://tools.ietf.org/html/rfc8259 says that JSON must be encoded using UTF-8. So,
+      // we're going to explicitly decode using UTF-8... if we don't do this, then we can easily
+      // end up with our JSON string containing incorrectly decoded characters.
+      responseBody = utf8.decode(response.bodyBytes);
+    } else {
+      responseBody = response.body;
+    }
+    Response res = Response(response, responseBody);
 
     if (req.json == true) {
       res = _tryDecodeJson(res);


### PR DESCRIPTION
This change resolves an ambiguity between the HTTP and JSON RFCs.

I've added a detailed comment in the code that describes what we're doing and why.