### PR TITLE
Prevent double call on token refreshment

### DIFF
--- a/chopper/lib/src/base.dart
+++ b/chopper/lib/src/base.dart
@@ -315,6 +315,13 @@ class ChopperClient {
 
       if (updatedRequest != null) {
         res = await send<BodyType, InnerType>(updatedRequest);
+        // To prevent double call with typed response
+        if (_responseIsSuccessful(res.statusCode)) {
+          return _processResponse(res);
+        } else {
+          res = await _handleErrorResponse<BodyType, InnerType>(res);
+          return _processResponse(res);
+        }
       }
     }
 
@@ -327,10 +334,14 @@ class ChopperClient {
       res = await _handleErrorResponse<BodyType, InnerType>(res);
     }
 
+    return _processResponse(res);
+  }
+
+  /// Utitlity method to shrink duplicated code (interceptors processing)
+  Future<Response<BodyType>> _processResponse<BodyType, InnerType>(
+      dynamic res) async {
     res = await _interceptResponse<BodyType, InnerType>(res);
-
     _responseController.add(res);
-
     return res;
   }
 

--- a/chopper/lib/src/base.dart
+++ b/chopper/lib/src/base.dart
@@ -337,7 +337,6 @@ class ChopperClient {
     return _processResponse(res);
   }
 
-  /// Utitlity method to shrink duplicated code (interceptors processing)
   Future<Response<BodyType>> _processResponse<BodyType, InnerType>(
       dynamic res) async {
     res = await _interceptResponse<BodyType, InnerType>(res);


### PR DESCRIPTION
There is double processing when you've got your authenticator call. It leads to exceptions like "BuiltList<YourType> is not a String" or something. 

https://github.com/lejard-h/chopper/issues/259 contains the same behavior description. 