### PR TITLE
Add stream support for body request and for output body response

### DIFF
--- a/chopper/CHANGELOG.md
+++ b/chopper/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.4.0
+
+- ***Breaking Change***
+  `Response.base` is now a `BaseRequest` instead of a `Request`, which means that you can't do base.body now.
+  Please use Response.bodyBytes or Response.bodyString instead for non streaming case.
+- Now supports streams !
+  - You can pass `Stream<List<int>>` as a body to a request
+  - You can also use `Stream<List<int>>` as the BodyType for the response, in this case the returned response will contain a stream in `body`.
+
 ## 2.3.1
 
 - Default value for a path is now `''` instead of '/'

--- a/chopper/lib/src/base.dart
+++ b/chopper/lib/src/base.dart
@@ -12,6 +12,7 @@ import "interceptor.dart";
 import "request.dart";
 import 'response.dart';
 import 'annotations.dart';
+import 'utils.dart';
 
 Type typeOf<T>() => T;
 
@@ -167,9 +168,12 @@ class ChopperClient {
     req = await _interceptRequest(req);
 
     _requestController.add(req);
-    final stream = await httpClient.send(await req.toBaseRequest());
+    final streamRes = await httpClient.send(await req.toBaseRequest());
+    if (isTypeOf<BodyType, Stream<List<int>>>()) {
+      return Response(streamRes, (streamRes.stream) as BodyType);
+    }
 
-    final response = await http.Response.fromStream(stream);
+    final response = await http.Response.fromStream(streamRes);
     Response res = Response(response, response.body);
 
     if (res.isSuccessful) {

--- a/chopper/lib/src/interceptor.dart
+++ b/chopper/lib/src/interceptor.dart
@@ -115,9 +115,12 @@ class HttpLoggingInterceptor
     response.base.headers.forEach((k, v) => chopperLogger.info('$k: $v'));
 
     var bytes;
-    if (response.base.body != null && response.base.body.isNotEmpty) {
-      chopperLogger.info(response.base.body);
-      bytes = ' (${response.base.bodyBytes.length}-byte body)';
+    if (response.base is http.Response) {
+      final resp = response.base as http.Response;
+      if (resp.body != null && resp.body.isNotEmpty) {
+        chopperLogger.info(resp.body);
+        bytes = ' (${response.bodyBytes?.length}-byte body)';
+      }
     }
 
     chopperLogger.info('--> END ${base.method}$bytes');

--- a/chopper/lib/src/request.dart
+++ b/chopper/lib/src/request.dart
@@ -61,6 +61,16 @@ class Request {
     final uri = _buildUri();
     final heads = _buildHeaders();
 
+    // TODO implements stream for multipart
+    if (body is Stream<List<int>>) {
+      return toStreamedRequest(
+        body,
+        method,
+        uri,
+        heads,
+      );
+    }
+
     if (multipart) {
       return toMultipartRequest(
         parts,
@@ -170,4 +180,19 @@ Future<http.MultipartRequest> toMultipartRequest(
     }
   }
   return baseRequest;
+}
+
+Future<http.BaseRequest> toStreamedRequest(
+  Stream<List<int>> bodyStream,
+  String method,
+  Uri uri,
+  Map<String, String> headers,
+) async {
+  final req = http.StreamedRequest(method, uri);
+  req.headers.addAll(headers);
+
+  bodyStream.listen(req.sink.add,
+      onDone: req.sink.close, onError: req.sink.addError);
+
+  return req;
 }

--- a/chopper/lib/src/response.dart
+++ b/chopper/lib/src/response.dart
@@ -5,12 +5,12 @@ import 'package:meta/meta.dart';
 
 @immutable
 class Response<BodyType> {
-  final http.Response base;
+  final http.BaseResponse base;
   final BodyType body;
 
-  const Response(this.base, this.body);
+  Response(this.base, this.body);
 
-  Response replace<NewBodyType>({http.Response base, NewBodyType body}) =>
+  Response replace<NewBodyType>({http.BaseResponse base, NewBodyType body}) =>
       Response<NewBodyType>(base ?? this.base, body ?? this.body);
 
   int get statusCode => base.statusCode;
@@ -19,5 +19,9 @@ class Response<BodyType> {
 
   Map<String, String> get headers => base.headers;
 
-  Uint8List get bodyBytes => base.bodyBytes;
+  Uint8List get bodyBytes =>
+      base is http.Response ? (base as http.Response).bodyBytes : null;
+
+  String get bodyString =>
+      base is http.Response ? (base as http.Response).body : null;
 }

--- a/chopper/lib/src/utils.dart
+++ b/chopper/lib/src/utils.dart
@@ -60,3 +60,9 @@ class _Pair<A, B> {
 
   String toString() => '$first=$second';
 }
+
+bool isTypeOf<ThisType, OfType>() => _Instance<ThisType>() is _Instance<OfType>;
+
+class _Instance<T> {
+  //
+}

--- a/chopper/pubspec.yaml
+++ b/chopper/pubspec.yaml
@@ -1,11 +1,11 @@
 name: chopper
 description: Chopper is an http client generator using source_gen and inspired from retrofit
-version: 2.3.1
+version: 2.4.0
 homepage: https://github.com/lejard-h/chopper
 author: Hadrien Lejard <hadrien.lejard@gmail.com>
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.1.0 <3.0.0'
 
 dependencies:
   http: ">=0.11.0 <1.0.0"

--- a/chopper/test/test_service.chopper.dart
+++ b/chopper/test/test_service.chopper.dart
@@ -21,6 +21,12 @@ class _$HttpTestService extends HttpTestService {
     return client.send<dynamic, dynamic>($request);
   }
 
+  Future<Response<Stream<List<int>>>> getStreamTest() {
+    final $url = '/test/get';
+    final $request = Request('GET', $url, client.baseUrl);
+    return client.send<Stream<List<int>>, int>($request);
+  }
+
   Future<Response> getQueryTest({String name, int number, int def = 42}) {
     final $url = '/test/query';
     final Map<String, dynamic> $params = {
@@ -50,6 +56,13 @@ class _$HttpTestService extends HttpTestService {
   Future<Response> postTest(String data) {
     final $url = '/test/post';
     final $body = data;
+    final $request = Request('POST', $url, client.baseUrl, body: $body);
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  Future<Response> postStreamTest(Stream<List<int>> byteStream) {
+    final $url = '/test/post';
+    final $body = byteStream;
     final $request = Request('POST', $url, client.baseUrl, body: $body);
     return client.send<dynamic, dynamic>($request);
   }

--- a/chopper/test/test_service.dart
+++ b/chopper/test/test_service.dart
@@ -15,6 +15,9 @@ abstract class HttpTestService extends ChopperService {
     @Header('test') String dynamicHeader,
   });
 
+  @Get(path: "get")
+  Future<Response<Stream<List<int>>>> getStreamTest();
+
   @Get(path: "query")
   Future<Response> getQueryTest({
     @Query('name') String name,
@@ -33,6 +36,9 @@ abstract class HttpTestService extends ChopperService {
 
   @Post(path: "post")
   Future<Response> postTest(@Body() String data);
+
+  @Post(path: "post")
+  Future<Response> postStreamTest(@Body() Stream<List<int>> byteStream);
 
   @Put(path: 'put/{id}')
   Future<Response> putTest(@Path('id') String test, @Body() String data);

--- a/example/web/main.dart
+++ b/example/web/main.dart
@@ -30,4 +30,5 @@ void main() {
 
 Object hot$onDestroy() {
   _app.destroy();
+  return null;
 }


### PR DESCRIPTION
For usage just pass a `Stream<List<int>>` as a body for requests, or specify `Response<Stream<List<int>>>` as a return type in your generator to get a stream.