### PR TITLE
Provide an example using an Isolate Worker Pool with Squadron

### DIFF
--- a/example/bin/main_json_serializable_squadron_worker_pool.dart
+++ b/example/bin/main_json_serializable_squadron_worker_pool.dart
@@ -1,0 +1,164 @@
+/// This example uses
+/// - https://github.com/google/json_serializable.dart
+/// - https://github.com/d-markey/squadron
+/// - https://github.com/d-markey/squadron_builder
+
+import 'dart:async' show FutureOr;
+import 'dart:convert' show jsonDecode;
+
+import 'package:chopper/chopper.dart';
+import 'package:chopper_example/json_decode_service.dart';
+import 'package:chopper_example/json_serializable.dart';
+import 'package:http/testing.dart';
+import 'package:squadron/squadron.dart';
+import 'package:http/http.dart' as http;
+
+import 'main_json_serializable.dart' show authHeader;
+
+typedef JsonFactory<T> = T Function(Map<String, dynamic> json);
+
+/// This JsonConverter works with or without a WorkerPool
+class JsonSerializableWorkerPoolConverter extends JsonConverter {
+  const JsonSerializableWorkerPoolConverter(this.factories, [this.workerPool]);
+
+  final Map<Type, JsonFactory> factories;
+  final JsonDecodeServiceWorkerPool? workerPool;
+
+  T? _decodeMap<T>(Map<String, dynamic> values) {
+    /// Get jsonFactory using Type parameters
+    /// if not found or invalid, throw error or return null
+    final jsonFactory = factories[T];
+    if (jsonFactory == null || jsonFactory is! JsonFactory<T>) {
+      /// throw serializer not found error;
+      return null;
+    }
+
+    return jsonFactory(values);
+  }
+
+  List<T> _decodeList<T>(Iterable values) =>
+      values.where((v) => v != null).map<T>((v) => _decode<T>(v)).toList();
+
+  dynamic _decode<T>(entity) {
+    if (entity is Iterable) return _decodeList<T>(entity as List);
+
+    if (entity is Map) return _decodeMap<T>(entity as Map<String, dynamic>);
+
+    return entity;
+  }
+
+  @override
+  FutureOr<Response<ResultType>> convertResponse<ResultType, Item>(
+    Response response,
+  ) async {
+    // use [JsonConverter] to decode json
+    final jsonRes = await super.convertResponse(response);
+
+    return jsonRes.copyWith<ResultType>(body: _decode<Item>(jsonRes.body));
+  }
+
+  @override
+  FutureOr<Response> convertError<ResultType, Item>(Response response) async {
+    // use [JsonConverter] to decode json
+    final jsonRes = await super.convertError(response);
+
+    return jsonRes.copyWith<ResourceError>(
+      body: ResourceError.fromJsonFactory(jsonRes.body),
+    );
+  }
+
+  @override
+  FutureOr<dynamic> tryDecodeJson(String data) async {
+    try {
+      // if there is a worker pool use it, otherwise run in the main thread
+      return workerPool != null
+          ? await workerPool!.jsonDecode(data)
+          : jsonDecode(data);
+    } catch (error) {
+      print(error);
+
+      chopperLogger.warning(error);
+
+      return data;
+    }
+  }
+}
+
+/// Simple client to have working example without remote server
+final client = MockClient((http.Request req) async {
+  if (req.method == 'POST') {
+    return http.Response('{"type":"Fatal","message":"fatal error"}', 500);
+  }
+  if (req.method == 'GET' && req.headers['test'] == 'list') {
+    return http.Response('[{"id":"1","name":"Foo"}]', 200);
+  }
+
+  return http.Response('{"id":"1","name":"Foo"}', 200);
+});
+
+/// inspired by https://github.com/d-markey/squadron_sample/blob/main/lib/main.dart
+void initSquadron(String id) {
+  Squadron.setId(id);
+  Squadron.setLogger(ConsoleSquadronLogger());
+  Squadron.logLevel = SquadronLogLevel.all;
+  Squadron.debugMode = true;
+}
+
+Future<void> main() async {
+  /// initialize Squadron before using it
+  initSquadron('worker_pool_example');
+
+  final jsonDecodeServiceWorkerPool = JsonDecodeServiceWorkerPool(
+    // Set whatever you want here
+    concurrencySettings: ConcurrencySettings.oneCpuThread,
+  );
+
+  /// start the Worker Pool
+  await jsonDecodeServiceWorkerPool.start();
+
+  final converter = JsonSerializableWorkerPoolConverter(
+    {
+      Resource: Resource.fromJsonFactory,
+    },
+    // make sure to provide the WorkerPool to the JsonConverter
+    jsonDecodeServiceWorkerPool,
+  );
+
+  final chopper = ChopperClient(
+    client: client,
+    baseUrl: 'http://localhost:8000',
+    // bind your object factories here
+    converter: converter,
+    errorConverter: converter,
+    services: [
+      // the generated service
+      MyService.create(),
+    ],
+    /* ResponseInterceptorFunc | RequestInterceptorFunc | ResponseInterceptor | RequestInterceptor */
+    interceptors: [authHeader],
+  );
+
+  final myService = chopper.getService<MyService>();
+
+  /// All of the calls below will use jsonDecode in an Isolate worker
+  final response1 = await myService.getResource('1');
+  print('response 1: ${response1.body}'); // undecoded String
+
+  final response2 = await myService.getResources();
+  print('response 2: ${response2.body}'); // decoded list of Resources
+
+  final response3 = await myService.getTypedResource();
+  print('response 3: ${response3.body}'); // decoded Resource
+
+  final response4 = await myService.getMapResource('1');
+  print('response 4: ${response4.body}'); // undecoded Resource
+
+  try {
+    await myService.newResource(Resource('3', 'Super Name'));
+  } on Response catch (error) {
+    print(error.body);
+  }
+
+  /// stop the Worker Pool
+  jsonDecodeServiceWorkerPool.stop();
+}

