### PR TITLE
Use "latest version" instead of hardcoded values in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ Add the generator to your dev dependencies
 
 ```yaml
 dependencies:
-  chopper: ^2.0.0
+  chopper: ^[latest version]
 
 dev_dependencies:
-  build_runner: ^1.0.0
-  chopper_generator: ^2.0.0
+  build_runner: ^[latest version]
+  chopper_generator: ^[latest version]
 ```
 
 ### Define and Generate your API

--- a/chopper/README.md
+++ b/chopper/README.md
@@ -11,11 +11,11 @@ Add the generator to your dev dependencies
 
 ```yaml
 dependencies:
-  chopper: ^2.0.0
+  chopper: ^[latest version]
 
 dev_dependencies:
-  build_runner: ^1.0.0
-  chopper_generator: ^2.0.0
+  build_runner: ^[latest version]
+  chopper_generator: ^[latest version]
 ```
 
 ### Define and Generate your API


### PR DESCRIPTION
Replaces hardcoded version values such as `^2.0.0` with `^[latest version]` to help users avoid unintentionally grabbing older versions.

I'm submitting this PR after spending more than an hour trying to figure out why my types were being generated incorrectly and after finally figuring out the package was actually at 2.4.2 and not 2.0.0. Sure, it is also my fault for not paying enough attention, but it happens.

**EDIT:** Scratch that. I realize now that pub actually does get the latest version and the issue I'm facing seems to be unrelated. Regardless, I feel this might be an appropriate change considering it looks like the versions in the README are lagging, so I will be waiting for input before closing.