### PR TITLE
analyzer dependency upgraded

### DIFF
--- a/chopper_generator/pubspec.yaml
+++ b/chopper_generator/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  analyzer: ^1.2.0
+  analyzer: ^2.0.0
   build: ^2.0.0
   built_collection: ^5.0.0
   chopper: ^4.0.0


### PR DESCRIPTION
Because json_serializable 5.0.0 depends on analyzer ^2.0.0 and chopper_generator >=4.0.1 depends on analyzer ^1.2.0 there is a version solving conflict that avoid using latest version of json_serializable.