--- a/example/lib/json_decode_service.activator.g.dart
+++ b/example/lib/json_decode_service.activator.g.dart
@@ -1,0 +1,9 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// **************************************************************************
+// SquadronWorkerGenerator
+// **************************************************************************
+
+import 'json_decode_service.vm.g.dart';
+
+final $JsonDecodeServiceActivator = $getJsonDecodeServiceActivator();

--- a/example/lib/json_decode_service.dart
+++ b/example/lib/json_decode_service.dart
@@ -1,0 +1,21 @@
+/// This example uses https://github.com/d-markey/squadron_builder
+
+import 'dart:async';
+import 'dart:convert' show json;
+
+import 'package:squadron/squadron.dart';
+import 'package:squadron/squadron_annotations.dart';
+
+import 'json_decode_service.activator.g.dart';
+
+part 'json_decode_service.worker.g.dart';
+
+@SquadronService(
+  // disable web to keep the number of generated files low for this example
+  web: false,
+)
+class JsonDecodeService extends WorkerService
+    with $JsonDecodeServiceOperations {
+  @SquadronMethod()
+  Future<dynamic> jsonDecode(String source) async => json.decode(source);
+}

--- a/example/lib/json_decode_service.vm.g.dart
+++ b/example/lib/json_decode_service.vm.g.dart
@@ -1,0 +1,13 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// **************************************************************************
+// SquadronWorkerGenerator
+// **************************************************************************
+
+import 'package:squadron/squadron_service.dart';
+import 'json_decode_service.dart';
+
+// VM entry point
+void _start(Map command) => run($JsonDecodeServiceInitializer, command);
+
+dynamic $getJsonDecodeServiceActivator() => _start;

--- a/example/lib/json_decode_service.worker.g.dart
+++ b/example/lib/json_decode_service.worker.g.dart
@@ -1,0 +1,59 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'json_decode_service.dart';
+
+// **************************************************************************
+// SquadronWorkerGenerator
+// **************************************************************************
+
+// Operations map for JsonDecodeService
+mixin $JsonDecodeServiceOperations on WorkerService {
+  @override
+  late final Map<int, CommandHandler> operations =
+      _getOperations(this as JsonDecodeService);
+
+  static const int _$jsonDecodeId = 1;
+
+  static Map<int, CommandHandler> _getOperations(JsonDecodeService svc) => {
+        _$jsonDecodeId: (r) => svc.jsonDecode(r.args[0]),
+      };
+}
+
+// Service initializer
+JsonDecodeService $JsonDecodeServiceInitializer(WorkerRequest startRequest) =>
+    JsonDecodeService();
+
+// Worker for JsonDecodeService
+class JsonDecodeServiceWorker extends Worker
+    with $JsonDecodeServiceOperations
+    implements JsonDecodeService {
+  JsonDecodeServiceWorker() : super($JsonDecodeServiceActivator);
+
+  @override
+  Future<dynamic> jsonDecode(String source) => send(
+        $JsonDecodeServiceOperations._$jsonDecodeId,
+        args: [source],
+        token: null,
+        inspectRequest: false,
+        inspectResponse: false,
+      );
+
+  @override
+  Map<int, CommandHandler> get operations => WorkerService.noOperations;
+}
+
+// Worker pool for JsonDecodeService
+class JsonDecodeServiceWorkerPool extends WorkerPool<JsonDecodeServiceWorker>
+    with $JsonDecodeServiceOperations
+    implements JsonDecodeService {
+  JsonDecodeServiceWorkerPool({ConcurrencySettings? concurrencySettings})
+      : super(() => JsonDecodeServiceWorker(),
+            concurrencySettings: concurrencySettings);
+
+  @override
+  Future<dynamic> jsonDecode(String source) =>
+      execute((w) => w.jsonDecode(source));
+
+  @override
+  Map<int, CommandHandler> get operations => WorkerService.noOperations;
+}

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   analyzer:
   http:
   built_collection:
+  squadron: ^4.3.0
 
 dev_dependencies:
   build_runner:
@@ -22,6 +23,7 @@ dev_dependencies:
   built_value_generator:
   dart_code_metrics: ^4.8.1
   lints: ^2.0.0
+  squadron_builder: ^0.9.0
 
 dependency_overrides:
  chopper:


### PR DESCRIPTION
This is a follow-up on https://github.com/lejard-h/chopper/issues/158#issuecomment-1245991530

Since wiring all this up isn't really that straightforward, I decided to write an example using:

- [json_serializable](https://github.com/google/json_serializable.dart)
- [squadron](https://github.com/d-markey/squadron)
- [squadron_builder](https://github.com/d-markey/squadron_builder)

Essentially all one needs to do is:

1. install the dependencies: `dart pub add squadron squadron_builder`
2. make a service like `example/lib/json_decode_service.dart`
3. run code generation: `dart run build_runner build`
4. wire up `example/lib/json_decode_service.dart` with a custom `JsonConverter`
5. configure and start a `WorkerPool`
6. run HTTP requests like a boss using Isolate Workers 😎