### PR TITLE
Support json api content type for UTF-8 decoding

### DIFF
--- a/chopper/lib/src/interceptor.dart
+++ b/chopper/lib/src/interceptor.dart
@@ -203,10 +203,7 @@ class JsonConverter implements Converter, ErrorConverter {
   }
 
   Response decodeJson<BodyType, InnerType>(Response response) {
-    final supportedContentTypes = [
-      jsonHeaders,
-      'application/vnd.api+json'
-    ];
+    final supportedContentTypes = [jsonHeaders, 'application/vnd.api+json'];
 
     final contentType = response.headers[contentTypeKey];
     var body = response.body;

--- a/chopper/lib/src/interceptor.dart
+++ b/chopper/lib/src/interceptor.dart
@@ -203,9 +203,15 @@ class JsonConverter implements Converter, ErrorConverter {
   }
 
   Response decodeJson<BodyType, InnerType>(Response response) {
-    var contentType = response.headers[contentTypeKey];
+    final supportedContentTypes = [
+      jsonHeaders,
+      'application/vnd.api+json'
+    ];
+
+    final contentType = response.headers[contentTypeKey];
     var body = response.body;
-    if (contentType != null && contentType.contains(jsonHeaders)) {
+
+    if (supportedContentTypes.contains(contentType)) {
       // If we're decoding JSON, there's some ambiguity in https://tools.ietf.org/html/rfc2616
       // about what encoding should be used if the content-type doesn't contain a 'charset'
       // parameter. See https://github.com/dart-lang/http/issues/186. In a nutshell, without


### PR DESCRIPTION
Fix https://github.com/lejard-h/chopper/issues/179

Adds to the decode process to support two content-types:
- `application/json`
- `application/vnd.api+json`

Im not sure if I should add it to the encode function also.
