### PR TITLE
Add Bug Report Github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: The application is crashing or throws an exception or something else looks wrong.
 title: ''
 labels: bug
-assignees:
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,69 @@
+---
+name: Bug report
+about: The application is crashing or throws an exception or something else looks wrong.
+title: ''
+labels: bug
+assignees:
+
+---
+
+## Steps to Reproduce
+
+<!-- Please include full steps to reproduce so that we can reproduce the problem. -->
+
+1. Execute `dart run` on the code sample <!-- (see "Code sample" section below) -->
+2. ... <!-- describe steps to demonstrate bug -->
+3. ... <!-- for example "Tap on X and see a crash" -->
+
+**Expected results:** <!-- what did you want to see? -->
+
+**Actual results:** <!-- what did you see? -->
+
+<details>
+<summary>Code sample</summary>
+
+<!--
+      Please create a minimal reproducible sample that shows the problem
+      and attach it below between the lines with the backticks.
+
+      To create it you can use `dart create bug` command and update the `main.dart` file.
+
+      Alternatively, you can use https://dartpad.dev/
+      which is capable of creating and running small Dart apps.
+
+      Without this we will unlikely be able to progress on the issue, and because of that
+      we regretfully will have to close it.
+-->
+
+```dart
+```
+
+</details>
+
+<details>
+  <summary>Logs</summary>
+
+<!--
+      Run your application with `dart run main.dart --verbose` and attach all the
+      log output below between the lines with the backticks. If there is an
+      exception, please see if the error message includes enough information
+      to explain how to solve the issue.
+-->
+
+```
+```
+
+<!--
+     Run `dart analyze` and attach any output of that command below.
+     If there are any analysis errors, try resolving them before filing this issue.
+-->
+
+```
+```
+
+<!-- Finally, paste the output of running `dart --version` here. -->
+
+```
+```
+
+</details>


### PR DESCRIPTION
I added a Github issue template to streamline bug reports.

It's essentially a carbon copy of the [template Flutter uses](https://github.com/flutter/flutter/blob/master/.github/ISSUE_TEMPLATE/2_bug.md). 🤓

I left the `assignees` field empty, because I'm not sure who should triage them.

@JEuler / @stewemetal  thoughts?