### PR TITLE
fix: fix this.body cast of null value when response body is null (#291)

### DIFF
--- a/chopper/lib/src/response.dart
+++ b/chopper/lib/src/response.dart
@@ -40,7 +40,7 @@ class Response<BodyType> {
   }) =>
       Response<NewBodyType>(
         base ?? this.base,
-        body ?? (this.body as NewBodyType),
+        body ?? (this.body as NewBodyType?),
         error: bodyError ?? error,
       );
 


### PR DESCRIPTION
fixes #291 