### PR TITLE
Add optionalBody parameter to suppress warnings

### DIFF
--- a/chopper/lib/src/annotations.dart
+++ b/chopper/lib/src/annotations.dart
@@ -158,8 +158,12 @@ class Method {
   /// Mark the body as optional to suppress warnings during code generation
   final bool optionalBody;
 
-  const Method(this.method,
-      {this.path = '', this.headers = const {}, this.optionalBody = true});
+  const Method(
+    this.method, {
+    this.path = '',
+    this.headers = const {},
+    this.optionalBody = true,
+  });
 }
 
 /// Defines a method as an HTTP GET request.
@@ -174,12 +178,16 @@ class Get extends Method {
 /// Use the [Body] annotation to pass data to send.
 @immutable
 class Post extends Method {
-  const Post(
-      {String path = '',
-      Map<String, String> headers = const {},
-      optionalBody = false})
-      : super(HttpMethod.Post,
-            path: path, headers: headers, optionalBody: optionalBody);
+  const Post({
+    String path = '',
+    Map<String, String> headers = const {},
+    optionalBody = false,
+  }) : super(
+          HttpMethod.Post,
+          path: path,
+          headers: headers,
+          optionalBody: optionalBody,
+        );
 }
 
 /// Defines a method as an HTTP DELETE request.
@@ -194,24 +202,32 @@ class Delete extends Method {
 /// Use the [Body] annotation to pass data to send.
 @immutable
 class Put extends Method {
-  const Put(
-      {String path = '',
-      Map<String, String> headers = const {},
-      bool optionalBody = false})
-      : super(HttpMethod.Put,
-            path: path, headers: headers, optionalBody: optionalBody);
+  const Put({
+    String path = '',
+    Map<String, String> headers = const {},
+    bool optionalBody = false,
+  }) : super(
+          HttpMethod.Put,
+          path: path,
+          headers: headers,
+          optionalBody: optionalBody,
+        );
 }
 
 /// Defines a method as an HTTP PATCH request.
 /// Use the [Body] annotation to pass data to send.
 @immutable
 class Patch extends Method {
-  const Patch(
-      {String path = '',
-      Map<String, String> headers = const {},
-      bool optionalBody = false})
-      : super(HttpMethod.Patch,
-            path: path, headers: headers, optionalBody: optionalBody);
+  const Patch({
+    String path = '',
+    Map<String, String> headers = const {},
+    bool optionalBody = false,
+  }) : super(
+          HttpMethod.Patch,
+          path: path,
+          headers: headers,
+          optionalBody: optionalBody,
+        );
 }
 
 /// Defined a method as an HTTP HEAD request.

--- a/chopper/lib/src/annotations.dart
+++ b/chopper/lib/src/annotations.dart
@@ -155,7 +155,11 @@ class Method {
   /// Headers [Map] that should be apply to the request
   final Map<String, String> headers;
 
-  const Method(this.method, {this.path = '', this.headers = const {}});
+  /// Mark the body as optional to suppress warnings during code generation
+  final bool optionalBody;
+
+  const Method(this.method,
+      {this.path = '', this.headers = const {}, this.optionalBody = true});
 }
 
 /// Defines a method as an HTTP GET request.
@@ -170,8 +174,12 @@ class Get extends Method {
 /// Use the [Body] annotation to pass data to send.
 @immutable
 class Post extends Method {
-  const Post({String path = '', Map<String, String> headers = const {}})
-      : super(HttpMethod.Post, path: path, headers: headers);
+  const Post(
+      {String path = '',
+      Map<String, String> headers = const {},
+      optionalBody = false})
+      : super(HttpMethod.Post,
+            path: path, headers: headers, optionalBody: optionalBody);
 }
 
 /// Defines a method as an HTTP DELETE request.
@@ -186,16 +194,24 @@ class Delete extends Method {
 /// Use the [Body] annotation to pass data to send.
 @immutable
 class Put extends Method {
-  const Put({String path = '', Map<String, String> headers = const {}})
-      : super(HttpMethod.Put, path: path, headers: headers);
+  const Put(
+      {String path = '',
+      Map<String, String> headers = const {},
+      bool optionalBody = false})
+      : super(HttpMethod.Put,
+            path: path, headers: headers, optionalBody: optionalBody);
 }
 
 /// Defines a method as an HTTP PATCH request.
 /// Use the [Body] annotation to pass data to send.
 @immutable
 class Patch extends Method {
-  const Patch({String path = '', Map<String, String> headers = const {}})
-      : super(HttpMethod.Patch, path: path, headers: headers);
+  const Patch(
+      {String path = '',
+      Map<String, String> headers = const {},
+      bool optionalBody = false})
+      : super(HttpMethod.Patch,
+            path: path, headers: headers, optionalBody: optionalBody);
 }
 
 /// Defined a method as an HTTP HEAD request.

--- a/chopper/lib/src/annotations.dart
+++ b/chopper/lib/src/annotations.dart
@@ -170,7 +170,7 @@ class Method {
 @immutable
 class Get extends Method {
   const Get({
-    optionalBody = true,
+    bool optionalBody = true,
     String path = '',
     Map<String, String> headers = const {},
   }) : super(
@@ -187,7 +187,7 @@ class Get extends Method {
 @immutable
 class Post extends Method {
   const Post({
-    optionalBody = false,
+    bool optionalBody = false,
     String path = '',
     Map<String, String> headers = const {},
   }) : super(
@@ -202,7 +202,7 @@ class Post extends Method {
 @immutable
 class Delete extends Method {
   const Delete({
-    optionalBody = true,
+    bool optionalBody = true,
     String path = '',
     Map<String, String> headers = const {},
   }) : super(

--- a/chopper/lib/src/annotations.dart
+++ b/chopper/lib/src/annotations.dart
@@ -160,17 +160,25 @@ class Method {
 
   const Method(
     this.method, {
+    this.optionalBody,
     this.path = '',
     this.headers = const {},
-    this.optionalBody = true,
   });
 }
 
 /// Defines a method as an HTTP GET request.
 @immutable
 class Get extends Method {
-  const Get({String path = '', Map<String, String> headers = const {}})
-      : super(HttpMethod.Get, path: path, headers: headers);
+  const Get({
+    optionalBody = true,
+    String path = '',
+    Map<String, String> headers = const {},
+  }) : super(
+          HttpMethod.Get,
+          optionalBody: optionalBody,
+          path: path,
+          headers: headers,
+        );
 }
 
 /// Defines a method as an HTTP POST request.
@@ -179,22 +187,30 @@ class Get extends Method {
 @immutable
 class Post extends Method {
   const Post({
+    optionalBody = false,
     String path = '',
     Map<String, String> headers = const {},
-    optionalBody = false,
   }) : super(
           HttpMethod.Post,
+          optionalBody: optionalBody,
           path: path,
           headers: headers,
-          optionalBody: optionalBody,
         );
 }
 
 /// Defines a method as an HTTP DELETE request.
 @immutable
 class Delete extends Method {
-  const Delete({String path = '', Map<String, String> headers = const {}})
-      : super(HttpMethod.Delete, path: path, headers: headers);
+  const Delete({
+    optionalBody = true,
+    String path = '',
+    Map<String, String> headers = const {},
+  }) : super(
+          HttpMethod.Delete,
+          optionalBody: optionalBody,
+          path: path,
+          headers: headers,
+        );
 }
 
 /// Defines a method as an HTTP PUT request.
@@ -203,14 +219,14 @@ class Delete extends Method {
 @immutable
 class Put extends Method {
   const Put({
+    bool optionalBody = false,
     String path = '',
     Map<String, String> headers = const {},
-    bool optionalBody = false,
   }) : super(
           HttpMethod.Put,
+          optionalBody: optionalBody,
           path: path,
           headers: headers,
-          optionalBody: optionalBody,
         );
 }
 
@@ -219,22 +235,30 @@ class Put extends Method {
 @immutable
 class Patch extends Method {
   const Patch({
+    bool optionalBody = false,
     String path = '',
     Map<String, String> headers = const {},
-    bool optionalBody = false,
   }) : super(
           HttpMethod.Patch,
+          optionalBody: optionalBody,
           path: path,
           headers: headers,
-          optionalBody: optionalBody,
         );
 }
 
 /// Defined a method as an HTTP HEAD request.
 @immutable
 class Head extends Method {
-  const Head({String path = '', Map<String, String> headers = const {}})
-      : super(HttpMethod.Head, path: path, headers: headers);
+  const Head({
+    bool optionalBody = true,
+    String path = '',
+    Map<String, String> headers = const {},
+  }) : super(
+          HttpMethod.Head,
+          optionalBody: optionalBody,
+          path: path,
+          headers: headers,
+        );
 }
 
 typedef ConvertRequest = Request Function(Request request);

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -217,7 +217,9 @@ class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
           '$methodName $methodUrl\n'
           'Body is null\n'
           'Use @Body() annotation on your method parameter to provide a body to your request\n'
-          '   e.g.: Future<Response> postRequest(@Body() Map body);',
+          '   e.g.: Future<Response> postRequest(@Body() Map body);\n'
+          'Or explicitly suppress this warning by setting the optionalBody property\n'
+          '   e.g.: @Post(optionalBody: true)',
         );
       }
 

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -212,10 +212,7 @@ class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
             _generateList(parts, fileFields).assignFinal(_partsVar).statement);
       }
 
-      if (!methodOptionalBody &&
-          !hasBody &&
-          !hasParts &&
-          _methodWithBody(methodName)) {
+      if (!methodOptionalBody && !hasBody && !hasParts) {
         _logger.warning(
           '$methodName $methodUrl\n'
           'Body is null\n'
@@ -492,11 +489,6 @@ Builder chopperGeneratorFactoryBuilder({String header}) => PartBuilder(
       '.chopper.dart',
       header: header,
     );
-
-bool _methodWithBody(String method) =>
-    method == chopper.HttpMethod.Post ||
-    method == chopper.HttpMethod.Patch ||
-    method == chopper.HttpMethod.Put;
 
 bool getMethodOptionalBody(ConstantReader method) =>
     method.read('optionalBody').boolValue;

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -189,6 +189,7 @@ class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
         blocks.add(headers);
       }
 
+      final methodOptionalBody = getMethodOptionalBody(method);
       final methodName = getMethodName(method);
       final methodUrl = getMethodPath(method);
       final hasBody = body.isNotEmpty || fields.isNotEmpty;
@@ -211,7 +212,10 @@ class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
             _generateList(parts, fileFields).assignFinal(_partsVar).statement);
       }
 
-      if (!hasBody && !hasParts && _methodWithBody(methodName)) {
+      if (!methodOptionalBody &&
+          !hasBody &&
+          !hasParts &&
+          _methodWithBody(methodName)) {
         _logger.warning(
           '$methodName $methodUrl\n'
           'Body is null\n'
@@ -493,6 +497,9 @@ bool _methodWithBody(String method) =>
     method == chopper.HttpMethod.Post ||
     method == chopper.HttpMethod.Patch ||
     method == chopper.HttpMethod.Put;
+
+bool getMethodOptionalBody(ConstantReader method) =>
+    method.read('optionalBody').boolValue;
 
 String getMethodPath(ConstantReader method) => method.read('path').stringValue;
 


### PR DESCRIPTION
Add an `optionalBody` parameter to the `Post`, `Patch` and `Put` annotations to allow suppressing the warning for missing bodies in these requests.

The parameter defaults to `true` for all other HTTP methods.

Fixes #149