### PR TITLE
Request extends http.BaseRequest

### DIFF
--- a/chopper/lib/chopper.dart
+++ b/chopper/lib/chopper.dart
@@ -7,6 +7,7 @@ export 'src/annotations.dart';
 export 'src/authenticator.dart';
 export 'src/base.dart';
 export 'src/constants.dart';
+export 'src/extensions.dart';
 export 'src/interceptor.dart';
 export 'src/request.dart';
 export 'src/response.dart';

--- a/chopper/lib/src/annotations.dart
+++ b/chopper/lib/src/annotations.dart
@@ -1,10 +1,9 @@
 import 'dart:async';
 
+import 'package:chopper/src/constants.dart';
+import 'package:chopper/src/request.dart';
+import 'package:chopper/src/response.dart';
 import 'package:meta/meta.dart';
-
-import 'constants.dart';
-import 'request.dart';
-import 'response.dart';
 
 /// Defines a Chopper API.
 ///

--- a/chopper/lib/src/base.dart
+++ b/chopper/lib/src/base.dart
@@ -1,15 +1,14 @@
 import 'dart:async';
 
+import 'package:chopper/src/annotations.dart';
+import 'package:chopper/src/authenticator.dart';
+import 'package:chopper/src/constants.dart';
+import 'package:chopper/src/interceptor.dart';
+import 'package:chopper/src/request.dart';
+import 'package:chopper/src/response.dart';
+import 'package:chopper/src/utils.dart';
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
-
-import 'annotations.dart';
-import 'authenticator.dart';
-import 'constants.dart';
-import 'interceptor.dart';
-import 'request.dart';
-import 'response.dart';
-import 'utils.dart';
 
 Type _typeOf<T>() => T;
 

--- a/chopper/lib/src/constants.dart
+++ b/chopper/lib/src/constants.dart
@@ -7,10 +7,7 @@ const String formEncodedHeaders = 'application/x-www-form-urlencoded';
 // Represent the header for a json api response https://jsonapi.org/#mime-types
 const String jsonApiHeaders = 'application/vnd.api+json';
 
