### PR TITLE
Add ability to use the BodyType in response interceptor

### DIFF
--- a/chopper/lib/src/base.dart
+++ b/chopper/lib/src/base.dart
@@ -20,7 +20,8 @@ final allowedInterceptorsType = <Type>[
   RequestInterceptor,
   RequestInterceptorFunc,
   ResponseInterceptor,
-  ResponseInterceptorFunc
+  ResponseInterceptorFunc,
+  DynamicResponseInterceptorFunc,
 ];
 
 /// Root object of chopper
@@ -77,7 +78,9 @@ class ChopperClient {
       value is RequestInterceptor || value is RequestInterceptorFunc;
 
   bool _isResponseInterceptor(value) =>
-      value is ResponseInterceptor || value is ResponseInterceptorFunc;
+      value is ResponseInterceptor ||
+      value is ResponseInterceptorFunc ||
+      value is DynamicResponseInterceptorFunc;
 
   bool _isAnInterceptor(value) =>
       _isResponseInterceptor(value) || _isRequestInterceptor(value);
@@ -145,6 +148,8 @@ class ChopperClient {
       if (i is ResponseInterceptor) {
         res = await i.onResponse(res);
       } else if (i is ResponseInterceptorFunc) {
+        res = await i(res);
+      } else if (i is DynamicResponseInterceptorFunc) {
         res = await i(res);
       }
     }

--- a/chopper/lib/src/interceptor.dart
+++ b/chopper/lib/src/interceptor.dart
@@ -52,8 +52,10 @@ class HeadersInterceptor implements RequestInterceptor {
       applyHeaders(request, headers);
 }
 
-typedef ResponseInterceptorFunc<Value> = FutureOr<Response> Function(
+typedef ResponseInterceptorFunc = FutureOr<Response<Value>> Function<Value>(
     Response<Value> response);
+typedef DynamicResponseInterceptorFunc = FutureOr<Response> Function(
+    Response response);
 typedef RequestInterceptorFunc = FutureOr<Request> Function(Request request);
 
 /// Interceptor that print a curl request

--- a/chopper/test/interceptors_test.dart
+++ b/chopper/test/interceptors_test.dart
@@ -64,7 +64,7 @@ void main() {
 
       await chopper.getService<HttpTestService>().getTest('1234');
 
-      expect(ResponseIntercept.intercepted is _Intercepted, isTrue);
+      expect(ResponseIntercept.intercepted, isA<_Intercepted>());
     });
 
     test('ResponseInterceptorFunc', () async {
@@ -85,7 +85,28 @@ void main() {
 
       await chopper.getService<HttpTestService>().getTest('1234');
 
-      expect(intercepted is _Intercepted, isTrue);
+      expect(intercepted, isA<_Intercepted<dynamic>>());
+    });
+
+    test('TypedResponseInterceptorFunc', () async {
+      var intercepted;
+
+      final chopper = ChopperClient(
+        interceptors: [
+          <BodyType>(Response<BodyType> response) {
+            intercepted = _Intercepted(response.body);
+            return response;
+          },
+        ],
+        services: [
+          HttpTestService.create(),
+        ],
+        client: responseClient,
+      );
+
+      await chopper.getService<HttpTestService>().getTest('1234');
+
+      expect(intercepted, isA<_Intercepted<String>>());
     });
 
     test('headers', () async {
@@ -196,8 +217,8 @@ class RequestIntercept implements RequestInterceptor {
       request.replace(url: '${request.url}/intercept');
 }
 
-class _Intercepted {
-  final dynamic body;
+class _Intercepted<BodyType> {
+  final BodyType body;
 
   _Intercepted(this.body);
 }


### PR DESCRIPTION
The current version of the `ResponseInterceptorFunc` did not allow me to use the `BodyType` in the actual interceptor because of how the typedef was done.
I also added the `DynamicResponseInterceptorFunc` such that old code that was using the interceptor without `BodyType` will keep working as expected

Note: it might be nice if in the future we also integrate the `BodyType` into the `onResponse` method of the `ResponseInterceptor` class