### PR TITLE
Cleanup deprecated

### DIFF
--- a/chopper/CHANGELOG.md
+++ b/chopper/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.0.0-nullsafety.1
+
+- Removed deprecated `FileField`, use `PartFile` instead
+
 ## 4.0.0-nullsafety.0
 
 - Null safety support

--- a/chopper/CHANGELOG.md
+++ b/chopper/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 4.0.0-nullsafety.1
 
-- Removed deprecated `FileField`, use `PartFile` instead
+- Remove deprecated `FileField`, use `PartFile` instead
+- Remove deprecated `Request.replace`, use `Request.copyWith` instead
 
 ## 4.0.0-nullsafety.0
 

--- a/chopper/CHANGELOG.md
+++ b/chopper/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## 4.0.0-nullsafety.1
-
-- Remove deprecated `FileField`, use `PartFile` instead
-- Remove deprecated `Request.replace`, use `Request.copyWith` instead
-- Remove deprecated `PartValue.replace`, use `PartValue.copyWith` instead
-- Remove deprecated `Response.replace`, use `Response.copyWith` instead
-
 ## 4.0.0-nullsafety.0
 
 - Null safety support
@@ -15,6 +8,10 @@
 - Support for OkHttp-like Authenticator implementation
 - Support for generic API methods
 - Updated public API documentation and how-tos
+- Remove deprecated `FileField`, use `PartFile` instead
+- Remove deprecated `Request.replace`, use `Request.copyWith` instead
+- Remove deprecated `PartValue.replace`, use `PartValue.copyWith` instead
+- Remove deprecated `Response.replace`, use `Response.copyWith` instead
 
 ## 3.0.3
 

--- a/chopper/CHANGELOG.md
+++ b/chopper/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Remove deprecated `FileField`, use `PartFile` instead
 - Remove deprecated `Request.replace`, use `Request.copyWith` instead
 - Remove deprecated `PartValue.replace`, use `PartValue.copyWith` instead
-
+- Remove deprecated `Response.replace`, use `Response.copyWith` instead
 
 ## 4.0.0-nullsafety.0
 

--- a/chopper/CHANGELOG.md
+++ b/chopper/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Remove deprecated `FileField`, use `PartFile` instead
 - Remove deprecated `Request.replace`, use `Request.copyWith` instead
+- Remove deprecated `PartValue.replace`, use `PartValue.copyWith` instead
+
 
 ## 4.0.0-nullsafety.0
 

--- a/chopper/lib/src/annotations.dart
+++ b/chopper/lib/src/annotations.dart
@@ -387,23 +387,5 @@ class PartFile {
   const PartFile([this.name]);
 }
 
-/// Use it to define a file field for a [Multipart] request.
-///
-/// ```dart
-/// @Post(path: 'file')
-/// @multipart
-/// Future<Response> postFile(@FileField('file') List<int> bytes);
-/// ```
-///
-/// Supports the following values:
-///   - `List<int>`
-///   - [String] (path of your file)
-///   - `MultipartFile` (from package:http)
-@immutable
-@Deprecated('Use PartFile instead')
-class FileField extends PartFile {
-  const FileField([String? name]) : super(name);
-}
-
 const multipart = Multipart();
 const body = Body();

--- a/chopper/lib/src/request.dart
+++ b/chopper/lib/src/request.dart
@@ -108,10 +108,6 @@ class PartValue<T> {
     this.value,
   );
 
-  @Deprecated('Prefer copyWith method')
-  PartValue<NewType> replace<NewType>({String? name, NewType? value}) =>
-      copyWith<NewType>(name: name, value: value);
-
   /// Makes a copy of this PartValue, replacing original values with the given ones.
   /// This method can also alter the type of the request body.
   PartValue<NewType> copyWith<NewType>({String? name, NewType? value}) =>

--- a/chopper/lib/src/request.dart
+++ b/chopper/lib/src/request.dart
@@ -32,30 +32,6 @@ class Request {
         multipart = multipart ?? false,
         parts = parts ?? const [];
 
-  @Deprecated('Prefer copyWith method')
-  Request replace({
-    HttpMethod? method,
-    String? url,
-    dynamic body,
-    Map<String, dynamic>? parameters,
-    Map<String, String>? headers,
-    Encoding? encoding,
-    List<PartValue>? parts,
-    bool? multipart,
-    String? baseUrl,
-  }) =>
-      copyWith(
-        method: method,
-        url: url,
-        body: body,
-        parameters: parameters,
-        headers: headers,
-        encoding: encoding,
-        parts: parts,
-        multipart: multipart,
-        baseUrl: baseUrl,
-      );
-
   /// Makes a copy of this request, replacing original values with the given ones.
   Request copyWith({
     HttpMethod? method,

--- a/chopper/lib/src/response.dart
+++ b/chopper/lib/src/response.dart
@@ -31,18 +31,6 @@ class Response<BodyType> {
 
   Response(this.base, this.body, {this.error});
 
-  @Deprecated('Prefer copyWith method')
-  Response<NewBodyType> replace<NewBodyType>({
-    http.BaseResponse? base,
-    NewBodyType? body,
-    Object? bodyError,
-  }) =>
-      copyWith<NewBodyType>(
-        base: base,
-        body: body,
-        bodyError: bodyError,
-      );
-
   /// Makes a copy of this Response, replacing original values with the given ones.
   /// This method can also alter the type of the response body.
   Response<NewBodyType> copyWith<NewBodyType>({

--- a/chopper/pubspec.yaml
+++ b/chopper/pubspec.yaml
@@ -18,11 +18,6 @@ dev_dependencies:
   build_runner: ^1.12.1
   build_test: ^2.0.0
   coverage: ^1.0.2
-# wait https://github.com/pulyaevskiy/test-coverage/pull/39
-#  test_coverage:
-#    git:
-#      url: https://github.com/JEuler/test-coverage.git
-#      ref: new-coverage
   http_parser: ^4.0.0
   pedantic: ^1.11.0
   chopper_generator:


### PR DESCRIPTION
- Remove deprecated `FileField`, use `PartFile` instead
- Remove deprecated `Request.replace`, use `Request.copyWith` instead
- Remove deprecated `PartValue.replace`, use `PartValue.copyWith` instead
- Remove deprecated `Response.replace`, use `Response.copyWith` instead