### PR TITLE
This allows chopper API methods with generic attributes

### DIFF
--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -129,6 +129,8 @@ class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
       b.annotations.add(refer('override'));
       b.name = m.displayName;
       b.returns = Reference(m.returnType.getDisplayString());
+      b.types.addAll(m.typeParameters
+          .map((t) => Reference(t.getDisplayString(withNullability: false))));
       b.requiredParameters.addAll(m.parameters
           .where((p) => p.isNotOptional)
           .map((p) => Parameter((pb) => pb


### PR DESCRIPTION
e.g.:
```
  @Post(path: URL.DOCUMENT_PRIOR_INFO)
  Future<Response<T>> getPriorInfo<T>(@Body() Params params);
```

Which is usefull when single API method may respond differently
depending on request parameter values.