### PR TITLE
Add unnecessary_brace_in_string_interps to lint ignores

### DIFF
--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -83,7 +83,7 @@ class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
     });
 
     final ignore =
-        '// ignore_for_file: always_put_control_body_on_new_line, always_specify_types, prefer_const_declarations';
+        '// ignore_for_file: always_put_control_body_on_new_line, always_specify_types, prefer_const_declarations, unnecessary_brace_in_string_interps';
     final emitter = DartEmitter();
     return DartFormatter().format('$ignore\n${classBuilder.accept(emitter)}');
   }


### PR DESCRIPTION
This PR adds `unnecessary_brace_in_string_interps` to the list of lint ignores for generated files.

https://github.com/lejard-h/chopper/pull/275 is the source of the issue, however it's difficult to determine when the braces are necessary.