### PR TITLE
Fix typo and invalid code sample in documentation

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -39,7 +39,7 @@ part "YOUR_FILE.chopper.dart";
 @ChopperApi(baseUrl: "/todos")
 abstract class TodosListService extends ChopperService {
 
-  // helper methods that help you instanciate your service
+  // helper methods that help you instantiate your service
   static TodosListService create([ChopperClient client]) => 
       _$TodosListService(client);
 }

--- a/interceptors.md
+++ b/interceptors.md
@@ -25,7 +25,7 @@ Called after successful or failed request
 ```dart
 final chopper = new ChopperClient(
    interceptors: [
-     (response) async => response.copyWith(body: {}),
+     (Response response) async => response.replace(body: {}),
    ]
 );
 ```


### PR DESCRIPTION
Fixing a minor typo in the docs, also I had issues with defining the interceptors the way the docs suggested. I had to define the type of the lambda parameter, also it looks like `Response` class has no `copyWith(...)` method, but has a `replace(..)` one.