### PR TITLE
Implement authenticator

### DIFF
--- a/chopper/lib/src/authenticator.dart
+++ b/chopper/lib/src/authenticator.dart
@@ -1,0 +1,9 @@
+import 'dart:async';
+
+import 'package:chopper/chopper.dart';
+
+/// Returns a request that includes a credential to satisfy an authentication challenge in
+/// [response]. Returns null if the challenge cannot be satisfied.
+abstract class Authenticator {
+  FutureOr<Request> authenticate(Request request, Response response);
+}

--- a/chopper/lib/src/authenticator.dart
+++ b/chopper/lib/src/authenticator.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 
 import 'package:chopper/chopper.dart';
 
-/// Returns a request that includes a credential to satisfy an authentication challenge in
-/// [response]. Returns null if the challenge cannot be satisfied.
+/// This method should return a [Request] that includes credentials to satisfy an authentication challenge received in
+/// [response]. It should return `null` if the challenge cannot be satisfied.
 abstract class Authenticator {
   FutureOr<Request> authenticate(Request request, Response response);
 }

--- a/chopper/lib/src/base.dart
+++ b/chopper/lib/src/base.dart
@@ -38,7 +38,7 @@ class ChopperClient {
   /// the request and response interceptors are called respectively.
   final Converter converter;
 
-  /// The [Authenticator] that handles provides reactive authentication for a
+  /// The [Authenticator] that can provide reactive authentication for a
   /// request.
   final Authenticator authenticator;
 
@@ -322,11 +322,10 @@ class ChopperClient {
     final response = await http.Response.fromStream(streamRes);
     dynamic res = Response(response, response.body);
 
-    if(authenticator != null) {
-
+    if (authenticator != null) {
       var updatedRequest = authenticator.authenticate(request, res);
 
-      if(updatedRequest != null) {
+      if (updatedRequest != null) {
         res = await send(updatedRequest);
       }
     }


### PR DESCRIPTION
An attempt to solve https://github.com/lejard-h/chopper/issues/47

Inspired by OkHTTP's [authenticator](https://github.com/square/okhttp/blob/480c20e46bb1745e280e42607bbcc73b2c953d97/okhttp/src/main/kotlin/okhttp3/Authenticator.kt)

The idea is to provide a reactive authentication in the event that an auth challenge is raised. It returns a nullable Request that contains a possible update to the original Request to satisfy the authentication challenge.

e.g. a request is made to a server that responses with a 401. The authenticator can be implemented however needed to update the original request, such as using a refresh token, then pass a new request back to be executed.
