### PR TITLE
Fix infinite loop when using Authenticators

### DIFF
--- a/chopper/lib/src/authenticator.dart
+++ b/chopper/lib/src/authenticator.dart
@@ -5,5 +5,5 @@ import 'package:chopper/chopper.dart';
 /// This method should return a [Request] that includes credentials to satisfy an authentication challenge received in
 /// [response]. It should return `null` if the challenge cannot be satisfied.
 abstract class Authenticator {
-  FutureOr<Request> authenticate(Request request, Response response);
+  FutureOr<Request?> authenticate(Request request, Response response);
 }

--- a/chopper/lib/src/base.dart
+++ b/chopper/lib/src/base.dart
@@ -311,9 +311,11 @@ class ChopperClient {
     dynamic res = Response(response, response.body);
 
     if (authenticator != null) {
-      var updatedRequest = authenticator!.authenticate(request, res);
+      var updatedRequest = await authenticator!.authenticate(request, res);
 
-      res = await send(await updatedRequest);
+      if (updatedRequest != null) {
+        res = await send(updatedRequest);
+      }
     }
 
     if (_responseIsSuccessful(response.statusCode)) {


### PR DESCRIPTION
As pointed out in the comments of #198, the Authenticator implementation went wrong along the way to null safety migration.

This PR attempts to fix that.