### PR TITLE
fix(generator): fix PartValueFile value not nullable if arg is (#288)

### DIFF
--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -456,7 +456,7 @@ class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
       ];
 
       list.add(
-        refer('PartValueFile<${p.type.getDisplayString(withNullability: false)}>')
+        refer('PartValueFile<${p.type.getDisplayString(withNullability: p.type.isNullable)}>')
             .newInstance(params),
       );
     });


### PR DESCRIPTION
For some reason `parts` items of type `PartValueFile` considered as non-nullable by default.

In `PartValueFile` implementation I am not seeing any constraints on inner value nullability.

`toMultipartRequest` method can throw out null values parts.

So I think we can make `parts` items of type `PartValueFile` support nullable inner values.

Fixes #288 