-class HttpMethod {
-  // prevent instantiating this class by accident
-  HttpMethod._();
-
+abstract class HttpMethod {
   static const String Get = 'GET';
   static const String Post = 'POST';
   static const String Put = 'PUT';

--- a/chopper/lib/src/constants.dart
+++ b/chopper/lib/src/constants.dart
@@ -8,6 +8,9 @@ const String formEncodedHeaders = 'application/x-www-form-urlencoded';
 const String jsonApiHeaders = 'application/vnd.api+json';
 
 class HttpMethod {
+  // prevent instantiating this class by accident
+  HttpMethod._();
+
   static const String Get = 'GET';
   static const String Post = 'POST';
   static const String Put = 'PUT';

--- a/chopper/lib/src/extensions.dart
+++ b/chopper/lib/src/extensions.dart
@@ -1,7 +1,7 @@
 extension StripStringExtension on String {
   /// The string without any leading whitespace and optional [character]
   String leftStrip([String? character]) {
-    final String trimmed = trim();
+    final String trimmed = trimLeft();
 
     if (character != null && trimmed.startsWith(character)) {
       return trimmed.substring(1);
@@ -12,7 +12,7 @@ extension StripStringExtension on String {
 
   /// The string without any trailing whitespace and optional [character]
   String rightStrip([String? character]) {
-    final String trimmed = trim();
+    final String trimmed = trimRight();
 
     if (character != null && trimmed.endsWith(character)) {
       return trimmed.substring(0, trimmed.length - 1);
@@ -22,13 +22,6 @@ extension StripStringExtension on String {
   }
 
   /// The string without any leading and trailing whitespace and optional [character]
-  String strip([String? character]) {
-    final String trimmed = trim();
-
-    if (character != null) {
-      return trimmed.leftStrip(character).rightStrip(character);
-    }
-
-    return trimmed;
-  }
+  String strip([String? character]) =>
+      character != null ? leftStrip(character).rightStrip(character) : trim();
 }

--- a/chopper/lib/src/extensions.dart
+++ b/chopper/lib/src/extensions.dart
@@ -1,0 +1,34 @@
+extension StripStringExtension on String {
+  /// The string without any leading whitespace and optional [character]
+  String leftStrip([String? character]) {
+    final String trimmed = trim();
+
+    if (character != null && trimmed.startsWith(character)) {
+      return trimmed.substring(1);
+    }
+
+    return trimmed;
+  }
+
+  /// The string without any trailing whitespace and optional [character]
+  String rightStrip([String? character]) {
+    final String trimmed = trim();
+
+    if (character != null && trimmed.endsWith(character)) {
+      return trimmed.substring(0, trimmed.length - 1);
+    }
+
+    return trimmed;
+  }
+
+  /// The string without any leading and trailing whitespace and optional [character]
+  String strip([String? character]) {
+    final String trimmed = trim();
+
+    if (character != null) {
+      return trimmed.leftStrip(character).rightStrip(character);
+    }
+
+    return trimmed;
+  }
+}

--- a/chopper/lib/src/interceptor.dart
+++ b/chopper/lib/src/interceptor.dart
@@ -172,7 +172,7 @@ class HttpLoggingInterceptor
   @override
   FutureOr<Request> onRequest(Request request) async {
     final http.BaseRequest base = await request.toBaseRequest();
-    chopperLogger.info('--> ${base.method} ${base.url}');
+    chopperLogger.info('--> ${base.method} ${base.url.toString()}');
     base.headers.forEach((k, v) => chopperLogger.info('$k: $v'));
 
     String bytes = '';
@@ -192,7 +192,7 @@ class HttpLoggingInterceptor
   @override
   FutureOr<Response> onResponse(Response response) {
     final http.BaseRequest? base = response.base.request;
-    chopperLogger.info('<-- ${response.statusCode} ${base!.url}');
+    chopperLogger.info('<-- ${response.statusCode} ${base!.url.toString()}');
 
     response.base.headers.forEach((k, v) => chopperLogger.info('$k: $v'));
 

--- a/chopper/lib/src/interceptor.dart
+++ b/chopper/lib/src/interceptor.dart
@@ -1,13 +1,12 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:chopper/src/constants.dart';
+import 'package:chopper/src/request.dart';
+import 'package:chopper/src/response.dart';
+import 'package:chopper/src/utils.dart';
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
-
-import 'constants.dart';
-import 'request.dart';
-import 'response.dart';
-import 'utils.dart';
 
 /// An interface for implementing response interceptors.
 ///

--- a/chopper/lib/src/request.dart
+++ b/chopper/lib/src/request.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 
+import 'package:chopper/src/constants.dart';
+import 'package:chopper/src/extensions.dart';
+import 'package:chopper/src/utils.dart';
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
-
-import 'constants.dart';
-import 'utils.dart';
 
 /// This class represents an HTTP request that can be made with Chopper.
 class Request extends http.BaseRequest {
@@ -88,21 +88,13 @@ class Request extends http.BaseRequest {
     // as-is and ignore the baseUrl.
     final Uri uri = url.startsWith('http://') || url.startsWith('https://')
         ? Uri.parse(url)
-        : !baseUrl.endsWith('/') && !url.startsWith('/')
-            ? Uri.parse('$baseUrl/$url')
-            : Uri.parse('$baseUrl$url');
+        : Uri.parse('${baseUrl.strip('/')}/${url.leftStrip('/')}');
 
-    String query = mapToQuery(parameters, useBrackets: useBrackets);
+    final String query = mapToQuery(parameters, useBrackets: useBrackets);
 
-    if (query.isNotEmpty) {
-      if (uri.hasQuery) {
-        query += '&${uri.query}';
-      }
-
-      return uri.replace(query: query);
-    }
-
-    return uri;
+    return query.isNotEmpty
+        ? uri.replace(query: uri.hasQuery ? '${uri.query}&$query' : query)
+        : uri;
   }
 
   /// Converts this Chopper Request into a [http.BaseRequest].

--- a/chopper/lib/src/request.dart
+++ b/chopper/lib/src/request.dart
@@ -8,6 +8,14 @@ import 'utils.dart';
 
 /// This class represents an HTTP request that can be made with Chopper.
 class Request extends http.BaseRequest {
+  final String origin;
+  final String path;
+  final dynamic body;
+  final List<PartValue> parts;
+  final Map<String, dynamic> parameters;
+  final bool multipart;
+  final bool useBrackets;
+
   Request(
     String method,
     this.path,
@@ -25,34 +33,6 @@ class Request extends http.BaseRequest {
     this.headers
       ..clear()
       ..addAll(headers);
-  }
-
-  final String origin;
-  final String path;
-  final dynamic body;
-  final List<PartValue> parts;
-  final Map<String, dynamic> parameters;
-  final bool multipart;
-  final bool useBrackets;
-
-  /// Converts this Chopper Request into a [http.BaseRequest].
-  ///
-  /// All [parameters] and [headers] are conserved.
-  ///
-  /// Depending on the request type the returning object will be:
-  ///   - [http.StreamedRequest] if body is a [Stream<List<int>>]
-  ///   - [http.MultipartRequest] if [multipart] is true
-  ///   - or a [http.Request]
-  FutureOr<http.BaseRequest> toBaseRequest() async {
-    if (body is Stream<List<int>>) {
-      return toStreamedRequest(body, method, url, {...headers});
-    }
-
-    if (multipart) {
-      return toMultipartRequest(parts, method, url, {...headers});
-    }
-
-    return toHttpRequest(body, method, url, {...headers});
   }
 
   /// Makes a copy of this request, replacing original values with the given ones.
@@ -78,6 +58,144 @@ class Request extends http.BaseRequest {
         origin ?? this.origin,
         useBrackets: useBrackets ?? this.useBrackets,
       );
+
+  /// Converts this Chopper Request into a [http.BaseRequest].
+  ///
+  /// All [parameters] and [headers] are conserved.
+  ///
+  /// Depending on the request type the returning object will be:
+  ///   - [http.StreamedRequest] if body is a [Stream<List<int>>]
+  ///   - [http.MultipartRequest] if [multipart] is true
+  ///   - or a [http.Request]
+  FutureOr<http.BaseRequest> toBaseRequest() async {
+    if (body is Stream<List<int>>) {
+      return toStreamedRequest(body, method, url, {...headers});
+    }
+
+    if (multipart) {
+      return toMultipartRequest(parts, method, url, {...headers});
+    }
+
+    return toHttpRequest(body, method, url, {...headers});
+  }
+
+  /// Builds a valid URI from [baseUrl], [url] and [parameters].
+  ///
+  /// If [url] starts with 'http://' or 'https://', baseUrl is ignored.
+  @visibleForTesting
+  static Uri buildUri(
+    String baseUrl,
+    String url,
+    Map<String, dynamic> parameters, {
+    bool useBrackets = false,
+  }) {
+    // If the request's url is already a fully qualified URL, we can use it
+    // as-is and ignore the baseUrl.
+    final Uri uri = url.startsWith('http://') || url.startsWith('https://')
+        ? Uri.parse(url)
+        : !baseUrl.endsWith('/') && !url.startsWith('/')
+            ? Uri.parse('$baseUrl/$url')
+            : Uri.parse('$baseUrl$url');
+
+    String query = mapToQuery(parameters, useBrackets: useBrackets);
+
+    if (query.isNotEmpty) {
+      if (uri.hasQuery) {
+        query += '&${uri.query}';
+      }
+
+      return uri.replace(query: query);
+    }
+
+    return uri;
+  }
+
+  @visibleForTesting
+  static http.Request toHttpRequest(
+    body,
+    String method,
+    Uri uri,
+    Map<String, String> headers,
+  ) {
+    final http.Request baseRequest = http.Request(method, uri)
+      ..headers.addAll(headers);
+
+    if (body != null) {
+      if (body is String) {
+        baseRequest.body = body;
+      } else if (body is List<int>) {
+        baseRequest.bodyBytes = body;
+      } else if (body is Map<String, String>) {
+        baseRequest.bodyFields = body;
+      } else {
+        throw ArgumentError.value('$body', 'body');
+      }
+    }
+
+    return baseRequest;
+  }
+
+  @visibleForTesting
+  static Future<http.MultipartRequest> toMultipartRequest(
+    List<PartValue> parts,
+    String method,
+    Uri uri,
+    Map<String, String> headers,
+  ) async {
+    final http.MultipartRequest baseRequest = http.MultipartRequest(method, uri)
+      ..headers.addAll(headers);
+
+    for (final PartValue part in parts) {
+      if (part.value == null) continue;
+
+      if (part.value is http.MultipartFile) {
+        baseRequest.files.add(part.value);
+      } else if (part.value is Iterable<http.MultipartFile>) {
+        baseRequest.files.addAll(part.value);
+      } else if (part is PartValueFile) {
+        if (part.value is List<int>) {
+          baseRequest.files.add(
+            http.MultipartFile.fromBytes(part.name, part.value),
+          );
+        } else if (part.value is String) {
+          baseRequest.files.add(
+            await http.MultipartFile.fromPath(part.name, part.value),
+          );
+        } else {
+          throw ArgumentError(
+            'Type ${part.value.runtimeType} is not a supported type for PartFile'
+            'Please use one of the following types'
+            ' - List<int>'
+            ' - String (path of your file) '
+            ' - MultipartFile (from package:http)',
+          );
+        }
+      } else {
+        baseRequest.fields[part.name] = part.value.toString();
+      }
+    }
+
+    return baseRequest;
+  }
+
+  @visibleForTesting
+  static http.StreamedRequest toStreamedRequest(
+    Stream<List<int>> bodyStream,
+    String method,
+    Uri uri,
+    Map<String, String> headers,
+  ) {
+    final http.StreamedRequest req = http.StreamedRequest(method, uri)
+      ..headers.addAll(headers);
+
+    bodyStream.listen(
+      req.sink.add,
+      onDone: req.sink.close,
+      onError: req.sink.addError,
+    );
+
+    return req;
+  }
 }
 
 /// Represents a part in a multipart request.
@@ -104,121 +222,4 @@ class PartValue<T> {
 @immutable
 class PartValueFile<T> extends PartValue<T> {
   const PartValueFile(super.name, super.value);
-}
-
-/// Builds a valid URI from [baseUrl], [url] and [parameters].
-///
-/// If [url] starts with 'http://' or 'https://', baseUrl is ignored.
-@visibleForTesting
-Uri buildUri(
-  String baseUrl,
-  String url,
-  Map<String, dynamic> parameters, {
-  bool useBrackets = false,
-}) {
-  // If the request's url is already a fully qualified URL, we can use it
-  // as-is and ignore the baseUrl.
-  Uri uri = url.startsWith('http://') || url.startsWith('https://')
-      ? Uri.parse(url)
-      : !baseUrl.endsWith('/') && !url.startsWith('/')
-          ? Uri.parse('$baseUrl/$url')
-          : Uri.parse('$baseUrl$url');
-
-  String query = mapToQuery(parameters, useBrackets: useBrackets);
-  if (query.isNotEmpty) {
-    if (uri.hasQuery) {
-      query += '&${uri.query}';
-    }
-
-    return uri.replace(query: query);
-  }
-
-  return uri;
-}
-
-@visibleForTesting
-http.Request toHttpRequest(
-  body,
-  String method,
-  Uri uri,
-  Map<String, String> headers,
-) {
-  final http.Request baseRequest = http.Request(method, uri)
-    ..headers.addAll(headers);
-
-  if (body != null) {
-    if (body is String) {
-      baseRequest.body = body;
-    } else if (body is List<int>) {
-      baseRequest.bodyBytes = body;
-    } else if (body is Map<String, String>) {
-      baseRequest.bodyFields = body;
-    } else {
-      throw ArgumentError.value('$body', 'body');
-    }
-  }
-
-  return baseRequest;
-}
-
-@visibleForTesting
-Future<http.MultipartRequest> toMultipartRequest(
-  List<PartValue> parts,
-  String method,
-  Uri uri,
-  Map<String, String> headers,
-) async {
-  final http.MultipartRequest baseRequest = http.MultipartRequest(method, uri)
-    ..headers.addAll(headers);
-
-  for (final PartValue part in parts) {
-    if (part.value == null) continue;
-
-    if (part.value is http.MultipartFile) {
-      baseRequest.files.add(part.value);
-    } else if (part.value is Iterable<http.MultipartFile>) {
-      baseRequest.files.addAll(part.value);
-    } else if (part is PartValueFile) {
-      if (part.value is List<int>) {
-        baseRequest.files.add(
-          http.MultipartFile.fromBytes(part.name, part.value),
-        );
-      } else if (part.value is String) {
-        baseRequest.files.add(
-          await http.MultipartFile.fromPath(part.name, part.value),
-        );
-      } else {
-        throw ArgumentError(
-          'Type ${part.value.runtimeType} is not a supported type for PartFile'
-          'Please use one of the following types'
-          ' - List<int>'
-          ' - String (path of your file) '
-          ' - MultipartFile (from package:http)',
-        );
-      }
-    } else {
-      baseRequest.fields[part.name] = part.value.toString();
-    }
-  }
-
-  return baseRequest;
-}
-
-@visibleForTesting
-http.StreamedRequest toStreamedRequest(
-  Stream<List<int>> bodyStream,
-  String method,
-  Uri uri,
-  Map<String, String> headers,
-) {
-  final http.StreamedRequest req = http.StreamedRequest(method, uri)
-    ..headers.addAll(headers);
-
-  bodyStream.listen(
-    req.sink.add,
-    onDone: req.sink.close,
-    onError: req.sink.addError,
-  );
-
-  return req;
 }

--- a/chopper/lib/src/request.dart
+++ b/chopper/lib/src/request.dart
@@ -33,7 +33,8 @@ class Request extends http.BaseRequest {
   }
 
   /// Build the Chopper [Request] using a [Uri] instead of a [path] and [origin].
-  /// If the [parameters] aren't provided they are taken from the [Uri]
+  /// Both the query parameters in the [Uri] and those provided explicitly in
+  /// the [parameters] are merged together.
   Request.uri(
     String method,
     Uri url, {
@@ -45,7 +46,7 @@ class Request extends http.BaseRequest {
     this.useBrackets = false,
   })  : origin = url.origin,
         path = url.path,
-        parameters = parameters ?? url.queryParametersAll,
+        parameters = {...url.queryParametersAll, ...?parameters},
         super(
           method,
           buildUri(

--- a/chopper/lib/src/request.dart
+++ b/chopper/lib/src/request.dart
@@ -33,18 +33,20 @@ class Request extends http.BaseRequest {
     this.headers.addAll(headers);
   }
 
-  /// Build the Chopper [Request] using a [Uri] instead of a [path] and [origin] String
+  /// Build the Chopper [Request] using a [Uri] instead of a [path] and [origin].
+  /// If the [parameters] aren't provided they are taken from the [Uri]
   Request.uri(
     super.method,
     super.url, {
     this.body,
-    this.parameters = const {},
+    Map<String, dynamic>? parameters,
     Map<String, String> headers = const {},
     this.multipart = false,
     this.parts = const [],
     this.useBrackets = false,
   })  : origin = url.origin,
-        path = url.path {
+        path = url.path,
+        parameters = parameters ?? url.queryParametersAll {
     this.headers.addAll(headers);
   }
 

--- a/chopper/lib/src/request.dart
+++ b/chopper/lib/src/request.dart
@@ -33,7 +33,7 @@ class Request extends http.BaseRequest {
     this.headers.addAll(headers);
   }
 
-  /// Build the Chopper [Request] using a [Uri] instead of a path and origin String
+  /// Build the Chopper [Request] using a [Uri] instead of a [path] and [origin] String
   Request.uri(
     super.method,
     super.url, {

--- a/chopper/lib/src/request.dart
+++ b/chopper/lib/src/request.dart
@@ -109,6 +109,7 @@ class PartValueFile<T> extends PartValue<T> {
 /// Builds a valid URI from [baseUrl], [url] and [parameters].
 ///
 /// If [url] starts with 'http://' or 'https://', baseUrl is ignored.
+@visibleForTesting
 Uri buildUri(
   String baseUrl,
   String url,

--- a/chopper/lib/src/request.dart
+++ b/chopper/lib/src/request.dart
@@ -35,8 +35,8 @@ class Request extends http.BaseRequest {
   /// Build the Chopper [Request] using a [Uri] instead of a [path] and [origin].
   /// If the [parameters] aren't provided they are taken from the [Uri]
   Request.uri(
-    super.method,
-    super.url, {
+    String method,
+    Uri url, {
     this.body,
     Map<String, dynamic>? parameters,
     Map<String, String> headers = const {},
@@ -45,7 +45,16 @@ class Request extends http.BaseRequest {
     this.useBrackets = false,
   })  : origin = url.origin,
         path = url.path,
-        parameters = parameters ?? url.queryParametersAll {
+        parameters = parameters ?? url.queryParametersAll,
+        super(
+          method,
+          buildUri(
+            url.origin,
+            url.path,
+            {...url.queryParametersAll, ...?parameters},
+            useBrackets: useBrackets,
+          ),
+        ) {
     this.headers.addAll(headers);
   }
 

--- a/chopper/lib/src/request.dart
+++ b/chopper/lib/src/request.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:chopper/src/constants.dart';
 import 'package:chopper/src/extensions.dart';
 import 'package:chopper/src/utils.dart';
 import 'package:http/http.dart' as http;
@@ -52,7 +51,7 @@ class Request extends http.BaseRequest {
 
   /// Makes a copy of this [Request], replacing original values with the given ones.
   Request copyWith({
-    HttpMethod? method,
+    String? method,
     String? path,
     String? origin,
     dynamic body,
@@ -63,7 +62,7 @@ class Request extends http.BaseRequest {
     bool? useBrackets,
   }) =>
       Request(
-        (method ?? this.method) as String,
+        method ?? this.method,
         path ?? this.path,
         origin ?? this.origin,
         body: body ?? this.body,

--- a/chopper/lib/src/request.dart
+++ b/chopper/lib/src/request.dart
@@ -8,12 +8,12 @@ import 'utils.dart';
 
 /// This class represents an HTTP request that can be made with Chopper.
 class Request extends http.BaseRequest {
-  final String origin;
   final String path;
+  final String origin;
   final dynamic body;
-  final List<PartValue> parts;
   final Map<String, dynamic> parameters;
   final bool multipart;
+  final List<PartValue> parts;
   final bool useBrackets;
 
   Request(
@@ -52,23 +52,23 @@ class Request extends http.BaseRequest {
   Request copyWith({
     HttpMethod? method,
     String? path,
+    String? origin,
     dynamic body,
     Map<String, dynamic>? parameters,
     Map<String, String>? headers,
-    List<PartValue>? parts,
     bool? multipart,
-    String? origin,
+    List<PartValue>? parts,
     bool? useBrackets,
   }) =>
       Request(
         (method ?? this.method) as String,
         path ?? this.path,
+        origin ?? this.origin,
         body: body ?? this.body,
         parameters: parameters ?? this.parameters,
         headers: headers ?? this.headers,
-        parts: parts ?? this.parts,
         multipart: multipart ?? this.multipart,
-        origin ?? this.origin,
+        parts: parts ?? this.parts,
         useBrackets: useBrackets ?? this.useBrackets,
       );
 

--- a/chopper/lib/src/request.dart
+++ b/chopper/lib/src/request.dart
@@ -27,7 +27,7 @@ class Request extends http.BaseRequest {
     this.parts = const [],
     this.useBrackets = false,
   }) : super(
-          method,
+          method.isNotEmpty ? method : HttpMethod.Get,
           buildUri(origin, path, parameters, useBrackets: useBrackets),
         ) {
     this.headers

--- a/chopper/lib/src/request.dart
+++ b/chopper/lib/src/request.dart
@@ -22,7 +22,9 @@ class Request extends http.BaseRequest {
           method,
           buildUri(origin, path, parameters, useBrackets: useBrackets),
         ) {
-    this.headers.addAll(headers);
+    this.headers
+      ..clear()
+      ..addAll(headers);
   }
 
   final String origin;

--- a/chopper/pubspec.yaml
+++ b/chopper/pubspec.yaml
@@ -9,16 +9,16 @@ environment:
 
 dependencies:
   http: ">=0.13.0 <1.0.0"
-  meta: ^1.3.0
   logging: ^1.0.0
+  meta: ^1.3.0
 
 dev_dependencies:
-  test: ^1.16.4
   build_runner: ^2.0.0
   build_test: ^2.0.0
   coverage: ^1.0.2
-  http_parser: ^4.0.0
   dart_code_metrics: ^4.8.1
+  http_parser: ^4.0.0
   lints: ^2.0.0
+  test: ^1.16.4
   chopper_generator:
     path: ../chopper_generator

--- a/chopper/pubspec.yaml
+++ b/chopper/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.0.0
   build_test: ^2.0.0
+  collection: ^1.16.0
   coverage: ^1.0.2
   dart_code_metrics: ^4.8.1
   http_parser: ^4.0.0

--- a/chopper/test/base_test.dart
+++ b/chopper/test/base_test.dart
@@ -767,7 +767,7 @@ void main() {
     chopper.onRequest.listen((request) {
       expect(
         request.url.toString(),
-        equals('/test/get/1234'),
+        equals('$baseUrl/test/get/1234'),
       );
     });
 

--- a/chopper/test/base_test.dart
+++ b/chopper/test/base_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: long-method
+
 import 'dart:async';
 import 'dart:convert';
 
@@ -49,6 +51,7 @@ void main() {
         );
       }
     });
+
     test('GET', () async {
       final httpClient = MockClient((request) async {
         expect(
@@ -467,40 +470,55 @@ void main() {
     });
 
     test('url concatenation', () async {
-      final url1 = Request.buildUri('foo', 'bar', {});
-      expect(url1.toString(), equals('foo/bar'));
-
-      final url2 = Request.buildUri('foo/', 'bar', {});
-      expect(url2.toString(), equals('foo/bar'));
-
-      final url3 = Request.buildUri('foo', '/bar', {});
-      expect(url3.toString(), equals('foo/bar'));
-
-      final url4 = Request.buildUri('foo/', '/bar', {});
-      expect(url4.toString(), equals('foo/bar'));
-
-      final url5 = Request.buildUri('http://foo', '/bar', {});
-      expect(url5.toString(), equals('http://foo/bar'));
-
-      final url6 = Request.buildUri('https://foo', '/bar', {});
-      expect(url6.toString(), equals('https://foo/bar'));
-
-      final url7 = Request.buildUri('https://foo/', '/bar', {});
-      expect(url7.toString(), equals('https://foo/bar'));
-
-      final url8 = Request.buildUri('https://foo/', '/bar', {'abc': 'xyz'});
-      expect(url8.toString(), equals('https://foo/bar?abc=xyz'));
-
-      final url9 = Request.buildUri(
-        'https://foo/',
-        '/bar?first=123&second=456',
-        {
-          'third': '789',
-          'fourth': '012',
-        },
-      );
       expect(
-        url9.toString(),
+        Request.buildUri('foo', 'bar', {}).toString(),
+        equals('foo/bar'),
+      );
+
+      expect(
+        Request.buildUri('foo/', 'bar', {}).toString(),
+        equals('foo/bar'),
+      );
+
+      expect(
+        Request.buildUri('foo', '/bar', {}).toString(),
+        equals('foo/bar'),
+      );
+
+      expect(
+        Request.buildUri('foo/', '/bar', {}).toString(),
+        equals('foo/bar'),
+      );
+
+      expect(
+        Request.buildUri('http://foo', '/bar', {}).toString(),
+        equals('http://foo/bar'),
+      );
+
+      expect(
+        Request.buildUri('https://foo', '/bar', {}).toString(),
+        equals('https://foo/bar'),
+      );
+
+      expect(
+        Request.buildUri('https://foo/', '/bar', {}).toString(),
+        equals('https://foo/bar'),
+      );
+
+      expect(
+        Request.buildUri('https://foo/', '/bar', {'abc': 'xyz'}).toString(),
+        equals('https://foo/bar?abc=xyz'),
+      );
+
+      expect(
+        Request.buildUri(
+          'https://foo/',
+          '/bar?first=123&second=456',
+          {
+            'third': '789',
+            'fourth': '012',
+          },
+        ).toString(),
         equals('https://foo/bar?first=123&second=456&third=789&fourth=012'),
       );
     });

--- a/chopper/test/base_test.dart
+++ b/chopper/test/base_test.dart
@@ -467,30 +467,30 @@ void main() {
     });
 
     test('url concatenation', () async {
-      final url1 = buildUri('foo', 'bar', {});
+      final url1 = Request.buildUri('foo', 'bar', {});
       expect(url1.toString(), equals('foo/bar'));
 
-      final url2 = buildUri('foo/', 'bar', {});
+      final url2 = Request.buildUri('foo/', 'bar', {});
       expect(url2.toString(), equals('foo/bar'));
 
-      final url3 = buildUri('foo', '/bar', {});
+      final url3 = Request.buildUri('foo', '/bar', {});
       expect(url3.toString(), equals('foo/bar'));
 
-      final url4 = buildUri('foo/', '/bar', {});
+      final url4 = Request.buildUri('foo/', '/bar', {});
       expect(url4.toString(), equals('foo//bar'));
 
-      final url5 = buildUri('http://foo', '/bar', {});
+      final url5 = Request.buildUri('http://foo', '/bar', {});
       expect(url5.toString(), equals('http://foo/bar'));
 
-      final url6 = buildUri('https://foo', '/bar', {});
+      final url6 = Request.buildUri('https://foo', '/bar', {});
       expect(url6.toString(), equals('https://foo/bar'));
 
-      final url7 = buildUri('https://foo/', '/bar', {});
+      final url7 = Request.buildUri('https://foo/', '/bar', {});
       expect(url7.toString(), equals('https://foo//bar'));
     });
 
-    test('BodyBytes', () async {
-      final request = await toHttpRequest(
+    test('BodyBytes', () {
+      final request = Request.toHttpRequest(
         [1, 2, 3],
         HttpMethod.Post,
         Uri.parse('/foo'),
@@ -500,8 +500,8 @@ void main() {
       expect(request.bodyBytes, equals([1, 2, 3]));
     });
 
-    test('BodyFields', () async {
-      final request = await toHttpRequest(
+    test('BodyFields', () {
+      final request = Request.toHttpRequest(
         {'foo': 'bar'},
         HttpMethod.Post,
         Uri.parse('/foo'),
@@ -511,9 +511,9 @@ void main() {
       expect(request.bodyFields, equals({'foo': 'bar'}));
     });
 
-    test('Wrong body', () async {
+    test('Wrong body', () {
       try {
-        await toHttpRequest(
+        Request.toHttpRequest(
           {'foo': 42},
           HttpMethod.Post,
           Uri.parse('/foo'),

--- a/chopper/test/base_test.dart
+++ b/chopper/test/base_test.dart
@@ -490,35 +490,32 @@ void main() {
     });
 
     test('BodyBytes', () {
-      final request = Request.toHttpRequest(
-        [1, 2, 3],
+      final request = Request.uri(
         HttpMethod.Post,
-        Uri.parse('/foo'),
-        {},
-      );
+        Uri.parse('https://foo/'),
+        body: [1, 2, 3],
+      ).toHttpRequest();
 
       expect(request.bodyBytes, equals([1, 2, 3]));
     });
 
     test('BodyFields', () {
-      final request = Request.toHttpRequest(
-        {'foo': 'bar'},
+      final request = Request.uri(
         HttpMethod.Post,
-        Uri.parse('/foo'),
-        {},
-      );
+        Uri.parse('https://foo/'),
+        body: {'foo': 'bar'},
+      ).toHttpRequest();
 
       expect(request.bodyFields, equals({'foo': 'bar'}));
     });
 
     test('Wrong body', () {
       try {
-        Request.toHttpRequest(
-          {'foo': 42},
+        Request.uri(
           HttpMethod.Post,
-          Uri.parse('/foo'),
-          {},
-        );
+          Uri.parse('https://foo/'),
+          body: {'foo': 42},
+        ).toHttpRequest();
       } on ArgumentError catch (e) {
         expect(e.toString(), equals('Invalid argument (body): "{foo: 42}"'));
       }

--- a/chopper/test/base_test.dart
+++ b/chopper/test/base_test.dart
@@ -891,15 +891,18 @@ void main() {
     final chopper = buildClient(httpClient);
     final service = chopper.getService<HttpTestService>();
 
-    try {
-      await service
-          .getTest('1234', dynamicHeader: '')
-          .timeout(const Duration(seconds: 3));
-    } catch (e) {
-      expect(e is TimeoutException, isTrue);
-    }
-
-    httpClient.close();
+    expect(
+      () async {
+        try {
+          await service
+              .getTest('1234', dynamicHeader: '')
+              .timeout(const Duration(seconds: 3));
+        } finally {
+          httpClient.close();
+        }
+      },
+      throwsA(isA<TimeoutException>()),
+    );
   });
 
   test('List query param', () async {

--- a/chopper/test/base_test.dart
+++ b/chopper/test/base_test.dart
@@ -477,7 +477,7 @@ void main() {
       expect(url3.toString(), equals('foo/bar'));
 
       final url4 = Request.buildUri('foo/', '/bar', {});
-      expect(url4.toString(), equals('foo//bar'));
+      expect(url4.toString(), equals('foo/bar'));
 
       final url5 = Request.buildUri('http://foo', '/bar', {});
       expect(url5.toString(), equals('http://foo/bar'));
@@ -486,7 +486,23 @@ void main() {
       expect(url6.toString(), equals('https://foo/bar'));
 
       final url7 = Request.buildUri('https://foo/', '/bar', {});
-      expect(url7.toString(), equals('https://foo//bar'));
+      expect(url7.toString(), equals('https://foo/bar'));
+
+      final url8 = Request.buildUri('https://foo/', '/bar', {'abc': 'xyz'});
+      expect(url8.toString(), equals('https://foo/bar?abc=xyz'));
+
+      final url9 = Request.buildUri(
+        'https://foo/',
+        '/bar?first=123&second=456',
+        {
+          'third': '789',
+          'fourth': '012',
+        },
+      );
+      expect(
+        url9.toString(),
+        equals('https://foo/bar?first=123&second=456&third=789&fourth=012'),
+      );
     });
 
     test('BodyBytes', () {

--- a/chopper/test/extensions_test.dart
+++ b/chopper/test/extensions_test.dart
@@ -1,0 +1,66 @@
+// ignore_for_file: long-method
+
+import 'package:chopper/src/extensions.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('String.leftStrip', () {
+    test('leftStrip without character any leading whitespace', () {
+      expect('/foo'.leftStrip(), '/foo');
+      expect('     /foo'.leftStrip(), '/foo');
+      expect('/foo   '.leftStrip(), '/foo   ');
+      expect('   /foo   '.leftStrip(), '/foo   ');
+    });
+
+    test(
+      'leftStrip with character removes single leading character and any leading whitespace',
+      () {
+        expect('/foo'.leftStrip('/'), 'foo');
+        expect('//foo'.leftStrip('/'), '/foo');
+        expect('     /foo'.leftStrip('/'), 'foo');
+        expect('/foo   '.leftStrip('/'), 'foo   ');
+        expect('   /foo   '.leftStrip('/'), 'foo   ');
+      },
+    );
+  });
+
+  group('String.rightStrip', () {
+    test('rightStrip without character any trailing whitespace', () {
+      expect('foo/'.rightStrip(), 'foo/');
+      expect('     foo/'.rightStrip(), '     foo/');
+      expect('foo/   '.rightStrip(), 'foo/');
+      expect('   foo/   '.rightStrip(), '   foo/');
+    });
+
+    test(
+      'rightStrip with character removes single trailing character and any trailing whitespace',
+          () {
+        expect('foo/'.rightStrip('/'), 'foo');
+        expect('foo//'.rightStrip('/'), 'foo/');
+        expect('     foo/'.rightStrip('/'), '     foo');
+        expect('foo/   '.rightStrip('/'), 'foo');
+        expect('   foo/   '.rightStrip('/'), '   foo');
+      },
+    );
+  });
+
+  group('String.strip', () {
+    test('strip without character any leading and trailing whitespace', () {
+      expect('/foo/'.strip(), '/foo/');
+      expect('     /foo/'.strip(), '/foo/');
+      expect('/foo/   '.strip(), '/foo/');
+      expect('   /foo/   '.strip(), '/foo/');
+    });
+
+    test(
+      'strip with character removes single leading and trailing character and any leading and trailing whitespace',
+          () {
+        expect('/foo/'.strip('/'), 'foo');
+        expect('//foo//'.strip('/'), '/foo/');
+        expect('     /foo/'.strip('/'), 'foo');
+        expect('/foo/   '.strip('/'), 'foo');
+        expect('   /foo/   '.strip('/'), 'foo');
+      },
+    );
+  });
+}

--- a/chopper/test/extensions_test.dart
+++ b/chopper/test/extensions_test.dart
@@ -34,7 +34,7 @@ void main() {
 
     test(
       'rightStrip with character removes single trailing character and any trailing whitespace',
-          () {
+      () {
         expect('foo/'.rightStrip('/'), 'foo');
         expect('foo//'.rightStrip('/'), 'foo/');
         expect('     foo/'.rightStrip('/'), '     foo');
@@ -54,7 +54,7 @@ void main() {
 
     test(
       'strip with character removes single leading and trailing character and any leading and trailing whitespace',
-          () {
+      () {
         expect('/foo/'.strip('/'), 'foo');
         expect('//foo//'.strip('/'), '/foo/');
         expect('     /foo/'.strip('/'), 'foo');

--- a/chopper/test/interceptors_test.dart
+++ b/chopper/test/interceptors_test.dart
@@ -48,7 +48,7 @@ void main() {
       final chopper = ChopperClient(
         interceptors: [
           (Request request) =>
-              request.copyWith(url: '${request.url}/intercept'),
+              request.copyWith(path: '${request.url}/intercept'),
         ],
         services: [
           HttpTestService.create(),
@@ -271,7 +271,7 @@ class ResponseIntercept implements ResponseInterceptor {
 class RequestIntercept implements RequestInterceptor {
   @override
   FutureOr<Request> onRequest(Request request) =>
-      request.copyWith(url: '${request.url}/intercept');
+      request.copyWith(path: '${request.url}/intercept');
 }
 
 class _Intercepted<BodyType> {

--- a/chopper/test/multipart_test.dart
+++ b/chopper/test/multipart_test.dart
@@ -311,4 +311,17 @@ void main() {
     bytes = await second.finalize().first;
     expect(bytes, equals([2, 1]));
   });
+
+  test('Throw exception', () async {
+    expect(
+      () async => await Request.uri(
+        HttpMethod.Post,
+        Uri.parse('https://foo/'),
+        parts: [
+          PartValueFile('', 123),
+        ],
+      ).toMultipartRequest(),
+      throwsA(isA<ArgumentError>()),
+    );
+  });
 }

--- a/chopper/test/multipart_test.dart
+++ b/chopper/test/multipart_test.dart
@@ -203,7 +203,7 @@ void main() {
   });
 
   test('PartValue', () async {
-    final req = await toMultipartRequest(
+    final req = await Request.toMultipartRequest(
       [
         PartValue<String>('foo', 'bar'),
         PartValue<int>('int', 42),
@@ -220,7 +220,7 @@ void main() {
   test(
     'PartFile',
     () async {
-      final req = await toMultipartRequest(
+      final req = await Request.toMultipartRequest(
         [
           PartValueFile<String>('foo', 'test/multipart_test.dart'),
           PartValueFile<List<int>>('int', [1, 2]),
@@ -259,7 +259,7 @@ void main() {
   });
 
   test('Multipart request non nullable', () async {
-    final req = await toMultipartRequest(
+    final req = await Request.toMultipartRequest(
       [
         PartValue<int>('int', 42),
         PartValueFile<List<int>>('list int', [1, 2]),
@@ -279,7 +279,7 @@ void main() {
   });
 
   test('PartValue with MultipartFile directly', () async {
-    final req = await toMultipartRequest(
+    final req = await Request.toMultipartRequest(
       [
         PartValue<http.MultipartFile>(
           '',

--- a/chopper/test/multipart_test.dart
+++ b/chopper/test/multipart_test.dart
@@ -203,15 +203,14 @@ void main() {
   });
 
   test('PartValue', () async {
-    final req = await Request.toMultipartRequest(
-      [
+    final req = await Request.uri(
+      HttpMethod.Post,
+      Uri.parse('https://foo/'),
+      parts: [
         PartValue<String>('foo', 'bar'),
         PartValue<int>('int', 42),
       ],
-      HttpMethod.Post,
-      Uri.parse('/foo'),
-      {},
-    );
+    ).toMultipartRequest();
 
     expect(req.fields['foo'], equals('bar'));
     expect(req.fields['int'], equals('42'));
@@ -220,15 +219,14 @@ void main() {
   test(
     'PartFile',
     () async {
-      final req = await Request.toMultipartRequest(
-        [
+      final req = await Request.uri(
+        HttpMethod.Post,
+        Uri.parse('https://foo/'),
+        parts: [
           PartValueFile<String>('foo', 'test/multipart_test.dart'),
           PartValueFile<List<int>>('int', [1, 2]),
         ],
-        HttpMethod.Post,
-        Uri.parse('/foo'),
-        {},
-      );
+      ).toMultipartRequest();
 
       expect(
         req.files.firstWhere((f) => f.field == 'foo').filename,
@@ -259,17 +257,16 @@ void main() {
   });
 
   test('Multipart request non nullable', () async {
-    final req = await Request.toMultipartRequest(
-      [
+    final req = await Request.uri(
+      HttpMethod.Post,
+      Uri.parse('https://foo/'),
+      parts: [
         PartValue<int>('int', 42),
         PartValueFile<List<int>>('list int', [1, 2]),
         PartValue('null value', null),
         PartValueFile('null file', null),
       ],
-      HttpMethod.Post,
-      Uri.parse('/foo'),
-      {},
-    );
+    ).toMultipartRequest();
 
     expect(req.fields.length, equals(1));
     expect(req.fields['int'], equals('42'));
@@ -279,8 +276,10 @@ void main() {
   });
 
   test('PartValue with MultipartFile directly', () async {
-    final req = await Request.toMultipartRequest(
-      [
+    final req = await Request.uri(
+      HttpMethod.Post,
+      Uri.parse('https://foo/'),
+      parts: [
         PartValue<http.MultipartFile>(
           '',
           http.MultipartFile.fromBytes(
@@ -298,10 +297,7 @@ void main() {
           ),
         ),
       ],
-      HttpMethod.Post,
-      Uri.parse('/foo'),
-      {},
-    );
+    ).toMultipartRequest();
 
     final first = req.files[0];
     final second = req.files[1];

--- a/chopper/test/request_test.dart
+++ b/chopper/test/request_test.dart
@@ -1,7 +1,6 @@
 // ignore_for_file: long-method
 
 import 'package:chopper/chopper.dart';
-import 'package:chopper/src/request.dart';
 import 'package:test/test.dart';
 import 'package:http/http.dart' as http;
 import 'package:collection/collection.dart';
@@ -132,7 +131,9 @@ void main() {
       expect(
         Request.uri(
           'GET',
-          Uri.parse('https://foo/bar?first=sit&second=amet&first_list=a&first_list=b'),
+          Uri.parse(
+            'https://foo/bar?first=sit&second=amet&first_list=a&first_list=b',
+          ),
           parameters: {
             'lorem': 'ipsum',
             'dolor': 123,

--- a/chopper/test/request_test.dart
+++ b/chopper/test/request_test.dart
@@ -1,0 +1,174 @@
+// ignore_for_file: long-method
+
+import 'package:chopper/chopper.dart';
+import 'package:chopper/src/request.dart';
+import 'package:test/test.dart';
+import 'package:http/http.dart' as http;
+import 'package:collection/collection.dart';
+
+void main() {
+  group('Request', () {
+    test('constructor produces a BaseRequest', () {
+      expect(
+        Request('GET', '/bar', 'https://foo/'),
+        isA<http.BaseRequest>(),
+      );
+    });
+
+    test('method gets preserved in BaseRequest', () {
+      expect(
+        Request('GET', '/bar', 'https://foo/').method,
+        equals('GET'),
+      );
+    });
+
+    test('url is correctly parsed and set in BaseRequest', () {
+      expect(
+        Request('GET', '/bar', 'https://foo/').url,
+        equals(Uri.parse('https://foo/bar')),
+      );
+
+      expect(
+        Request('GET', '/bar?lorem=ipsum&dolor=123', 'https://foo/').url,
+        equals(Uri.parse('https://foo/bar?lorem=ipsum&dolor=123')),
+      );
+
+      expect(
+        Request(
+          'GET',
+          '/bar',
+          'https://foo/',
+          parameters: {
+            'lorem': 'ipsum',
+            'dolor': 123,
+          },
+        ).url,
+        equals(Uri.parse('https://foo/bar?lorem=ipsum&dolor=123')),
+      );
+
+      expect(
+        Request(
+          'GET',
+          '/bar?first=sit&second=amet&first_list=a&first_list=b',
+          'https://foo/',
+          parameters: {
+            'lorem': 'ipsum',
+            'dolor': 123,
+            'second_list': ['a', 'b'],
+          },
+        ).url,
+        equals(Uri.parse(
+          'https://foo/bar?first=sit&second=amet&first_list=a&first_list=b&lorem=ipsum&dolor=123&second_list=a&second_list=b',
+        )),
+      );
+    });
+
+    test('headers are preserved in BaseRequest', () {
+      final Map<String, String> headers = {
+        'content-type': 'application/json; charset=utf-8',
+        'accept': 'application/json; charset=utf-8',
+      };
+
+      final Request request = Request(
+        'GET',
+        '/bar',
+        'https://foo/',
+        headers: headers,
+      );
+
+      expect(
+        MapEquality().equals(request.headers, headers),
+        true,
+      );
+    });
+
+    test('copyWith creates a BaseRequest', () {
+      expect(
+        Request('GET', '/bar', 'https://foo/').copyWith(method: HttpMethod.Put),
+        isA<http.BaseRequest>(),
+      );
+    });
+  });
+
+  group('Request.uri', () {
+    test('constructor produces a BaseRequest', () {
+      expect(
+        Request.uri('GET', Uri.parse('https://foo/bar')),
+        isA<http.BaseRequest>(),
+      );
+    });
+
+    test('method gets preserved in BaseRequest', () {
+      expect(
+        Request.uri('GET', Uri.parse('https://foo/bar')).method,
+        equals('GET'),
+      );
+    });
+
+    test('url is correctly parsed and set in BaseRequest', () {
+      expect(
+        Request.uri('GET', Uri.parse('https://foo/bar')).url,
+        equals(Uri.parse('https://foo/bar')),
+      );
+
+      expect(
+        Request.uri('GET', Uri.parse('https://foo/bar?lorem=ipsum&dolor=123'))
+            .url,
+        equals(Uri.parse('https://foo/bar?lorem=ipsum&dolor=123')),
+      );
+
+      expect(
+        Request.uri(
+          'GET',
+          Uri.parse('https://foo/bar'),
+          parameters: {
+            'lorem': 'ipsum',
+            'dolor': 123,
+          },
+        ).url,
+        equals(Uri.parse('https://foo/bar?lorem=ipsum&dolor=123')),
+      );
+
+      expect(
+        Request.uri(
+          'GET',
+          Uri.parse('https://foo/bar?first=sit&second=amet&first_list=a&first_list=b'),
+          parameters: {
+            'lorem': 'ipsum',
+            'dolor': 123,
+            'second_list': ['a', 'b'],
+          },
+        ).url,
+        equals(Uri.parse(
+          'https://foo/bar?first=sit&second=amet&first_list=a&first_list=b&lorem=ipsum&dolor=123&second_list=a&second_list=b',
+        )),
+      );
+    });
+
+    test('headers are preserved in BaseRequest', () {
+      final Map<String, String> headers = {
+        'content-type': 'application/json; charset=utf-8',
+        'accept': 'application/json; charset=utf-8',
+      };
+
+      final Request request = Request.uri(
+        'GET',
+        Uri.parse('https://foo/bar'),
+        headers: headers,
+      );
+
+      expect(
+        MapEquality().equals(request.headers, headers),
+        true,
+      );
+    });
+
+    test('copyWith creates a BaseRequest', () {
+      expect(
+        Request.uri('GET', Uri.parse('https://foo/bar'))
+            .copyWith(method: HttpMethod.Put),
+        isA<http.BaseRequest>(),
+      );
+    });
+  });
+}

--- a/chopper_built_value/test/converter_test.dart
+++ b/chopper_built_value/test/converter_test.dart
@@ -26,7 +26,11 @@ void main() {
 
   group('BuiltValueConverter', () {
     test('convert request', () {
-      var request = Request('', '', '', body: data);
+      var request = Request.uri(
+        HttpMethod.Post,
+        Uri.parse('https://foo/'),
+        body: data,
+      );
       request = converter.convertRequest(request);
       expect(request.body, '{"\$":"DataModel","id":42,"name":"foo"}');
     });
@@ -65,7 +69,11 @@ void main() {
     });
 
     test('has json headers', () {
-      var request = Request('', '', '', body: data);
+      var request = Request.uri(
+        HttpMethod.Get,
+        Uri.parse('https://foo/'),
+        body: data,
+      );
       request = converter.convertRequest(request);
 
       expect(request.headers['content-type'], equals('application/json'));


### PR DESCRIPTION
I think that [`Request`](https://github.com/lejard-h/chopper/blob/master/chopper/lib/src/request.dart#L11) should inherit from [`BaseRequest`](https://pub.dev/documentation/http/latest/http/BaseRequest-class.html).

The added benefit of this is that `Request` ceases to be a Chopper-specific class and now behaves like a `BaseRequest`. 

The only downside is that `Request` can no longer be immutable and have a `const` constructor as `BaseClass` and all its children also aren't immutable and don't have `const` constructors.

```dart
class Request extends http.BaseRequest {
  /// I renamed this to [path] because it is essentially the same as [Uri.path]
  final String path;
  /// I renamed this to [origin] because it is essentially the same as [Uri.origin]
  final String origin;
  final dynamic body;
  final Map<String, dynamic> parameters;
  final bool multipart;
  final List<PartValue> parts;
  final bool useBrackets;

  Request(
    String method,
    this.path,
    this.origin, {
    this.body,
    this.parameters = const {},
    Map<String, String> headers = const {},
    this.multipart = false,
    this.parts = const [],
    this.useBrackets = false,
  }) : super(
          method,
          /// here I used [buildUrl] to construct a [Uri] and use it as the [url] parameter 
          /// of the parent [BaseRequest] constructor
          buildUri(origin, path, parameters, useBrackets: useBrackets),
        ) {
    /// Updating [BaseRequest.headers] is just nasty 🤪
    this.headers.addAll(headers);
  }

  /// Build the Chopper [Request] using a [Uri] instead of a [path] and [origin].
  /// Both the query parameters in the [Uri] and those provided explicitly in
  /// the [parameters] are merged together.
  Request.uri(
    String method,
    Uri url, {
    this.body,
    Map<String, dynamic>? parameters,
    Map<String, String> headers = const {},
    this.multipart = false,
    this.parts = const [],
    this.useBrackets = false,
  })  : origin = url.origin,
        path = url.path,
        parameters = {...url.queryParametersAll, ...?parameters},
        super(
          method,
          buildUri(
            url.origin,
            url.path,
            {...url.queryParametersAll, ...?parameters},
            useBrackets: useBrackets,
          ),
        ) {
    this.headers.addAll(headers);
  }

  /// These methods that were before sitting outside are now class methods
  /// Their API if therefore now vastly simpler.

  /// Convert this [Request] to a [http.Request]
  @visibleForTesting
  http.Request toHttpRequest() {
    // ... stuff
  }
  
  /// Convert this [Request] to a [http.MultipartRequest]
  @visibleForTesting
  Future<http.MultipartRequest> toMultipartRequest() async {
    // ... stuff
  }
  
  /// Convert this [Request] to a [http.StreamedRequest]
  @visibleForTesting
  http.StreamedRequest toStreamedRequest(Stream<List<int>> bodyStream) {
    // ... stuff
  }

  // ... stuff
}
```

I'll work on this PR over the coming days to add some more tests and fix some broken ones.

Lemme know if you even agree with this. 🙈