### PR TITLE
Add double quotes to url in CurlInterceptor log

### DIFF
--- a/chopper/lib/src/interceptor.dart
+++ b/chopper/lib/src/interceptor.dart
@@ -156,7 +156,7 @@ class CurlInterceptor implements RequestInterceptor {
         curl += ' -d \'$body\'';
       }
     }
-    curl += ' $url';
+    curl += ' \"$url\"';
     chopperLogger.info(curl);
     return request;
   }


### PR DESCRIPTION
Prints the Curl URL wrapped with double-quotes.

A super small change but extremely helpful.
It fixes issues when pasting the resulting log to the command line, where the curl request in some cases would not be closed by the terminal or fail to execute.

This is also the default behavior for the OkHttp Interceptor:
https://github.com/mrmike/Ok2Curl/blob/master/ok2curl/src/main/java/com/moczul/ok2curl/CurlBuilder.java#L27