### PR TITLE
Change return type of decodeJson to FutureOr in order to be able to support compute()

### DIFF
--- a/chopper/lib/src/interceptor.dart
+++ b/chopper/lib/src/interceptor.dart
@@ -279,6 +279,7 @@ class JsonConverter implements Converter, ErrorConverter {
           Response response) async =>
       (await decodeJson<BodyType, InnerType>(response)) as Response<BodyType>;
 
+  @protected
   FutureOr<dynamic> tryDecodeJson(String data) {
     try {
       return json.decode(data);

--- a/chopper/lib/src/interceptor.dart
+++ b/chopper/lib/src/interceptor.dart
@@ -247,7 +247,7 @@ class JsonConverter implements Converter, ErrorConverter {
     return request;
   }
 
-  Response decodeJson<BodyType, InnerType>(Response response) {
+  FutureOr<Response> decodeJson<BodyType, InnerType>(Response response) async {
     final supportedContentTypes = [jsonHeaders, jsonApiHeaders];
 
     final contentType = response.headers[contentTypeKey];
@@ -264,7 +264,7 @@ class JsonConverter implements Converter, ErrorConverter {
       body = utf8.decode(response.bodyBytes);
     }
 
-    body = _tryDecodeJson(body);
+    body = await tryDecodeJson(body);
     if (isTypeOf<BodyType, Iterable<InnerType>>()) {
       body = body.cast<InnerType>();
     } else if (isTypeOf<BodyType, Map<String, InnerType>>()) {
@@ -275,11 +275,11 @@ class JsonConverter implements Converter, ErrorConverter {
   }
 
   @override
-  Response<BodyType> convertResponse<BodyType, InnerType>(Response response) {
-    return decodeJson<BodyType, InnerType>(response) as Response<BodyType>;
-  }
+  FutureOr<Response<BodyType>> convertResponse<BodyType, InnerType>(
+          Response response) async =>
+      (await decodeJson<BodyType, InnerType>(response)) as Response<BodyType>;
 
-  dynamic _tryDecodeJson(String data) {
+  FutureOr<dynamic> tryDecodeJson(String data) {
     try {
       return json.decode(data);
     } catch (e) {
@@ -289,14 +289,13 @@ class JsonConverter implements Converter, ErrorConverter {
   }
 
   @override
-  Response convertError<BodyType, InnerType>(Response response) =>
-      decodeJson(response);
+  FutureOr<Response> convertError<BodyType, InnerType>(
+          Response response) async =>
+      await decodeJson(response);
 
-  static Response<BodyType> responseFactory<BodyType, InnerType>(
-    Response response,
-  ) {
-    return const JsonConverter().convertResponse<BodyType, InnerType>(response);
-  }
+  static FutureOr<Response<BodyType>> responseFactory<BodyType, InnerType>(
+          Response response) =>
+      const JsonConverter().convertResponse<BodyType, InnerType>(response);
 
   static Request requestFactory(Request request) {
     return const JsonConverter().convertRequest(request);
@@ -339,7 +338,8 @@ class FormUrlEncodedConverter implements Converter, ErrorConverter {
   }
 
   @override
-  Response<BodyType> convertResponse<BodyType, InnerType>(Response response) =>
+  FutureOr<Response<BodyType>> convertResponse<BodyType, InnerType>(
+          Response response) =>
       response as Response<BodyType>;
 
   @override

--- a/chopper/test/converter_test.dart
+++ b/chopper/test/converter_test.dart
@@ -67,39 +67,41 @@ void main() {
   group('JsonConverter', () {
     final jsonConverter = JsonConverter();
 
-    test('decode String', () {
+    test('decode String', () async {
       final value = 'foo';
       final res = Response(http.Response('"$value"', 200), '"$value"');
-      final converted = jsonConverter.convertResponse<String, String>(res);
+      final converted =
+          await jsonConverter.convertResponse<String, String>(res);
 
       expect(converted.body, equals(value));
     });
 
-    test('decode List String', () {
+    test('decode List String', () async {
       final res = Response(
         http.Response('["foo","bar"]', 200),
         '["foo","bar"]',
       );
       final converted =
-          jsonConverter.convertResponse<List<String>, String>(res);
+          await jsonConverter.convertResponse<List<String>, String>(res);
 
       expect(converted.body, equals(['foo', 'bar']));
     });
 
-    test('decode List int', () {
+    test('decode List int', () async {
       final res = Response(http.Response('[1,2]', 200), '[1,2]');
-      final converted = jsonConverter.convertResponse<List<int>, int>(res);
+      final converted =
+          await jsonConverter.convertResponse<List<int>, int>(res);
 
       expect(converted.body, equals([1, 2]));
     });
 
-    test('decode Map', () {
+    test('decode Map', () async {
       final res = Response(
         http.Response('{"foo":"bar"}', 200),
         '{"foo":"bar"}',
       );
       final converted =
-          jsonConverter.convertResponse<Map<String, String>, String>(res);
+          await jsonConverter.convertResponse<Map<String, String>, String>(res);
 
       expect(converted.body, equals({'foo': 'bar'}));
     });

--- a/chopper_built_value/lib/chopper_built_value.dart
+++ b/chopper_built_value/lib/chopper_built_value.dart
@@ -1,7 +1,8 @@
-import 'package:chopper/chopper.dart';
+import 'dart:async';
 
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/serializer.dart';
+import 'package:chopper/chopper.dart';
 
 /// A custom [Converter] and [ErrorConverter] that handles conversion for classes
 /// having a serializer implementation made with the built_value package.
@@ -52,15 +53,17 @@ class BuiltValueConverter implements Converter, ErrorConverter {
   }
 
   @override
-  Response<BodyType> convertResponse<BodyType, InnerType>(Response response) {
-    final jsonResponse = jsonConverter.convertResponse(response);
+  FutureOr<Response<BodyType>> convertResponse<BodyType, InnerType>(
+      Response response) async {
+    final jsonResponse = await jsonConverter.convertResponse(response);
     final body = deserialize<BodyType, InnerType>(jsonResponse.body);
     return jsonResponse.copyWith(body: body);
   }
 
   @override
-  Response convertError<BodyType, InnerType>(Response response) {
-    final jsonResponse = jsonConverter.convertResponse(response);
+  FutureOr<Response> convertError<BodyType, InnerType>(
+      Response response) async {
+    final jsonResponse = await jsonConverter.convertResponse(response);
 
     var body;
 

--- a/chopper_built_value/test/converter_test.dart
+++ b/chopper_built_value/test/converter_test.dart
@@ -2,8 +2,8 @@ import 'package:built_collection/built_collection.dart';
 import 'package:built_value/standard_json_plugin.dart';
 import 'package:chopper/chopper.dart';
 import 'package:chopper_built_value/chopper_built_value.dart';
-import 'package:test/test.dart';
 import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
 
 import 'data.dart';
 import 'serializers.dart';
@@ -31,31 +31,31 @@ void main() {
       expect(request.body, '{"\$":"DataModel","id":42,"name":"foo"}');
     });
 
-    test('convert response with wireName', () {
+    test('convert response with wireName', () async {
       final string = '{"\$":"DataModel","id":42,"name":"foo"}';
       final response = Response(http.Response(string, 200), string);
       final convertedResponse =
-          converter.convertResponse<DataModel, DataModel>(response);
+          await converter.convertResponse<DataModel, DataModel>(response);
 
       expect(convertedResponse.body?.id, equals(42));
       expect(convertedResponse.body?.name, equals('foo'));
     });
 
-    test('convert response without wireName', () {
+    test('convert response without wireName', () async {
       final string = '{"id":42,"name":"foo"}';
       final response = Response(http.Response(string, 200), string);
       final convertedResponse =
-          converter.convertResponse<DataModel, DataModel>(response);
+          await converter.convertResponse<DataModel, DataModel>(response);
 
       expect(convertedResponse.body?.id, equals(42));
       expect(convertedResponse.body?.name, equals('foo'));
     });
 
-    test('convert response List', () {
+    test('convert response List', () async {
       final string = '[{"id":42,"name":"foo"},{"id":25,"name":"bar"}]';
       final response = Response(http.Response(string, 200), string);
-      final convertedResponse =
-          converter.convertResponse<BuiltList<DataModel>, DataModel>(response);
+      final convertedResponse = await converter
+          .convertResponse<BuiltList<DataModel>, DataModel>(response);
 
       final list = convertedResponse.body;
       expect(list?.first.id, equals(42));
@@ -71,19 +71,19 @@ void main() {
       expect(request.headers['content-type'], equals('application/json'));
     });
 
-    test('convert error with wire name', () {
+    test('convert error with wire name', () async {
       final string = '{"\$":"DataModel","id":42,"name":"foo"}';
       final response = Response(http.Response(string, 200), string);
-      final convertedResponse = converter.convertError(response);
+      final convertedResponse = await converter.convertError(response);
 
       expect(convertedResponse.body.id, equals(42));
       expect(convertedResponse.body.name, equals('foo'));
     });
 
-    test('convert error using provided type', () {
+    test('convert error using provided type', () async {
       final string = '{"message":"Error message"}';
       final response = Response(http.Response(string, 200), string);
-      final convertedResponse = converter.convertError(response);
+      final convertedResponse = await converter.convertError(response);
 
       expect(convertedResponse.body.message, equals('Error message'));
     });

--- a/chopper_generator/pubspec.yaml
+++ b/chopper_generator/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  analyzer: ^4.1.0
+  analyzer: ">=4.1.0 <4.3.0"
   build: ^2.0.0
   built_collection: ^5.0.0
   chopper: ^4.0.0

--- a/example/bin/main_built_value.dart
+++ b/example/bin/main_built_value.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/serializer.dart';
 import 'package:chopper/chopper.dart';
@@ -84,9 +86,10 @@ class BuiltValueConverter extends JsonConverter {
   }
 
   @override
-  Response<ResultType> convertResponse<ResultType, Item>(Response response) {
+  FutureOr<Response<ResultType>> convertResponse<ResultType, Item>(
+      Response response) async {
     // use [JsonConverter] to decode json
-    final jsonRes = super.convertResponse(response);
+    final jsonRes = await super.convertResponse(response);
     final body = _decode<Item>(jsonRes.body);
     return jsonRes.copyWith<ResultType>(body: body);
   }

--- a/example/bin/main_json_serializable.dart
+++ b/example/bin/main_json_serializable.dart
@@ -91,9 +91,10 @@ class JsonSerializableConverter extends JsonConverter {
   }
 
   @override
-  Response<ResultType> convertResponse<ResultType, Item>(Response response) {
+  FutureOr<Response<ResultType>> convertResponse<ResultType, Item>(
+      Response response) async {
     // use [JsonConverter] to decode json
-    final jsonRes = super.convertResponse(response);
+    final jsonRes = await super.convertResponse(response);
 
     return jsonRes.copyWith<ResultType>(body: _decode<Item>(jsonRes.body));
   }
@@ -102,9 +103,9 @@ class JsonSerializableConverter extends JsonConverter {
   // all objects should implements toJson method
   Request convertRequest(Request request) => super.convertRequest(request);
 
-  Response convertError<ResultType, Item>(Response response) {
+  FutureOr<Response> convertError<ResultType, Item>(Response response) async {
     // use [JsonConverter] to decode json
-    final jsonRes = super.convertError(response);
+    final jsonRes = await super.convertError(response);
 
     return jsonRes.copyWith<ResourceError>(
       body: ResourceError.fromJsonFactory(jsonRes.body),


### PR DESCRIPTION
This partially addresses https://github.com/lejard-h/chopper/issues/158 and is mostly based on @lejard-h's suggestion https://github.com/lejard-h/chopper/issues/158#issuecomment-678760392

**This is a breaking change** as it changes the response types of some `JsonConverter` methods, namely:

- `decodeJson` now returns `FutureOr<Response>`
  ```dart
  /// before
  Response decodeJson<BodyType, InnerType>(Response response) {
    /* sync decode stuf */
  }

  /// after
  FutureOr<Response> decodeJson<BodyType, InnerType>(Response response) async {
    /* async decode stuff */
  }
  ```

- `convertResponse` now returns `FutureOr<Response<BodyType>>`
  ```dart
  /// before
  @override
  Response<BodyType> convertResponse<BodyType, InnerType>(Response response) {
    /* sync convert stuff */
  }

  /// after
  @override
  FutureOr<Response<BodyType>> convertResponse<BodyType, InnerType>(Response response) async {
    /* async convert stuff */
  }
  ```

- `tryDecodeJson` now returns `FutureOr<dynamic>` and is now `public`
  ```dart
  /// before
  dynamic _tryDecodeJson(String data) {
    /* decode json */
  }

  /// after
  FutureOr<dynamic> tryDecodeJson(String data) {
    /* now you can override this method and use compute to decode json */
  }
  ```

- `convertError` now returns `FutureOr<Response>`
  ```dart
  /// before
  @override
  Response convertError<BodyType, InnerType>(Response response) {
    /* sync decode error */
  }

  /// after
  @override
  FutureOr<Response> convertError<BodyType, InnerType>(Response response) async {
    /* async decode error */
  }
  ```

- `responseFactory` now returns `FutureOr<Response<BodyType>>`
  ```dart
  /// before
  static Response<BodyType> responseFactory<BodyType, InnerType>(Response response) {
    /* stuff */
  }

  /// after
  static FutureOr<Response<BodyType>> responseFactory<BodyType, InnerType>(Response response){
    /* stuff */
  }
  ```
