### PR TITLE
Revert analyzer to ^4.1.0 and silence linters for Element.enclosingElement

### DIFF
--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -339,8 +339,12 @@ class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
     });
   }
 
+  /// TODO: upgrade analyzer to ^4.4.0 to replace enclosingElement with enclosingElement3
+  /// https://github.com/dart-lang/sdk/blob/main/pkg/analyzer/CHANGELOG.md#440
   String _factoryForFunction(FunctionTypedElement function) =>
+      // ignore: deprecated_member_use
       function.enclosingElement is ClassElement
+          // ignore: deprecated_member_use
           ? '${function.enclosingElement!.name}.${function.name}'
           : function.name!;
 

--- a/chopper_generator/pubspec.yaml
+++ b/chopper_generator/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  analyzer: ">=4.1.0 <4.3.0"
+  analyzer: ^4.1.0
   build: ^2.0.0
   built_collection: ^5.0.0
   chopper: ^5.0.0

--- a/chopper_generator/pubspec.yaml
+++ b/chopper_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chopper_generator
 description: Chopper is an http client generator using source_gen, inspired by Retrofit
-version: 5.0.0
+version: 5.0.0+1
 documentation: https://hadrien-lejard.gitbook.io/chopper
 repository: https://github.com/lejard-h/chopper
 


### PR DESCRIPTION
[As mentioned previously](https://github.com/lejard-h/chopper/pull/345#issuecomment-1193179037) I had to pin [`analyzer`](https://github.com/dart-lang/sdk/tree/main/pkg/analyzer) to `>=4.1.0 <4.3.0`.

The issue is that [`analyzer`](https://github.com/dart-lang/sdk/tree/main/pkg/analyzer) deprecated [`Element.enclosingElement`](https://github.com/dart-lang/sdk/blob/main/pkg/analyzer/CHANGELOG.md#430) which is being used in [chopper_generator](https://github.com/lejard-h/chopper/blob/master/chopper_generator/lib/src/generator.dart#L343) and that caused the tests to fail because of a linter warning. 🚨

This change inadvertently affects users of [`mockito`](https://github.com/dart-lang/mockito), which has to be pinned to `>=5.2.0 <5.3.0` to circumvent this small issue.

I have now reverted `analyzer` back to `^4.1.0` and silenced those linter errors, however, going forward we should migrate from `Element.enclosingElement` to `Element.enclosingElement3` [as both `Element.enclosingElement` and `Element.enclosingElement2` have been **removed from `analyzer` 5.0.0**](https://github.com/dart-lang/sdk/blob/main/pkg/analyzer/CHANGELOG.md#500).

[`Element.enclosingElement3` became available in `analyzer: ^4.4.0`](https://github.com/dart-lang/sdk/blob/main/pkg/analyzer/CHANGELOG.md#440). An upgrade to that version will be required in the future.

I have put a `TODO` comment into the code precisely for that reason.