### PR TITLE
Fix converter getting called twice if using an authenticator with a JsonConverter on the request

### DIFF
--- a/chopper/lib/src/authenticator.dart
+++ b/chopper/lib/src/authenticator.dart
@@ -5,5 +5,5 @@ import 'package:chopper/chopper.dart';
 /// This method should return a [Request] that includes credentials to satisfy an authentication challenge received in
 /// [response]. It should return `null` if the challenge cannot be satisfied.
 abstract class Authenticator {
-  FutureOr<Request?> authenticate(Request request, Response response);
+  FutureOr<Request?> authenticate(Request request, Response response, Request originalRequest);
 }

--- a/chopper/lib/src/authenticator.dart
+++ b/chopper/lib/src/authenticator.dart
@@ -5,5 +5,6 @@ import 'package:chopper/chopper.dart';
 /// This method should return a [Request] that includes credentials to satisfy an authentication challenge received in
 /// [response]. It should return `null` if the challenge cannot be satisfied.
 abstract class Authenticator {
-  FutureOr<Request?> authenticate(Request request, Response response, Request originalRequest);
+  FutureOr<Request?> authenticate(
+      Request request, Response response, Request originalRequest);
 }

--- a/chopper/lib/src/authenticator.dart
+++ b/chopper/lib/src/authenticator.dart
@@ -5,6 +5,6 @@ import 'package:chopper/chopper.dart';
 /// This method should return a [Request] that includes credentials to satisfy an authentication challenge received in
 /// [response]. It should return `null` if the challenge cannot be satisfied.
 abstract class Authenticator {
-  FutureOr<Request?> authenticate(
-      Request request, Response response, Request originalRequest);
+  FutureOr<Request?> authenticate(Request request, Response response,
+      [Request? originalRequest]);
 }

--- a/chopper/lib/src/base.dart
+++ b/chopper/lib/src/base.dart
@@ -311,7 +311,7 @@ class ChopperClient {
     dynamic res = Response(response, response.body);
 
     if (authenticator != null) {
-      var updatedRequest = await authenticator!.authenticate(req, res);
+      var updatedRequest = await authenticator!.authenticate(request, res);
 
       if (updatedRequest != null) {
         res = await send<BodyType, InnerType>(

--- a/chopper/lib/src/base.dart
+++ b/chopper/lib/src/base.dart
@@ -311,7 +311,7 @@ class ChopperClient {
     dynamic res = Response(response, response.body);
 
     if (authenticator != null) {
-      var updatedRequest = await authenticator!.authenticate(request, res);
+      var updatedRequest = await authenticator!.authenticate(req, res, request);
 
       if (updatedRequest != null) {
         res = await send<BodyType, InnerType>(


### PR DESCRIPTION
Fix `_handleRequestConverter` getting called twice if using an authenticator with a `JsonConverter` on the request.

Otherwise an already encoded body string in `req.body` will be encoded again after the authentication challenge was solved.

So in the end in this MR we call `send()` with the same arguments as the initial request which fails with 403 as the token is outdated.

This behaviour was last changed in #310 to fix #308.