### PR TITLE
Add suport for JsonApi utf8 serialization

### DIFF
--- a/chopper/lib/src/constants.dart
+++ b/chopper/lib/src/constants.dart
@@ -2,6 +2,9 @@ const contentTypeKey = 'content-type';
 const jsonHeaders = 'application/json';
 const formEncodedHeaders = 'application/x-www-form-urlencoded';
 
+// Represent the header for a json api response https://jsonapi.org/#mime-types
+const jsonApiHeaders = 'application/vnd.api+json';
+
 class HttpMethod {
   static const String Get = 'GET';
   static const String Post = 'POST';

--- a/chopper/lib/src/interceptor.dart
+++ b/chopper/lib/src/interceptor.dart
@@ -203,9 +203,12 @@ class JsonConverter implements Converter, ErrorConverter {
   }
 
   Response decodeJson<BodyType, InnerType>(Response response) {
-    var contentType = response.headers[contentTypeKey];
+    final supportedContentTypes = [jsonHeaders, 'application/vnd.api+json'];
+
+    final contentType = response.headers[contentTypeKey];
     var body = response.body;
-    if (contentType != null && contentType.contains(jsonHeaders)) {
+
+    if (supportedContentTypes.contains(contentType)) {
       // If we're decoding JSON, there's some ambiguity in https://tools.ietf.org/html/rfc2616
       // about what encoding should be used if the content-type doesn't contain a 'charset'
       // parameter. See https://github.com/dart-lang/http/issues/186. In a nutshell, without

--- a/chopper/lib/src/interceptor.dart
+++ b/chopper/lib/src/interceptor.dart
@@ -203,7 +203,7 @@ class JsonConverter implements Converter, ErrorConverter {
   }
 
   Response decodeJson<BodyType, InnerType>(Response response) {
-    final supportedContentTypes = [jsonHeaders, 'application/vnd.api+json'];
+    final supportedContentTypes = [jsonHeaders, jsonApiHeaders];
 
     final contentType = response.headers[contentTypeKey];
     var body = response.body;


### PR DESCRIPTION
Fix https://github.com/lejard-h/chopper/issues/179

Adds to the decode process to support two content-types:
- `application/json`
- `application/vnd.api+json`

Im not sure if I should add it to the encode function also.

I made a new PR *again* (https://github.com/lejard-h/chopper/pull/184) because the last one was opened from master and not from `develop` branch.

BTW is there any chance that you add a label hacktoberfest-accepted to this PR so it counts for this https://hacktoberfest.digitalocean.com ?