### PR TITLE
Converter types fix

### DIFF
--- a/chopper/lib/src/base.dart
+++ b/chopper/lib/src/base.dart
@@ -88,7 +88,7 @@ class ChopperClient {
   ) async {
     if (withConverter == null) return response;
 
-    final converted = await withConverter.convertResponse<ToDecode>(response);
+    final converted = await withConverter.convertResponse<Body, ToDecode>(response);
 
     if (converted == null) {
       throw Exception("No converter found for type $ToDecode");

--- a/chopper/lib/src/base.dart
+++ b/chopper/lib/src/base.dart
@@ -82,16 +82,16 @@ class ChopperClient {
     return request;
   }
 
-  Future<Response<Body>> _decodeResponse<Body, ToDecode>(
+  Future<Response<Body>> _decodeResponse<Body, Item>(
     Response response,
     Converter withConverter,
   ) async {
     if (withConverter == null) return response;
 
-    final converted = await withConverter.convertResponse<Body, ToDecode>(response);
+    final converted = await withConverter.convertResponse<Body, Item>(response);
 
     if (converted == null) {
-      throw Exception("No converter found for type $ToDecode");
+      throw Exception("No converter found for type $Item");
     }
 
     return converted;
@@ -121,7 +121,7 @@ class ChopperClient {
     return res;
   }
 
-  Future<Response<Body>> send<Body, ToDecode>(
+  Future<Response<Body>> send<Body, Item>(
     Request request, {
     ConvertRequest requestConverter,
     ConvertResponse responseConverter,
@@ -148,7 +148,7 @@ class ChopperClient {
       if (responseConverter != null) {
         res = await responseConverter(res);
       } else {
-        res = await _decodeResponse<Body, ToDecode>(res, converter);
+        res = await _decodeResponse<Body, Item>(res, converter);
       }
     } else {
       res = await _decodeResponse(res, errorConverter);

--- a/chopper/lib/src/interceptor.dart
+++ b/chopper/lib/src/interceptor.dart
@@ -21,7 +21,7 @@ abstract class RequestInterceptor {
 @immutable
 abstract class Converter {
   FutureOr<Request> convertRequest(Request request);
-  FutureOr<Response> convertResponse<ConvertedResponseType>(Response response);
+  FutureOr<Response> convertResponse<ResultType, ItemType>(Response response);
 }
 
 @immutable
@@ -123,7 +123,7 @@ class JsonConverter implements Converter {
       );
 
   @override
-  Response convertResponse<ConvertedResponseType>(Response response) {
+  Response convertResponse<ResultType, ItemType>(Response response) {
     var contentType = response.headers[contentTypeKey];
     var body = response.body;
     if (contentType != null && contentType.contains(jsonHeaders)) {
@@ -160,6 +160,5 @@ class FormUrlEncodedConverter implements Converter {
       );
 
   @override
-  Response convertResponse<ConvertedResponseType>(Response response) =>
-      response;
+  Response convertResponse<ResultType, ItemType>(Response response) => response;
 }

--- a/chopper/pubspec.yaml
+++ b/chopper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chopper
 description: Chopper is an http client generator using source_gen and inspired from retrofit
-version: 2.1.0
+version: 2.1.1
 homepage: https://github.com/lejard-h/chopper
 author: Hadrien Lejard <hadrien.lejard@gmail.com>
 

--- a/chopper/test/converter_test.dart
+++ b/chopper/test/converter_test.dart
@@ -62,7 +62,8 @@ class TestConverter extends Converter {
   @override
   Response<T> convertResponse<T, V>(Response res) {
     if (res.body is String) {
-      return res.replace<_Converted<String>>(body: _Converted<String>(res.body)) as Response<T>;
+      return res.replace<_Converted<String>>(body: _Converted<String>(res.body)) 
+          as Response<T>;
     }
     return res;
   }
@@ -78,7 +79,8 @@ class TestErrorConverter extends Converter {
   @override
   Response<T> convertResponse<T, V>(Response res) {
     if (res.body is String) {
-      return res.replace<_ConvertedError<String>>(body: _ConvertedError<String>(res.body));
+      return res.replace<_ConvertedError<String>>(
+          body: _ConvertedError<String>(res.body));
     }
     return res;
   }

--- a/chopper/test/converter_test.dart
+++ b/chopper/test/converter_test.dart
@@ -18,7 +18,8 @@ void main() {
     test('base decode', () async {
       final converter = TestConverter();
 
-      final decoded = await converter.convertResponse<_Converted<String>, _Converted<String>>(
+      final decoded = await converter
+          .convertResponse<_Converted<String>, _Converted<String>>(
         Response<String>(http.Response('', 200), 'foo'),
       );
 
@@ -62,7 +63,7 @@ class TestConverter extends Converter {
   @override
   Response<T> convertResponse<T, V>(Response res) {
     if (res.body is String) {
-      return res.replace<_Converted<String>>(body: _Converted<String>(res.body)) 
+      return res.replace<_Converted<String>>(body: _Converted<String>(res.body))
           as Response<T>;
     }
     return res;

--- a/chopper/test/converter_test.dart
+++ b/chopper/test/converter_test.dart
@@ -18,7 +18,7 @@ void main() {
     test('base decode', () async {
       final converter = TestConverter();
 
-      final decoded = await converter.convertResponse<_Converted<String>>(
+      final decoded = await converter.convertResponse<_Converted<String>, _Converted<String>>(
         Response<String>(http.Response('', 200), 'foo'),
       );
 
@@ -60,10 +60,9 @@ void main() {
 
 class TestConverter extends Converter {
   @override
-  Response<T> convertResponse<T>(Response res) {
+  Response<T> convertResponse<T, V>(Response res) {
     if (res.body is String) {
-      return res.replace<_Converted<String>>(body: _Converted<String>(res.body))
-          as Response<T>;
+      return res.replace<_Converted<String>>(body: _Converted<String>(res.body)) as Response<T>;
     }
     return res;
   }
@@ -77,10 +76,9 @@ class TestConverter extends Converter {
 
 class TestErrorConverter extends Converter {
   @override
-  Response<T> convertResponse<T>(Response res) {
+  Response<T> convertResponse<T, V>(Response res) {
     if (res.body is String) {
-      return res.replace<_ConvertedError<String>>(
-          body: _ConvertedError<String>(res.body));
+      return res.replace<_ConvertedError<String>>(body: _ConvertedError<String>(res.body));
     }
     return res;
   }

--- a/chopper_generator/pubspec.yaml
+++ b/chopper_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chopper_generator
 description: Chopper is an http client generator using source_gen and inspired from retrofit
-version: 2.1.0
+version: 2.1.1
 homepage: https://github.com/lejard-h/chopper
 author: Hadrien Lejard <hadrien.lejard@gmail.com>
 

--- a/example/bin/main_built_value.dart
+++ b/example/bin/main_built_value.dart
@@ -33,13 +33,13 @@ main() async {
   final myService = chopper.service<MyService>(MyService);
 
   final response1 = await myService.getResource("1");
-  print(response1.body); // undecoded String
+  print('response 1: ${response1.body}'); // undecoded String
 
   final response2 = await myService.getTypedResource();
-  print(response2.body); // decoded Resource
+  print('response 2: ${response2.body}'); // decoded Resource
 
   final response3 = await myService.getBuiltListResources();
-  print(response3.body);
+  print('response 3: ${response3.body}');
 
   try {
     final builder = ResourceBuilder()
@@ -77,14 +77,14 @@ class BuiltValueConverter extends JsonConverter {
   }
 
   @override
-  Response convertResponse<T>(Response response) {
+  Response convertResponse<ResultType, Item>(Response response) {
     // use [JsonConverter] to decode json
-    final jsonRes = super.convertResponse<T>(response);
+    final jsonRes = super.convertResponse<ResultType, Item>(response);
 
-    final body = _decode<T>(jsonRes.body);
+    final body = _decode<ResultType>(jsonRes.body);
 
-    if (body is BuiltList) return jsonRes.replace<BuiltList<T>>(body: body);
-    return jsonRes.replace<T>(body: body);
+    if (body is BuiltList) return jsonRes.replace<BuiltList<Item>>(body: body);
+    return jsonRes.replace<ResultType>(body: body);
   }
 
   @override

--- a/example/bin/main_jaguar_serializer.dart
+++ b/example/bin/main_jaguar_serializer.dart
@@ -8,7 +8,7 @@ import 'package:jaguar_serializer/jaguar_serializer.dart';
 final client = MockClient((req) async {
   if (req.method == 'POST')
     return http.Response('{"type":"Fatal","message":"fatal erorr"}', 500);
-  if (req.method == 'GET' && req.headers['test'] == 'list') 
+  if (req.method == 'GET' && req.headers['test'] == 'list')
     return http.Response('[{"id":"1","name":"Foo"}]', 200);
   return http.Response('{"id":"1","name":"Foo"}', 200);
 });
@@ -31,7 +31,7 @@ main() async {
   print('response 1: ${response1.body}'); // undecoded String
 
   final response2 = await myService.getResources();
-  print('response 2: ${response2.body}'); // decoded list of Resources 
+  print('response 2: ${response2.body}'); // decoded list of Resources
 
   final response3 = await myService.getTypedResource();
   print('response 3: ${response3.body}'); // decoded Resource

--- a/example/bin/main_jaguar_serializer.dart
+++ b/example/bin/main_jaguar_serializer.dart
@@ -8,6 +8,8 @@ import 'package:jaguar_serializer/jaguar_serializer.dart';
 final client = MockClient((req) async {
   if (req.method == 'POST')
     return http.Response('{"type":"Fatal","message":"fatal erorr"}', 500);
+  if (req.method == 'GET' && req.headers['test'] == 'list') 
+    return http.Response('[{"id":"1","name":"Foo"}]', 200);
   return http.Response('{"id":"1","name":"Foo"}', 200);
 });
 
@@ -26,13 +28,16 @@ main() async {
   final myService = chopper.service<MyService>(MyService);
 
   final response1 = await myService.getResource("1");
-  print(response1.body); // undecoded String
+  print('response 1: ${response1.body}'); // undecoded String
 
-  final response2 = await myService.getTypedResource();
-  print(response2.body); // decoded Resour
+  final response2 = await myService.getResources();
+  print('response 2: ${response2.body}'); // decoded list of Resources 
 
-  final response3 = await myService.getMapResource("1");
-  print(response3.body); // und Resource
+  final response3 = await myService.getTypedResource();
+  print('response 3: ${response3.body}'); // decoded Resource
+
+  final response4 = await myService.getMapResource("1");
+  print('response 4: ${response4.body}'); // undecoded Resource
 
   try {
     await myService.newResource(Resource("3", "Super Name"));
@@ -47,14 +52,14 @@ final repository = SerializerRepoImpl(serializers: [
 ]);
 
 class JaguarConverter extends JsonConverter {
-  dynamic _decode<ConvertedResponseType>(entity) {
+  dynamic _decode<Item>(entity) {
     /// handle case when we want to access to Map<String, dynamic> directly
     /// getResource or getMapResource
     /// Avoid dynamic or unconverted value, this could lead to several issues
-    if (entity is ConvertedResponseType) return entity;
+    if (entity is Item) return entity;
 
-    final serializer = repository.getByType<ConvertedResponseType>(
-      ConvertedResponseType,
+    final serializer = repository.getByType<Item>(
+      Item,
     );
 
     /// throw serializer not found error;
@@ -62,18 +67,18 @@ class JaguarConverter extends JsonConverter {
 
     if (entity is Map) return serializer.fromMap(entity);
 
-    if (entity is List) return serializer.fromList(entity);
+    if (entity is List) return serializer.fromList(entity.cast<Map>());
 
     return entity;
   }
 
   @override
-  Response convertResponse<ConvertedResponseType>(Response response) {
+  Response<ResultType> convertResponse<ResultType, Item>(Response response) {
     // use [JsonConverter] to decode json
-    final jsonRes = super.convertResponse<ConvertedResponseType>(response);
+    final jsonRes = super.convertResponse<ResultType, Item>(response);
 
-    return jsonRes.replace<ConvertedResponseType>(
-      body: _decode<ConvertedResponseType>(jsonRes.body),
+    return jsonRes.replace<ResultType>(
+      body: _decode<Item>(jsonRes.body),
     );
   }
 
@@ -89,7 +94,7 @@ class ErrorConverter extends JsonConverter {
   final _serializer = ResourceErrorSerializer();
 
   @override
-  Response convertResponse<ConvertedResponseType>(Response response) {
+  Response<ResultType> convertResponse<ResultType, Item>(Response response) {
     // use [JsonConverter] to decode json
     final jsonRes = super.convertResponse(response);
 

--- a/example/bin/main_json_serializable.dart
+++ b/example/bin/main_json_serializable.dart
@@ -9,7 +9,7 @@ import 'package:http/testing.dart';
 final client = MockClient((req) async {
   if (req.method == 'POST')
     return http.Response('{"type":"Fatal","message":"fatal erorr"}', 500);
-  if (req.method == 'GET' && req.headers['test'] == 'list') 
+  if (req.method == 'GET' && req.headers['test'] == 'list')
     return http.Response('[{"id":"1","name":"Foo"}]', 200);
   return http.Response('{"id":"1","name":"Foo"}', 200);
 });
@@ -39,7 +39,7 @@ main() async {
   print('response 1: ${response1.body}'); // undecoded String
 
   final response2 = await myService.getResources();
-  print('response 2: ${response2.body}'); // decoded list of Resources 
+  print('response 2: ${response2.body}'); // decoded list of Resources
 
   final response3 = await myService.getTypedResource();
   print('response 3: ${response3.body}'); // decoded Resource

--- a/example/lib/built_value_resource.dart
+++ b/example/lib/built_value_resource.dart
@@ -1,5 +1,7 @@
 library resource;
 
+import 'dart:async';
+
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';

--- a/example/lib/jaguar_serializer.chopper.dart
+++ b/example/lib/jaguar_serializer.chopper.dart
@@ -20,6 +20,13 @@ class _$MyService extends MyService {
     return client.send<dynamic, dynamic>($request);
   }
 
+  Future<Response<List<Resource>>> getResources() {
+    final $url = '/resources/all';
+    final $headers = {'test': 'list'};
+    final $request = Request('GET', $url, client.baseUrl, headers: $headers);
+    return client.send<List<Resource>, Resource>($request);
+  }
+
   Future<Response<Map>> getMapResource(String id) {
     final $url = '/resources/';
     final $params = {'id': '$id'};

--- a/example/lib/jaguar_serializer.dart
+++ b/example/lib/jaguar_serializer.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:chopper/chopper.dart';
 import 'package:jaguar_serializer/jaguar_serializer.dart';
 

--- a/example/lib/jaguar_serializer.dart
+++ b/example/lib/jaguar_serializer.dart
@@ -33,6 +33,9 @@ abstract class MyService extends ChopperService {
   @Get(path: "/{id}/")
   Future<Response> getResource(@Path() String id);
 
+  @Get(path: "/all", headers: const {"test": "list"})
+  Future<Response<List<Resource>>> getResources();
+
   @Get(path: "/")
   Future<Response<Map>> getMapResource(@Query() String id);
 

--- a/example/lib/json_serializable.chopper.dart
+++ b/example/lib/json_serializable.chopper.dart
@@ -20,6 +20,13 @@ class _$MyService extends MyService {
     return client.send<dynamic, dynamic>($request);
   }
 
+  Future<Response<List<Resource>>> getResources() {
+    final $url = '/resources/all';
+    final $headers = {'test': 'list'};
+    final $request = Request('GET', $url, client.baseUrl, headers: $headers);
+    return client.send<List<Resource>, Resource>($request);
+  }
+
   Future<Response<Map>> getMapResource(String id) {
     final $url = '/resources/';
     final $params = {'id': '$id'};

--- a/example/lib/json_serializable.dart
+++ b/example/lib/json_serializable.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:chopper/chopper.dart';
 import 'package:json_annotation/json_annotation.dart';
 

--- a/example/lib/json_serializable.dart
+++ b/example/lib/json_serializable.dart
@@ -35,6 +35,9 @@ abstract class MyService extends ChopperService {
   @Get(path: "/{id}/")
   Future<Response> getResource(@Path() String id);
 
+  @Get(path: "/all", headers: const {"test": "list"})
+  Future<Response<List<Resource>>> getResources();
+
   @Get(path: "/")
   Future<Response<Map>> getMapResource(@Query() String id);
 


### PR DESCRIPTION
I have just faced the issue, that if you want to convert Response from JSON string to a `List` of objects, you can not do it because converter _does not know_ about the `Body` type, and request fails on converting. 

``` 
Future<Response<Body>> _decodeResponse<Body, ToDecode>(...) async {
    ...
    final converted = await withConverter.convertResponse<ToDecode>(response);
    ...
    return converted;
  }
```

![image](https://user-images.githubusercontent.com/28561249/54465791-a2427e80-4785-11e9-8bc8-4acc9146b858.png)

`Unhandled Exception: type 'Response<dynamic>' is not a subtype of type 'FutureOr<Response<List<Language>>>'`

You can play with this types, but in this case without extra generic type you cannot get working program

The main idea of solution - just to add `ResultType` to converters with renaming `ToDecode` to `ItemType`

In `Converter`:
`convertResponse<ToDecode> => convertResponse<ResultType, ItemType>`

@lejard-h If you can, polish this variant (if needed) and give a stable version 2.2.0 (fox example) as fast as possible :)