### PR TITLE
Fix nullable QueryMap fails to compile

### DIFF
--- a/chopper/example/definition.chopper.dart
+++ b/chopper/example/definition.chopper.dart
@@ -6,7 +6,7 @@ part of 'definition.dart';
 // ChopperGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line, always_specify_types, dead_null_aware_expression, prefer_const_declarations, unnecessary_brace_in_string_interps
+// ignore_for_file: always_put_control_body_on_new_line, always_specify_types, prefer_const_declarations, unnecessary_brace_in_string_interps
 class _$MyService extends MyService {
   _$MyService([ChopperClient? client]) {
     if (client == null) return;

--- a/chopper/example/definition.chopper.dart
+++ b/chopper/example/definition.chopper.dart
@@ -6,7 +6,7 @@ part of 'definition.dart';
 // ChopperGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line, always_specify_types, prefer_const_declarations
+// ignore_for_file: always_put_control_body_on_new_line, always_specify_types, dead_null_aware_expression, prefer_const_declarations, unnecessary_brace_in_string_interps
 class _$MyService extends MyService {
   _$MyService([ChopperClient? client]) {
     if (client == null) return;
@@ -18,7 +18,7 @@ class _$MyService extends MyService {
 
   @override
   Future<Response<dynamic>> getResource(String id) {
-    final $url = '/resources/$id';
+    final $url = '/resources/${id}';
     final $request = Request('GET', $url, client.baseUrl);
     return client.send<dynamic, dynamic>($request);
   }

--- a/chopper/test/base_test.dart
+++ b/chopper/test/base_test.dart
@@ -591,6 +591,160 @@ void main() {
     });
   });
 
+  test('Query Map 3', () async {
+    final httpClient = MockClient((request) async {
+      expect(
+        request.url.toString(),
+        equals('$baseUrl/test/query_map?name=foo&number=1234'),
+      );
+      expect(request.method, equals('GET'));
+
+      return http.Response('get response', 200);
+    });
+
+    final chopper = buildClient(httpClient);
+    final service = chopper.getService<HttpTestService>();
+
+    final response = await service.getQueryMapTest3(
+      name: 'foo',
+      number: 1234,
+    );
+
+    expect(response.body, equals('get response'));
+    expect(response.statusCode, equals(200));
+
+    httpClient.close();
+  });
+
+  test('Query Map 4 without QueryMap', () async {
+    final httpClient = MockClient((request) async {
+      expect(
+        request.url.toString(),
+        equals('$baseUrl/test/query_map?name=foo&number=1234'),
+      );
+      expect(request.method, equals('GET'));
+
+      return http.Response('get response', 200);
+    });
+
+    final chopper = buildClient(httpClient);
+    final service = chopper.getService<HttpTestService>();
+
+    final response = await service.getQueryMapTest4(
+      name: 'foo',
+      number: 1234,
+    );
+
+    expect(response.body, equals('get response'));
+    expect(response.statusCode, equals(200));
+
+    httpClient.close();
+  });
+
+  test('Query Map 4 with QueryMap', () async {
+    final httpClient = MockClient((request) async {
+      expect(
+        request.url.toString(),
+        equals('$baseUrl/test/query_map?name=foo&number=1234&filter_1=filter_value_1'),
+      );
+      expect(request.method, equals('GET'));
+
+      return http.Response('get response', 200);
+    });
+
+    final chopper = buildClient(httpClient);
+    final service = chopper.getService<HttpTestService>();
+
+    final response = await service.getQueryMapTest4(
+      name: 'foo',
+      number: 1234,
+      filters: {
+        'filter_1': 'filter_value_1'
+      }
+    );
+
+    expect(response.body, equals('get response'));
+    expect(response.statusCode, equals(200));
+
+    httpClient.close();
+  });
+
+  test('Query Map 4 with QueryMap that overwrites a previous value from Query', () async {
+    final httpClient = MockClient((request) async {
+      expect(
+        request.url.toString(),
+        equals('$baseUrl/test/query_map?name=bar&number=1234'),
+      );
+      expect(request.method, equals('GET'));
+
+      return http.Response('get response', 200);
+    });
+
+    final chopper = buildClient(httpClient);
+    final service = chopper.getService<HttpTestService>();
+
+    final response = await service.getQueryMapTest4(
+        name: 'foo',
+        number: 1234,
+        filters: {
+          'name': 'bar'
+        }
+    );
+
+    expect(response.body, equals('get response'));
+    expect(response.statusCode, equals(200));
+
+    httpClient.close();
+  });
+
+  test('Query Map 5 without QueryMap', () async {
+    final httpClient = MockClient((request) async {
+      expect(
+        request.url.toString(),
+        equals('$baseUrl/test/query_map'),
+      );
+      expect(request.method, equals('GET'));
+
+      return http.Response('get response', 200);
+    });
+
+    final chopper = buildClient(httpClient);
+    final service = chopper.getService<HttpTestService>();
+
+    final response = await service.getQueryMapTest5();
+
+    expect(response.body, equals('get response'));
+    expect(response.statusCode, equals(200));
+
+    httpClient.close();
+  });
+
+  test('Query Map 5 with QueryMap', () async {
+    final httpClient = MockClient((request) async {
+      expect(
+        request.url.toString(),
+        equals('$baseUrl/test/query_map?filter_1=filter_value_1'),
+      );
+      expect(request.method, equals('GET'));
+
+      return http.Response('get response', 200);
+    });
+
+    final chopper = buildClient(httpClient);
+    final service = chopper.getService<HttpTestService>();
+
+    final response = await service.getQueryMapTest5(
+      filters: {
+        'filter_1': 'filter_value_1'
+      }
+    );
+
+    expect(response.body, equals('get response'));
+    expect(response.statusCode, equals(200));
+
+    httpClient.close();
+  });
+
   test('onRequest Stream', () async {
     final client = MockClient((http.Request req) async {
       return http.Response('ok', 200);

--- a/chopper/test/base_test.dart
+++ b/chopper/test/base_test.dart
@@ -645,7 +645,8 @@ void main() {
     final httpClient = MockClient((request) async {
       expect(
         request.url.toString(),
-        equals('$baseUrl/test/query_map?name=foo&number=1234&filter_1=filter_value_1'),
+        equals(
+            '$baseUrl/test/query_map?name=foo&number=1234&filter_1=filter_value_1'),
       );
       expect(request.method, equals('GET'));
 
@@ -656,12 +657,7 @@ void main() {
     final service = chopper.getService<HttpTestService>();
 
     final response = await service.getQueryMapTest4(
-      name: 'foo',
-      number: 1234,
-      filters: {
-        'filter_1': 'filter_value_1'
-      }
-    );
+        name: 'foo', number: 1234, filters: {'filter_1': 'filter_value_1'});
 
     expect(response.body, equals('get response'));
     expect(response.statusCode, equals(200));
@@ -669,7 +665,8 @@ void main() {
     httpClient.close();
   });
 
-  test('Query Map 4 with QueryMap that overwrites a previous value from Query', () async {
+  test('Query Map 4 with QueryMap that overwrites a previous value from Query',
+      () async {
     final httpClient = MockClient((request) async {
       expect(
         request.url.toString(),
@@ -683,13 +680,8 @@ void main() {
     final chopper = buildClient(httpClient);
     final service = chopper.getService<HttpTestService>();
 
-    final response = await service.getQueryMapTest4(
-        name: 'foo',
-        number: 1234,
-        filters: {
-          'name': 'bar'
-        }
-    );
+    final response = await service
+        .getQueryMapTest4(name: 'foo', number: 1234, filters: {'name': 'bar'});
 
     expect(response.body, equals('get response'));
     expect(response.statusCode, equals(200));
@@ -733,11 +725,8 @@ void main() {
     final chopper = buildClient(httpClient);
     final service = chopper.getService<HttpTestService>();
 
-    final response = await service.getQueryMapTest5(
-      filters: {
-        'filter_1': 'filter_value_1'
-      }
-    );
+    final response =
+        await service.getQueryMapTest5(filters: {'filter_1': 'filter_value_1'});
 
     expect(response.body, equals('get response'));
     expect(response.statusCode, equals(200));

--- a/chopper/test/base_test.dart
+++ b/chopper/test/base_test.dart
@@ -646,7 +646,8 @@ void main() {
       expect(
         request.url.toString(),
         equals(
-            '$baseUrl/test/query_map?name=foo&number=1234&filter_1=filter_value_1'),
+          '$baseUrl/test/query_map?name=foo&number=1234&filter_1=filter_value_1',
+        ),
       );
       expect(request.method, equals('GET'));
 
@@ -657,7 +658,12 @@ void main() {
     final service = chopper.getService<HttpTestService>();
 
     final response = await service.getQueryMapTest4(
-        name: 'foo', number: 1234, filters: {'filter_1': 'filter_value_1'});
+      name: 'foo',
+      number: 1234,
+      filters: {
+        'filter_1': 'filter_value_1',
+      },
+    );
 
     expect(response.body, equals('get response'));
     expect(response.statusCode, equals(200));
@@ -665,29 +671,36 @@ void main() {
     httpClient.close();
   });
 
-  test('Query Map 4 with QueryMap that overwrites a previous value from Query',
-      () async {
-    final httpClient = MockClient((request) async {
-      expect(
-        request.url.toString(),
-        equals('$baseUrl/test/query_map?name=bar&number=1234'),
+  test(
+    'Query Map 4 with QueryMap that overwrites a previous value from Query',
+    () async {
+      final httpClient = MockClient((request) async {
+        expect(
+          request.url.toString(),
+          equals('$baseUrl/test/query_map?name=bar&number=1234'),
+        );
+        expect(request.method, equals('GET'));
+
+        return http.Response('get response', 200);
+      });
+
+      final chopper = buildClient(httpClient);
+      final service = chopper.getService<HttpTestService>();
+
+      final response = await service.getQueryMapTest4(
+        name: 'foo',
+        number: 1234,
+        filters: {
+          'name': 'bar',
+        },
       );
-      expect(request.method, equals('GET'));
 
-      return http.Response('get response', 200);
-    });
+      expect(response.body, equals('get response'));
+      expect(response.statusCode, equals(200));
 
-    final chopper = buildClient(httpClient);
-    final service = chopper.getService<HttpTestService>();
-
-    final response = await service
-        .getQueryMapTest4(name: 'foo', number: 1234, filters: {'name': 'bar'});
-
-    expect(response.body, equals('get response'));
-    expect(response.statusCode, equals(200));
-
-    httpClient.close();
-  });
+      httpClient.close();
+    },
+  );
 
   test('Query Map 5 without QueryMap', () async {
     final httpClient = MockClient((request) async {
@@ -725,8 +738,11 @@ void main() {
     final chopper = buildClient(httpClient);
     final service = chopper.getService<HttpTestService>();
 
-    final response =
-        await service.getQueryMapTest5(filters: {'filter_1': 'filter_value_1'});
+    final response = await service.getQueryMapTest5(
+      filters: {
+        'filter_1': 'filter_value_1',
+      },
+    );
 
     expect(response.body, equals('get response'));
     expect(response.statusCode, equals(200));

--- a/chopper/test/test_service.chopper.dart
+++ b/chopper/test/test_service.chopper.dart
@@ -6,7 +6,7 @@ part of 'test_service.dart';
 // ChopperGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line, always_specify_types, prefer_const_declarations
+// ignore_for_file: always_put_control_body_on_new_line, always_specify_types, dead_null_aware_expression, prefer_const_declarations, unnecessary_brace_in_string_interps
 class _$HttpTestService extends HttpTestService {
   _$HttpTestService([ChopperClient? client]) {
     if (client == null) return;
@@ -18,7 +18,7 @@ class _$HttpTestService extends HttpTestService {
 
   @override
   Future<Response<String>> getTest(String id, {required String dynamicHeader}) {
-    final $url = '/test/get/$id';
+    final $url = '/test/get/${id}';
     final $headers = {
       'test': dynamicHeader,
     };
@@ -78,7 +78,7 @@ class _$HttpTestService extends HttpTestService {
   @override
   Future<Response<dynamic>> getQueryMapTest(Map<String, dynamic> query) {
     final $url = '/test/query_map';
-    final $params = query;
+    final $params = query ?? {};
     final $request = Request('GET', $url, client.baseUrl, parameters: $params);
     return client.send<dynamic, dynamic>($request);
   }
@@ -88,7 +88,37 @@ class _$HttpTestService extends HttpTestService {
       {bool? test}) {
     final $url = '/test/query_map';
     final $params = <String, dynamic>{'test': test};
-    $params.addAll(query);
+    $params.addAll(query ?? {});
+    final $request = Request('GET', $url, client.baseUrl, parameters: $params);
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getQueryMapTest3(
+      {String name = '',
+      int? number,
+      Map<String, dynamic> filters = const {}}) {
+    final $url = '/test/query_map';
+    final $params = <String, dynamic>{'name': name, 'number': number};
+    $params.addAll(filters ?? {});
+    final $request = Request('GET', $url, client.baseUrl, parameters: $params);
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getQueryMapTest4(
+      {String name = '', int? number, Map<String, dynamic>? filters}) {
+    final $url = '/test/query_map';
+    final $params = <String, dynamic>{'name': name, 'number': number};
+    $params.addAll(filters ?? {});
+    final $request = Request('GET', $url, client.baseUrl, parameters: $params);
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getQueryMapTest5({Map<String, dynamic>? filters}) {
+    final $url = '/test/query_map';
+    final $params = filters ?? {};
     final $request = Request('GET', $url, client.baseUrl, parameters: $params);
     return client.send<dynamic, dynamic>($request);
   }
@@ -119,7 +149,7 @@ class _$HttpTestService extends HttpTestService {
 
   @override
   Future<Response<dynamic>> putTest(String test, String data) {
-    final $url = '/test/put/$test';
+    final $url = '/test/put/${test}';
     final $body = data;
     final $request = Request('PUT', $url, client.baseUrl, body: $body);
     return client.send<dynamic, dynamic>($request);
@@ -127,7 +157,7 @@ class _$HttpTestService extends HttpTestService {
 
   @override
   Future<Response<dynamic>> deleteTest(String id) {
-    final $url = '/test/delete/$id';
+    final $url = '/test/delete/${id}';
     final $headers = {
       'foo': 'bar',
     };
@@ -138,7 +168,7 @@ class _$HttpTestService extends HttpTestService {
 
   @override
   Future<Response<dynamic>> patchTest(String id, String data) {
-    final $url = '/test/patch/$id';
+    final $url = '/test/patch/${id}';
     final $body = data;
     final $request = Request('PATCH', $url, client.baseUrl, body: $body);
     return client.send<dynamic, dynamic>($request);

--- a/chopper/test/test_service.chopper.dart
+++ b/chopper/test/test_service.chopper.dart
@@ -6,7 +6,7 @@ part of 'test_service.dart';
 // ChopperGenerator
 // **************************************************************************
 
-// ignore_for_file: always_put_control_body_on_new_line, always_specify_types, dead_null_aware_expression, prefer_const_declarations, unnecessary_brace_in_string_interps
+// ignore_for_file: always_put_control_body_on_new_line, always_specify_types, prefer_const_declarations, unnecessary_brace_in_string_interps
 class _$HttpTestService extends HttpTestService {
   _$HttpTestService([ChopperClient? client]) {
     if (client == null) return;
@@ -78,7 +78,7 @@ class _$HttpTestService extends HttpTestService {
   @override
   Future<Response<dynamic>> getQueryMapTest(Map<String, dynamic> query) {
     final $url = '/test/query_map';
-    final $params = query ?? {};
+    final $params = query;
     final $request = Request('GET', $url, client.baseUrl, parameters: $params);
     return client.send<dynamic, dynamic>($request);
   }
@@ -88,7 +88,7 @@ class _$HttpTestService extends HttpTestService {
       {bool? test}) {
     final $url = '/test/query_map';
     final $params = <String, dynamic>{'test': test};
-    $params.addAll(query ?? {});
+    $params.addAll(query);
     final $request = Request('GET', $url, client.baseUrl, parameters: $params);
     return client.send<dynamic, dynamic>($request);
   }
@@ -100,7 +100,7 @@ class _$HttpTestService extends HttpTestService {
       Map<String, dynamic> filters = const {}}) {
     final $url = '/test/query_map';
     final $params = <String, dynamic>{'name': name, 'number': number};
-    $params.addAll(filters ?? {});
+    $params.addAll(filters);
     final $request = Request('GET', $url, client.baseUrl, parameters: $params);
     return client.send<dynamic, dynamic>($request);
   }

--- a/chopper/test/test_service.dart
+++ b/chopper/test/test_service.dart
@@ -48,6 +48,25 @@ abstract class HttpTestService extends ChopperService {
     @Query('test') bool? test,
   });
 
+  @Get(path: 'query_map')
+  Future<Response> getQueryMapTest3({
+    @Query('name') String name = '',
+    @Query('number') int? number,
+    @QueryMap() Map<String, dynamic> filters = const {},
+  });
+
+  @Get(path: 'query_map')
+  Future<Response> getQueryMapTest4({
+    @Query('name') String name = '',
+    @Query('number') int? number,
+    @QueryMap() Map<String, dynamic>? filters,
+  });
+
+  @Get(path: 'query_map')
+  Future<Response> getQueryMapTest5({
+    @QueryMap() Map<String, dynamic>? filters,
+  });
+
   @Get(path: 'get_body')
   Future<Response> getBody(@Body() dynamic body);
 

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -10,6 +10,7 @@ import 'package:built_collection/built_collection.dart';
 import 'package:dart_style/dart_style.dart';
 
 import 'package:source_gen/source_gen.dart';
+
 // TODO(lejard_h) Code builder not null safe yet
 // ignore: import_of_legacy_library_into_null_safe
 import 'package:code_builder/code_builder.dart';
@@ -82,7 +83,7 @@ class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
     });
 
     final ignore =
-        '// ignore_for_file: always_put_control_body_on_new_line, always_specify_types, prefer_const_declarations, unnecessary_brace_in_string_interps';
+        '// ignore_for_file: always_put_control_body_on_new_line, always_specify_types, dead_null_aware_expression, prefer_const_declarations, unnecessary_brace_in_string_interps';
     final emitter = DartEmitter();
     return DartFormatter().format('$ignore\n${classBuilder.accept(emitter)}');
   }
@@ -175,11 +176,14 @@ class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
       if (hasQueryMap) {
         if (queries.isNotEmpty) {
           blocks.add(refer('$_parametersVar.addAll').call(
-            [refer(queryMap.keys.first)],
+            [refer(queryMap.keys.first).ifNullThen(refer('{}'))],
           ).statement);
         } else {
           blocks.add(
-            refer(queryMap.keys.first).assignFinal(_parametersVar).statement,
+            refer(queryMap.keys.first)
+                .ifNullThen(refer('{}'))
+                .assignFinal(_parametersVar)
+                .statement,
           );
         }
       }

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -173,7 +173,7 @@ class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
       }
 
       // Build an iterable of all the parameters that are nullable
-      final Iterable<String> optionalNullableParameters = [
+      final optionalNullableParameters = [
         ...m.parameters.where((p) => p.isOptionalPositional),
         ...m.parameters.where((p) => p.isNamed),
       ].where((el) => el.type.isNullable).map((el) => el.name);


### PR DESCRIPTION
This addresses https://github.com/lejard-h/chopper/issues/343

I've used [Expression.ifNullThen](https://pub.dev/documentation/code_builder/latest/code_builder/Expression/ifNullThen.html) to additionally check for a nullable `QueryMap`.

This should be able to take

```dart
@Get(path: 'query_map')
Future<Response> getQueryMapTest4({
  @Query('name') String name = '',
  @Query('number') int? number,
  @QueryMap() Map<String, dynamic>? filters, // <-- nullable / optional filters
});
```

and generate

```dart
@override
Future<Response<dynamic>> getQueryMapTest4(
    {String name = '', int? number, Map<String, dynamic>? filters}) {
  final $url = '/test/query_map';
  final $params = <String, dynamic>{'name': name, 'number': number};
  $params.addAll(filters ?? {}); // <-- because Map.addAll expects a non-nullable Map
  final $request = Request('GET', $url, client.baseUrl, parameters: $params);
  return client.send<dynamic, dynamic>($request);
}
```

without any subsequent compilation errors.

Before this hotfix one had to use a default `const {}` like this in order to omit the `QueryMap` and avoid a compilation error

```dart
@Get(path: 'query_map')
Future<Response> getQueryMapTest3({
  @Query('name') String name = '',
  @Query('number') int? number,
  @QueryMap() Map<String, dynamic> filters = const {}, // <-- default
});
```

which would generate

```dart
@override
Future<Response<dynamic>> getQueryMapTest3(
    {String name = '',
    int? number,
    Map<String, dynamic> filters = const {}}) { // <-- default
  final $url = '/test/query_map';
  final $params = <String, dynamic>{'name': name, 'number': number};
  $params.addAll(filters);
  final $request = Request('GET', $url, client.baseUrl, parameters: $params);
  return client.send<dynamic, dynamic>($request);
}
```

~~However, this fix will also add a null check `??` when the value is not nullable and that's why I've added the extra ignore flag `dead_null_aware_expression` in order to silence the linter in a case like this~~

```dart
@Get(path: 'query_map')
Future<Response> getQueryMapTest2(
  @QueryMap() Map<String, dynamic> query, {
  @Query('test') bool? test,
});
```

~~which generates~~

```dart
@override
Future<Response<dynamic>> getQueryMapTest2(Map<String, dynamic> query,
    {bool? test}) {
  final $url = '/test/query_map';
  final $params = <String, dynamic>{'test': test};
  $params.addAll(query ?? {}); // <-- dead_null_aware_expression because `query` is not nullable
  final $request = Request('GET', $url, client.baseUrl, parameters: $params);
  return client.send<dynamic, dynamic>($request);
}
```

~~As such, this should be regarded more or less as a hotfix as some more robust null checking should be performed on the `QueryMap` itself. At this point, I lack the expertise to do this with `source_gen` and would appreciate any further guidance 😊~~

EDIT: This issue has now been rectified. See https://github.com/lejard-h/chopper/pull/344#issuecomment-1180750751

Oh, and of course, I've added a few test cases. ☑️