### PR TITLE
Exclude null query vars by default and add new @Method annotation includeNullQueryVars

### DIFF
--- a/chopper/lib/src/annotations.dart
+++ b/chopper/lib/src/annotations.dart
@@ -169,12 +169,16 @@ class Method {
   /// hxxp://path/to/script?user[name]=john&user[surname]=doe&user[age]=21
   final bool useBrackets;
 
+  /// Set to true to truncate all null query variables
+  final bool ignoreNullQueryVars;
+
   const Method(
     this.method, {
     this.optionalBody = false,
     this.path = '',
     this.headers = const {},
     this.useBrackets = false,
+    this.ignoreNullQueryVars = false,
   });
 }
 
@@ -186,6 +190,7 @@ class Get extends Method {
     super.path,
     super.headers,
     super.useBrackets,
+    super.ignoreNullQueryVars,
   }) : super(HttpMethod.Get);
 }
 
@@ -199,6 +204,7 @@ class Post extends Method {
     super.path,
     super.headers,
     super.useBrackets,
+    super.ignoreNullQueryVars,
   }) : super(HttpMethod.Post);
 }
 
@@ -210,6 +216,7 @@ class Delete extends Method {
     super.path,
     super.headers,
     super.useBrackets,
+    super.ignoreNullQueryVars,
   }) : super(HttpMethod.Delete);
 }
 
@@ -223,6 +230,7 @@ class Put extends Method {
     super.path,
     super.headers,
     super.useBrackets,
+    super.ignoreNullQueryVars,
   }) : super(HttpMethod.Put);
 }
 
@@ -235,6 +243,7 @@ class Patch extends Method {
     super.path,
     super.headers,
     super.useBrackets,
+    super.ignoreNullQueryVars,
   }) : super(HttpMethod.Patch);
 }
 
@@ -246,6 +255,7 @@ class Head extends Method {
     super.path,
     super.headers,
     super.useBrackets,
+    super.ignoreNullQueryVars,
   }) : super(HttpMethod.Head);
 }
 
@@ -256,6 +266,7 @@ class Options extends Method {
     super.path,
     super.headers,
     super.useBrackets,
+    super.ignoreNullQueryVars,
   }) : super(HttpMethod.Options);
 }
 

--- a/chopper/lib/src/annotations.dart
+++ b/chopper/lib/src/annotations.dart
@@ -169,8 +169,31 @@ class Method {
   /// hxxp://path/to/script?user[name]=john&user[surname]=doe&user[age]=21
   final bool useBrackets;
 
-  /// Set to true to truncate all null query variables
-  final bool ignoreNullQueryVars;
+  /// Set to [true] to include query variables with null values. This includes nested maps.
+  /// The default is to exclude them.
+  ///
+  /// NOTE: Empty strings are always included.
+  ///
+  /// ```dart
+  /// @Get(
+  ///   path: '/script',
+  ///   includeNullQueryVars: true,
+  /// )
+  /// Future<Response<String>> getData({
+  ///   @Query('foo') String? foo,
+  ///   @Query('bar') String? bar,
+  ///   @Query('baz') String? baz,
+  /// });
+  ///
+  /// final response = await service.getData(
+  ///   foo: 'foo_val',
+  ///   bar: null, // omitting it would have the same effect
+  ///   baz: 'baz_val',
+  /// );
+  /// ```
+  ///
+  /// The above code produces hxxp://path/to/script&foo=foo_var&bar=&baz=baz_var
+  final bool includeNullQueryVars;
 
   const Method(
     this.method, {
@@ -178,7 +201,7 @@ class Method {
     this.path = '',
     this.headers = const {},
     this.useBrackets = false,
-    this.ignoreNullQueryVars = false,
+    this.includeNullQueryVars = false,
   });
 }
 
@@ -190,7 +213,7 @@ class Get extends Method {
     super.path,
     super.headers,
     super.useBrackets,
-    super.ignoreNullQueryVars,
+    super.includeNullQueryVars,
   }) : super(HttpMethod.Get);
 }
 
@@ -204,7 +227,7 @@ class Post extends Method {
     super.path,
     super.headers,
     super.useBrackets,
-    super.ignoreNullQueryVars,
+    super.includeNullQueryVars,
   }) : super(HttpMethod.Post);
 }
 
@@ -216,7 +239,7 @@ class Delete extends Method {
     super.path,
     super.headers,
     super.useBrackets,
-    super.ignoreNullQueryVars,
+    super.includeNullQueryVars,
   }) : super(HttpMethod.Delete);
 }
 
@@ -230,7 +253,7 @@ class Put extends Method {
     super.path,
     super.headers,
     super.useBrackets,
-    super.ignoreNullQueryVars,
+    super.includeNullQueryVars,
   }) : super(HttpMethod.Put);
 }
 
@@ -243,7 +266,7 @@ class Patch extends Method {
     super.path,
     super.headers,
     super.useBrackets,
-    super.ignoreNullQueryVars,
+    super.includeNullQueryVars,
   }) : super(HttpMethod.Patch);
 }
 
@@ -255,7 +278,7 @@ class Head extends Method {
     super.path,
     super.headers,
     super.useBrackets,
-    super.ignoreNullQueryVars,
+    super.includeNullQueryVars,
   }) : super(HttpMethod.Head);
 }
 
@@ -266,7 +289,7 @@ class Options extends Method {
     super.path,
     super.headers,
     super.useBrackets,
-    super.ignoreNullQueryVars,
+    super.includeNullQueryVars,
   }) : super(HttpMethod.Options);
 }
 

--- a/chopper/lib/src/request.dart
+++ b/chopper/lib/src/request.dart
@@ -14,6 +14,7 @@ class Request extends http.BaseRequest {
   final bool multipart;
   final List<PartValue> parts;
   final bool useBrackets;
+  final bool ignoreNullQueryVars;
 
   Request(
     String method,
@@ -25,9 +26,16 @@ class Request extends http.BaseRequest {
     this.multipart = false,
     this.parts = const [],
     this.useBrackets = false,
+    this.ignoreNullQueryVars = false,
   }) : super(
           method,
-          buildUri(origin, path, parameters, useBrackets: useBrackets),
+          buildUri(
+            origin,
+            path,
+            parameters,
+            useBrackets: useBrackets,
+            ignoreNullQueryVars: ignoreNullQueryVars,
+          ),
         ) {
     this.headers.addAll(headers);
   }
@@ -44,6 +52,7 @@ class Request extends http.BaseRequest {
     this.multipart = false,
     this.parts = const [],
     this.useBrackets = false,
+    this.ignoreNullQueryVars = false,
   })  : origin = url.origin,
         path = url.path,
         parameters = {...url.queryParametersAll, ...?parameters},
@@ -54,6 +63,7 @@ class Request extends http.BaseRequest {
             url.path,
             {...url.queryParametersAll, ...?parameters},
             useBrackets: useBrackets,
+            ignoreNullQueryVars: ignoreNullQueryVars,
           ),
         ) {
     this.headers.addAll(headers);
@@ -70,6 +80,7 @@ class Request extends http.BaseRequest {
     bool? multipart,
     List<PartValue>? parts,
     bool? useBrackets,
+    bool? ignoreNullQueryVars,
   }) =>
       Request(
         method ?? this.method,
@@ -81,6 +92,7 @@ class Request extends http.BaseRequest {
         multipart: multipart ?? this.multipart,
         parts: parts ?? this.parts,
         useBrackets: useBrackets ?? this.useBrackets,
+        ignoreNullQueryVars: ignoreNullQueryVars ?? this.ignoreNullQueryVars,
       );
 
   /// Builds a valid URI from [baseUrl], [url] and [parameters].
@@ -92,6 +104,7 @@ class Request extends http.BaseRequest {
     String url,
     Map<String, dynamic> parameters, {
     bool useBrackets = false,
+    bool ignoreNullQueryVars = false,
   }) {
     // If the request's url is already a fully qualified URL, we can use it
     // as-is and ignore the baseUrl.
@@ -99,7 +112,11 @@ class Request extends http.BaseRequest {
         ? Uri.parse(url)
         : Uri.parse('${baseUrl.strip('/')}/${url.leftStrip('/')}');
 
-    final String query = mapToQuery(parameters, useBrackets: useBrackets);
+    final String query = mapToQuery(
+      parameters,
+      useBrackets: useBrackets,
+      ignoreNullQueryVars: ignoreNullQueryVars,
+    );
 
     return query.isNotEmpty
         ? uri.replace(query: uri.hasQuery ? '${uri.query}&$query' : query)

--- a/chopper/lib/src/request.dart
+++ b/chopper/lib/src/request.dart
@@ -14,7 +14,7 @@ class Request extends http.BaseRequest {
   final bool multipart;
   final List<PartValue> parts;
   final bool useBrackets;
-  final bool ignoreNullQueryVars;
+  final bool includeNullQueryVars;
 
   Request(
     String method,
@@ -26,7 +26,7 @@ class Request extends http.BaseRequest {
     this.multipart = false,
     this.parts = const [],
     this.useBrackets = false,
-    this.ignoreNullQueryVars = false,
+    this.includeNullQueryVars = false,
   }) : super(
           method,
           buildUri(
@@ -34,7 +34,7 @@ class Request extends http.BaseRequest {
             path,
             parameters,
             useBrackets: useBrackets,
-            ignoreNullQueryVars: ignoreNullQueryVars,
+            includeNullQueryVars: includeNullQueryVars,
           ),
         ) {
     this.headers.addAll(headers);
@@ -52,7 +52,7 @@ class Request extends http.BaseRequest {
     this.multipart = false,
     this.parts = const [],
     this.useBrackets = false,
-    this.ignoreNullQueryVars = false,
+    this.includeNullQueryVars = false,
   })  : origin = url.origin,
         path = url.path,
         parameters = {...url.queryParametersAll, ...?parameters},
@@ -63,7 +63,7 @@ class Request extends http.BaseRequest {
             url.path,
             {...url.queryParametersAll, ...?parameters},
             useBrackets: useBrackets,
-            ignoreNullQueryVars: ignoreNullQueryVars,
+            includeNullQueryVars: includeNullQueryVars,
           ),
         ) {
     this.headers.addAll(headers);
@@ -80,7 +80,7 @@ class Request extends http.BaseRequest {
     bool? multipart,
     List<PartValue>? parts,
     bool? useBrackets,
-    bool? ignoreNullQueryVars,
+    bool? includeNullQueryVars,
   }) =>
       Request(
         method ?? this.method,
@@ -92,7 +92,7 @@ class Request extends http.BaseRequest {
         multipart: multipart ?? this.multipart,
         parts: parts ?? this.parts,
         useBrackets: useBrackets ?? this.useBrackets,
-        ignoreNullQueryVars: ignoreNullQueryVars ?? this.ignoreNullQueryVars,
+        includeNullQueryVars: includeNullQueryVars ?? this.includeNullQueryVars,
       );
 
   /// Builds a valid URI from [baseUrl], [url] and [parameters].
@@ -104,7 +104,7 @@ class Request extends http.BaseRequest {
     String url,
     Map<String, dynamic> parameters, {
     bool useBrackets = false,
-    bool ignoreNullQueryVars = false,
+    bool includeNullQueryVars = false,
   }) {
     // If the request's url is already a fully qualified URL, we can use it
     // as-is and ignore the baseUrl.
@@ -115,7 +115,7 @@ class Request extends http.BaseRequest {
     final String query = mapToQuery(
       parameters,
       useBrackets: useBrackets,
-      ignoreNullQueryVars: ignoreNullQueryVars,
+      includeNullQueryVars: includeNullQueryVars,
     );
 
     return query.isNotEmpty

--- a/chopper/lib/src/utils.dart
+++ b/chopper/lib/src/utils.dart
@@ -59,19 +59,19 @@ final chopperLogger = Logger('Chopper');
 String mapToQuery(
   Map<String, dynamic> map, {
   bool useBrackets = false,
-  bool ignoreNullQueryVars = false,
+  bool includeNullQueryVars = false,
 }) =>
     _mapToQuery(
       map,
       useBrackets: useBrackets,
-      ignoreNullQueryVars: ignoreNullQueryVars,
+      includeNullQueryVars: includeNullQueryVars,
     ).join('&');
 
 Iterable<_Pair<String, String>> _mapToQuery(
   Map<String, dynamic> map, {
   String? prefix,
   bool useBrackets = false,
-  bool ignoreNullQueryVars = false,
+  bool includeNullQueryVars = false,
 }) {
   final Set<_Pair<String, String>> pairs = {};
 
@@ -89,7 +89,12 @@ Iterable<_Pair<String, String>> _mapToQuery(
         pairs.addAll(_iterableToQuery(name, value, useBrackets: useBrackets));
       } else if (value is Map<String, dynamic>) {
         pairs.addAll(
-          _mapToQuery(value, prefix: name, useBrackets: useBrackets),
+          _mapToQuery(
+            value,
+            prefix: name,
+            useBrackets: useBrackets,
+            includeNullQueryVars: includeNullQueryVars,
+          ),
         );
       } else {
         pairs.add(
@@ -97,7 +102,7 @@ Iterable<_Pair<String, String>> _mapToQuery(
         );
       }
     } else {
-      if (!ignoreNullQueryVars) {
+      if (includeNullQueryVars) {
         pairs.add(_Pair<String, String>(name, ''));
       }
     }

--- a/chopper/lib/src/utils.dart
+++ b/chopper/lib/src/utils.dart
@@ -56,13 +56,22 @@ final chopperLogger = Logger('Chopper');
 /// Creates a valid URI query string from [map].
 ///
 /// E.g., `{'foo': 'bar', 'ints': [ 1337, 42 ] }` will become 'foo=bar&ints=1337&ints=42'.
-String mapToQuery(Map<String, dynamic> map, {bool useBrackets = false}) =>
-    _mapToQuery(map, useBrackets: useBrackets).join('&');
+String mapToQuery(
+  Map<String, dynamic> map, {
+  bool useBrackets = false,
+  bool ignoreNullQueryVars = false,
+}) =>
+    _mapToQuery(
+      map,
+      useBrackets: useBrackets,
+      ignoreNullQueryVars: ignoreNullQueryVars,
+    ).join('&');
 
 Iterable<_Pair<String, String>> _mapToQuery(
   Map<String, dynamic> map, {
   String? prefix,
   bool useBrackets = false,
+  bool ignoreNullQueryVars = false,
 }) {
   final Set<_Pair<String, String>> pairs = {};
 
@@ -88,7 +97,9 @@ Iterable<_Pair<String, String>> _mapToQuery(
         );
       }
     } else {
-      pairs.add(_Pair<String, String>(name, ''));
+      if (!ignoreNullQueryVars) {
+        pairs.add(_Pair<String, String>(name, ''));
+      }
     }
   });
 

--- a/chopper/test/base_test.dart
+++ b/chopper/test/base_test.dart
@@ -923,6 +923,33 @@ void main() {
     );
   });
 
+  test('Ignore null query vars', () async {
+    final httpClient = MockClient((request) async {
+      expect(
+        request.url.toString(),
+        equals('$baseUrl/test/query_param_ignore_query_vars'
+            '?foo=foo_val'
+            '&baz=baz_val'),
+      );
+      expect(request.method, equals('GET'));
+
+      return http.Response('get response', 200);
+    });
+
+    final chopper = buildClient(httpClient);
+    final service = chopper.getService<HttpTestService>();
+
+    final response = await service.getUsingQueryParamIgnoreQueryVars(
+      foo: 'foo_val',
+      baz: 'baz_val',
+    );
+
+    expect(response.body, equals('get response'));
+    expect(response.statusCode, equals(200));
+
+    httpClient.close();
+  });
+
   test('List query param', () async {
     final httpClient = MockClient((request) async {
       expect(

--- a/chopper/test/base_test.dart
+++ b/chopper/test/base_test.dart
@@ -110,7 +110,7 @@ void main() {
       final httpClient = MockClient((request) async {
         expect(
           request.url.toString(),
-          equals('$baseUrl/test/query?name=&int=&default_value='),
+          equals('$baseUrl/test/query?name='),
         );
         expect(request.method, equals('GET'));
 
@@ -132,7 +132,7 @@ void main() {
       final httpClient = MockClient((request) async {
         expect(
           request.url.toString(),
-          equals('$baseUrl/test/query?name=&int=&default_value=42'),
+          equals('$baseUrl/test/query?name=&default_value=42'),
         );
         expect(request.method, equals('GET'));
 
@@ -923,12 +923,13 @@ void main() {
     );
   });
 
-  test('Ignore null query vars', () async {
+  test('Include null query vars', () async {
     final httpClient = MockClient((request) async {
       expect(
         request.url.toString(),
-        equals('$baseUrl/test/query_param_ignore_query_vars'
+        equals('$baseUrl/test/query_param_include_null_query_vars'
             '?foo=foo_val'
+            '&bar='
             '&baz=baz_val'),
       );
       expect(request.method, equals('GET'));
@@ -939,7 +940,7 @@ void main() {
     final chopper = buildClient(httpClient);
     final service = chopper.getService<HttpTestService>();
 
-    final response = await service.getUsingQueryParamIgnoreQueryVars(
+    final response = await service.getUsingQueryParamIncludeNullQueryVars(
       foo: 'foo_val',
       baz: 'baz_val',
     );
@@ -1084,6 +1085,90 @@ void main() {
         'mno': <String, dynamic>{
           'opq': 'rst',
           'uvw': 'xyz',
+          'list': ['a', 123, false],
+        },
+      },
+    });
+
+    expect(response.body, equals('get response'));
+    expect(response.statusCode, equals(200));
+
+    httpClient.close();
+  });
+
+  test('Map query param without including null query vars', () async {
+    final httpClient = MockClient((request) async {
+      expect(
+        request.url.toString(),
+        equals('$baseUrl/test/map_query_param'
+            '?value.bar=baz'
+            '&value.etc.abc=def'
+            '&value.etc.mno.opq=rst'
+            '&value.etc.mno.list=a'
+            '&value.etc.mno.list=123'
+            '&value.etc.mno.list=false'),
+      );
+      expect(request.method, equals('GET'));
+
+      return http.Response('get response', 200);
+    });
+
+    final chopper = buildClient(httpClient);
+    final service = chopper.getService<HttpTestService>();
+
+    final response = await service.getUsingMapQueryParam(<String, dynamic>{
+      'bar': 'baz',
+      'zap': null,
+      'etc': <String, dynamic>{
+        'abc': 'def',
+        'ghi': null,
+        'mno': <String, dynamic>{
+          'opq': 'rst',
+          'uvw': null,
+          'list': ['a', 123, false],
+        },
+      },
+    });
+
+    expect(response.body, equals('get response'));
+    expect(response.statusCode, equals(200));
+
+    httpClient.close();
+  });
+
+  test('Map query param including null query vars', () async {
+    final httpClient = MockClient((request) async {
+      expect(
+        request.url.toString(),
+        equals('$baseUrl/test/map_query_param_include_null_query_vars'
+            '?value.bar=baz'
+            '&value.zap='
+            '&value.etc.abc=def'
+            '&value.etc.ghi='
+            '&value.etc.mno.opq=rst'
+            '&value.etc.mno.uvw='
+            '&value.etc.mno.list=a'
+            '&value.etc.mno.list=123'
+            '&value.etc.mno.list=false'),
+      );
+      expect(request.method, equals('GET'));
+
+      return http.Response('get response', 200);
+    });
+
+    final chopper = buildClient(httpClient);
+    final service = chopper.getService<HttpTestService>();
+
+    final response = await service
+        .getUsingMapQueryParamIncludeNullQueryVars(<String, dynamic>{
+      'bar': 'baz',
+      'zap': null,
+      'etc': <String, dynamic>{
+        'abc': 'def',
+        'ghi': null,
+        'mno': <String, dynamic>{
+          'opq': 'rst',
+          'uvw': null,
           'list': ['a', 123, false],
         },
       },

--- a/chopper/test/test_service.chopper.dart
+++ b/chopper/test/test_service.chopper.dart
@@ -490,12 +490,12 @@ class _$HttpTestService extends HttpTestService {
   }
 
   @override
-  Future<Response<String>> getUsingQueryParamIgnoreQueryVars({
+  Future<Response<String>> getUsingQueryParamIncludeNullQueryVars({
     String? foo,
     String? bar,
     String? baz,
   }) {
-    final String $url = '/test/query_param_ignore_query_vars';
+    final String $url = '/test/query_param_include_null_query_vars';
     final Map<String, dynamic> $params = <String, dynamic>{
       'foo': foo,
       'bar': bar,
@@ -506,7 +506,7 @@ class _$HttpTestService extends HttpTestService {
       $url,
       client.baseUrl,
       parameters: $params,
-      ignoreNullQueryVars: true,
+      includeNullQueryVars: true,
     );
     return client.send<String, String>($request);
   }
@@ -548,6 +548,21 @@ class _$HttpTestService extends HttpTestService {
       $url,
       client.baseUrl,
       parameters: $params,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getUsingMapQueryParamIncludeNullQueryVars(
+      Map<String, dynamic> value) {
+    final String $url = '/test/map_query_param_include_null_query_vars';
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      includeNullQueryVars: true,
     );
     return client.send<String, String>($request);
   }

--- a/chopper/test/test_service.chopper.dart
+++ b/chopper/test/test_service.chopper.dart
@@ -490,6 +490,28 @@ class _$HttpTestService extends HttpTestService {
   }
 
   @override
+  Future<Response<String>> getUsingQueryParamIgnoreQueryVars({
+    String? foo,
+    String? bar,
+    String? baz,
+  }) {
+    final String $url = '/test/query_param_ignore_query_vars';
+    final Map<String, dynamic> $params = <String, dynamic>{
+      'foo': foo,
+      'bar': bar,
+      'baz': baz,
+    };
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      ignoreNullQueryVars: true,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
   Future<Response<String>> getUsingListQueryParam(List<String> value) {
     final String $url = '/test/list_query_param';
     final Map<String, dynamic> $params = <String, dynamic>{'value': value};

--- a/chopper/test/test_service.dart
+++ b/chopper/test/test_service.dart
@@ -139,6 +139,13 @@ abstract class HttpTestService extends ChopperService {
   @Post(path: 'no-body')
   Future<Response> noBody();
 
+  @Get(path: '/query_param_ignore_query_vars', ignoreNullQueryVars: true)
+  Future<Response<String>> getUsingQueryParamIgnoreQueryVars({
+    @Query('foo') String? foo,
+    @Query('bar') String? bar,
+    @Query('baz') String? baz,
+  });
+
   @Get(path: '/list_query_param')
   Future<Response<String>> getUsingListQueryParam(
     @Query('value') List<String> value,

--- a/chopper/test/test_service.dart
+++ b/chopper/test/test_service.dart
@@ -139,8 +139,8 @@ abstract class HttpTestService extends ChopperService {
   @Post(path: 'no-body')
   Future<Response> noBody();
 
-  @Get(path: '/query_param_ignore_query_vars', ignoreNullQueryVars: true)
-  Future<Response<String>> getUsingQueryParamIgnoreQueryVars({
+  @Get(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
+  Future<Response<String>> getUsingQueryParamIncludeNullQueryVars({
     @Query('foo') String? foo,
     @Query('bar') String? bar,
     @Query('baz') String? baz,
@@ -158,6 +158,14 @@ abstract class HttpTestService extends ChopperService {
 
   @Get(path: '/map_query_param')
   Future<Response<String>> getUsingMapQueryParam(
+    @Query('value') Map<String, dynamic> value,
+  );
+
+  @Get(
+    path: '/map_query_param_include_null_query_vars',
+    includeNullQueryVars: true,
+  )
+  Future<Response<String>> getUsingMapQueryParamIncludeNullQueryVars(
     @Query('value') Map<String, dynamic> value,
   );
 

--- a/chopper/test/utils_test.dart
+++ b/chopper/test/utils_test.dart
@@ -28,6 +28,36 @@ void main() {
         test('$map -> $query', () => expect(mapToQuery(map), query)));
   });
 
+  group('mapToQuery single with ignoreNullQueryVars', () {
+    <Map<String, dynamic>, String>{
+      {'foo': null}: '',
+      {'foo': ''}: 'foo=',
+      {'foo': ' '}: 'foo=%20',
+      {'foo': '  '}: 'foo=%20%20',
+      {'foo': '\t'}: 'foo=%09',
+      {'foo': '\t\t'}: 'foo=%09%09',
+      {'foo': 'null'}: 'foo=null',
+      {'foo': 'bar'}: 'foo=bar',
+      {'foo': ' bar '}: 'foo=%20bar%20',
+      {'foo': '\tbar\t'}: 'foo=%09bar%09',
+      {'foo': '\t\tbar\t\t'}: 'foo=%09%09bar%09%09',
+      {'foo': 123}: 'foo=123',
+      {'foo': 0}: 'foo=0',
+      {'foo': -0.01}: 'foo=-0.01',
+      {'foo': '0.00'}: 'foo=0.00',
+      {'foo': 123.456}: 'foo=123.456',
+      {'foo': 123.450}: 'foo=123.45',
+      {'foo': -123.456}: 'foo=-123.456',
+      {'foo': true}: 'foo=true',
+      {'foo': false}: 'foo=false',
+    }.forEach(
+      (map, query) => test(
+        '$map -> $query',
+        () => expect(mapToQuery(map, ignoreNullQueryVars: true), query),
+      ),
+    );
+  });
+
   group('mapToQuery multiple', () {
     <Map<String, dynamic>, String>{
       {'foo': null, 'baz': null}: 'foo=&baz=',
@@ -51,6 +81,35 @@ void main() {
       {'foo': false, 'baz': false}: 'foo=false&baz=false',
     }.forEach((map, query) =>
         test('$map -> $query', () => expect(mapToQuery(map), query)));
+  });
+
+  group('mapToQuery multiple with ignoreNullQueryVars', () {
+    <Map<String, dynamic>, String>{
+      {'foo': null, 'baz': null}: '',
+      {'foo': '', 'baz': ''}: 'foo=&baz=',
+      {'foo': null, 'baz': ''}: 'baz=',
+      {'foo': '', 'baz': null}: 'foo=',
+      {'foo': 'bar', 'baz': ''}: 'foo=bar&baz=',
+      {'foo': null, 'baz': 'etc'}: 'baz=etc',
+      {'foo': '', 'baz': 'etc'}: 'foo=&baz=etc',
+      {'foo': 'bar', 'baz': 'etc'}: 'foo=bar&baz=etc',
+      {'foo': 'null', 'baz': 'null'}: 'foo=null&baz=null',
+      {'foo': ' ', 'baz': ' '}: 'foo=%20&baz=%20',
+      {'foo': '\t', 'baz': '\t'}: 'foo=%09&baz=%09',
+      {'foo': 123, 'baz': 456}: 'foo=123&baz=456',
+      {'foo': 0, 'baz': 0}: 'foo=0&baz=0',
+      {'foo': '0.00', 'baz': '0.00'}: 'foo=0.00&baz=0.00',
+      {'foo': 123.456, 'baz': 789.012}: 'foo=123.456&baz=789.012',
+      {'foo': 123.450, 'baz': 789.010}: 'foo=123.45&baz=789.01',
+      {'foo': -123.456, 'baz': -789.012}: 'foo=-123.456&baz=-789.012',
+      {'foo': true, 'baz': true}: 'foo=true&baz=true',
+      {'foo': false, 'baz': false}: 'foo=false&baz=false',
+    }.forEach(
+      (map, query) => test(
+        '$map -> $query',
+        () => expect(mapToQuery(map, ignoreNullQueryVars: true), query),
+      ),
+    );
   });
 
   group('mapToQuery lists', () {
@@ -93,6 +152,52 @@ void main() {
       }: 'foo=bar&foo=baz&foo=etc&bar=baz&etc=&xyz=',
     }.forEach((map, query) =>
         test('$map -> $query', () => expect(mapToQuery(map), query)));
+  });
+
+  group('mapToQuery lists with ignoreNullQueryVars', () {
+    <Map<String, dynamic>, String>{
+      {
+        'foo': ['bar', 'baz', 'etc'],
+      }: 'foo=bar&foo=baz&foo=etc',
+      {
+        'foo': ['bar', 123, 456.789, 0, -123, -456.789],
+      }: 'foo=bar&foo=123&foo=456.789&foo=0&foo=-123&foo=-456.789',
+      {
+        'foo': ['', 'baz', 'etc'],
+      }: 'foo=baz&foo=etc',
+      {
+        'foo': ['bar', '', 'etc'],
+      }: 'foo=bar&foo=etc',
+      {
+        'foo': ['bar', 'baz', ''],
+      }: 'foo=bar&foo=baz',
+      {
+        'foo': [null, 'baz', 'etc'],
+      }: 'foo=baz&foo=etc',
+      {
+        'foo': ['bar', null, 'etc'],
+      }: 'foo=bar&foo=etc',
+      {
+        'foo': ['bar', 'baz', null],
+      }: 'foo=bar&foo=baz',
+      {
+        'foo': ['bar', 'baz', ' '],
+      }: 'foo=bar&foo=baz&foo=%20',
+      {
+        'foo': ['bar', 'baz', '\t'],
+      }: 'foo=bar&foo=baz&foo=%09',
+      {
+        'foo': ['bar', 'baz', 'etc'],
+        'bar': 'baz',
+        'etc': '',
+        'xyz': null,
+      }: 'foo=bar&foo=baz&foo=etc&bar=baz&etc=',
+    }.forEach(
+      (map, query) => test(
+        '$map -> $query',
+        () => expect(mapToQuery(map, ignoreNullQueryVars: true), query),
+      ),
+    );
   });
 
   group('mapToQuery lists with brackets', () {
@@ -138,6 +243,55 @@ void main() {
         '$map -> $query',
         () => expect(
           mapToQuery(map, useBrackets: true),
+          query,
+        ),
+      ),
+    );
+  });
+
+  group('mapToQuery lists with brackets with ignoreNullQueryVars', () {
+    <Map<String, dynamic>, String>{
+      {
+        'foo': ['bar', 'baz', 'etc'],
+      }: 'foo%5B%5D=bar&foo%5B%5D=baz&foo%5B%5D=etc',
+      {
+        'foo': ['bar', 123, 456.789, 0, -123, -456.789],
+      }: 'foo%5B%5D=bar&foo%5B%5D=123&foo%5B%5D=456.789&foo%5B%5D=0&foo%5B%5D=-123&foo%5B%5D=-456.789',
+      {
+        'foo': ['', 'baz', 'etc'],
+      }: 'foo%5B%5D=baz&foo%5B%5D=etc',
+      {
+        'foo': ['bar', '', 'etc'],
+      }: 'foo%5B%5D=bar&foo%5B%5D=etc',
+      {
+        'foo': ['bar', 'baz', ''],
+      }: 'foo%5B%5D=bar&foo%5B%5D=baz',
+      {
+        'foo': [null, 'baz', 'etc'],
+      }: 'foo%5B%5D=baz&foo%5B%5D=etc',
+      {
+        'foo': ['bar', null, 'etc'],
+      }: 'foo%5B%5D=bar&foo%5B%5D=etc',
+      {
+        'foo': ['bar', 'baz', null],
+      }: 'foo%5B%5D=bar&foo%5B%5D=baz',
+      {
+        'foo': ['bar', 'baz', ' '],
+      }: 'foo%5B%5D=bar&foo%5B%5D=baz&foo%5B%5D=%20',
+      {
+        'foo': ['bar', 'baz', '\t'],
+      }: 'foo%5B%5D=bar&foo%5B%5D=baz&foo%5B%5D=%09',
+      {
+        'foo': ['bar', 'baz', 'etc'],
+        'bar': 'baz',
+        'etc': '',
+        'xyz': null,
+      }: 'foo%5B%5D=bar&foo%5B%5D=baz&foo%5B%5D=etc&bar=baz&etc=',
+    }.forEach(
+      (map, query) => test(
+        '$map -> $query',
+        () => expect(
+          mapToQuery(map, useBrackets: true, ignoreNullQueryVars: true),
           query,
         ),
       ),
@@ -206,6 +360,72 @@ void main() {
         test('$map -> $query', () => expect(mapToQuery(map), query)));
   });
 
+  group('mapToQuery maps with ignoreNullQueryVars', () {
+    <Map<String, dynamic>, String>{
+      {
+        'foo': {'bar': 'baz'},
+      }: 'foo.bar=baz',
+      {
+        'foo': {'bar': ''},
+      }: 'foo.bar=',
+      {
+        'foo': {'bar': null},
+      }: 'foo.bar=',
+      {
+        'foo': {'bar': ' '},
+      }: 'foo.bar=%20',
+      {
+        'foo': {'bar': '\t'},
+      }: 'foo.bar=%09',
+      {
+        'foo': {'bar': 'baz', 'etc': 'xyz', 'space': ' ', 'tab': '\t'},
+      }: 'foo.bar=baz&foo.etc=xyz&foo.space=%20&foo.tab=%09',
+      {
+        'foo': {
+          'bar': 'baz',
+          'int': 123,
+          'double': 456.789,
+          'zero': 0,
+          'negInt': -123,
+          'negDouble': -456.789,
+          'emptyString': '',
+          'nullValue': null,
+          'space': ' ',
+          'tab': '\t',
+          'list': ['a', 123, false],
+        },
+      }: 'foo.bar=baz&foo.int=123&foo.double=456.789&foo.zero=0&foo.negInt=-123&foo.negDouble=-456.789&foo.emptyString=&foo.nullValue=&foo.space=%20&foo.tab=%09&foo.list=a&foo.list=123&foo.list=false',
+      {
+        'foo': {'bar': 'baz'},
+        'etc': 'xyz',
+      }: 'foo.bar=baz&etc=xyz',
+      {
+        'foo': {
+          'bar': 'baz',
+          'zap': 'abc',
+          'etc': {
+            'abc': 'def',
+            'ghi': 'jkl',
+            'mno': {
+              'opq': 'rst',
+              'uvw': 'xyz',
+              'aab': [
+                'bbc',
+                'ccd',
+                'eef',
+              ],
+            },
+          },
+        },
+      }: 'foo.bar=baz&foo.zap=abc&foo.etc.abc=def&foo.etc.ghi=jkl&foo.etc.mno.opq=rst&foo.etc.mno.uvw=xyz&foo.etc.mno.aab=bbc&foo.etc.mno.aab=ccd&foo.etc.mno.aab=eef',
+    }.forEach(
+      (map, query) => test(
+        '$map -> $query',
+        () => expect(mapToQuery(map, ignoreNullQueryVars: true), query),
+      ),
+    );
+  });
+
   group('mapToQuery maps with brackets', () {
     <Map<String, dynamic>, String>{
       {
@@ -269,6 +489,75 @@ void main() {
         '$map -> $query',
         () => expect(
           mapToQuery(map, useBrackets: true),
+          query,
+        ),
+      ),
+    );
+  });
+
+  group('mapToQuery maps with brackets with ignoreNullQueryVars', () {
+    <Map<String, dynamic>, String>{
+      {
+        'foo': {'bar': 'baz'},
+      }: 'foo%5Bbar%5D=baz',
+      {
+        'foo': {'bar': ''},
+      }: 'foo%5Bbar%5D=',
+      {
+        'foo': {'bar': null},
+      }: 'foo%5Bbar%5D=',
+      {
+        'foo': {'bar': ' '},
+      }: 'foo%5Bbar%5D=%20',
+      {
+        'foo': {'bar': '\t'},
+      }: 'foo%5Bbar%5D=%09',
+      {
+        'foo': {'bar': 'baz', 'etc': 'xyz', 'space': ' ', 'tab': '\t'},
+      }: 'foo%5Bbar%5D=baz&foo%5Betc%5D=xyz&foo%5Bspace%5D=%20&foo%5Btab%5D=%09',
+      {
+        'foo': {
+          'bar': 'baz',
+          'int': 123,
+          'double': 456.789,
+          'zero': 0,
+          'negInt': -123,
+          'negDouble': -456.789,
+          'emptyString': '',
+          'nullValue': null,
+          'space': ' ',
+          'tab': '\t',
+          'list': ['a', 123, false],
+        },
+      }: 'foo%5Bbar%5D=baz&foo%5Bint%5D=123&foo%5Bdouble%5D=456.789&foo%5Bzero%5D=0&foo%5BnegInt%5D=-123&foo%5BnegDouble%5D=-456.789&foo%5BemptyString%5D=&foo%5BnullValue%5D=&foo%5Bspace%5D=%20&foo%5Btab%5D=%09&foo%5Blist%5D%5B%5D=a&foo%5Blist%5D%5B%5D=123&foo%5Blist%5D%5B%5D=false',
+      {
+        'foo': {'bar': 'baz'},
+        'etc': 'xyz',
+      }: 'foo%5Bbar%5D=baz&etc=xyz',
+      {
+        'foo': {
+          'bar': 'baz',
+          'zap': 'abc',
+          'etc': {
+            'abc': 'def',
+            'ghi': 'jkl',
+            'mno': {
+              'opq': 'rst',
+              'uvw': 'xyz',
+              'aab': [
+                'bbc',
+                'ccd',
+                'eef',
+              ],
+            },
+          },
+        },
+      }: 'foo%5Bbar%5D=baz&foo%5Bzap%5D=abc&foo%5Betc%5D%5Babc%5D=def&foo%5Betc%5D%5Bghi%5D=jkl&foo%5Betc%5D%5Bmno%5D%5Bopq%5D=rst&foo%5Betc%5D%5Bmno%5D%5Buvw%5D=xyz&foo%5Betc%5D%5Bmno%5D%5Baab%5D%5B%5D=bbc&foo%5Betc%5D%5Bmno%5D%5Baab%5D%5B%5D=ccd&foo%5Betc%5D%5Bmno%5D%5Baab%5D%5B%5D=eef',
+    }.forEach(
+      (map, query) => test(
+        '$map -> $query',
+        () => expect(
+          mapToQuery(map, useBrackets: true, ignoreNullQueryVars: true),
           query,
         ),
       ),

--- a/chopper/test/utils_test.dart
+++ b/chopper/test/utils_test.dart
@@ -4,32 +4,6 @@ import 'package:test/test.dart';
 void main() {
   group('mapToQuery single', () {
     <Map<String, dynamic>, String>{
-      {'foo': null}: 'foo=',
-      {'foo': ''}: 'foo=',
-      {'foo': ' '}: 'foo=%20',
-      {'foo': '  '}: 'foo=%20%20',
-      {'foo': '\t'}: 'foo=%09',
-      {'foo': '\t\t'}: 'foo=%09%09',
-      {'foo': 'null'}: 'foo=null',
-      {'foo': 'bar'}: 'foo=bar',
-      {'foo': ' bar '}: 'foo=%20bar%20',
-      {'foo': '\tbar\t'}: 'foo=%09bar%09',
-      {'foo': '\t\tbar\t\t'}: 'foo=%09%09bar%09%09',
-      {'foo': 123}: 'foo=123',
-      {'foo': 0}: 'foo=0',
-      {'foo': -0.01}: 'foo=-0.01',
-      {'foo': '0.00'}: 'foo=0.00',
-      {'foo': 123.456}: 'foo=123.456',
-      {'foo': 123.450}: 'foo=123.45',
-      {'foo': -123.456}: 'foo=-123.456',
-      {'foo': true}: 'foo=true',
-      {'foo': false}: 'foo=false',
-    }.forEach((map, query) =>
-        test('$map -> $query', () => expect(mapToQuery(map), query)));
-  });
-
-  group('mapToQuery single with ignoreNullQueryVars', () {
-    <Map<String, dynamic>, String>{
       {'foo': null}: '',
       {'foo': ''}: 'foo=',
       {'foo': ' '}: 'foo=%20',
@@ -50,40 +24,41 @@ void main() {
       {'foo': -123.456}: 'foo=-123.456',
       {'foo': true}: 'foo=true',
       {'foo': false}: 'foo=false',
+    }.forEach((map, query) =>
+        test('$map -> $query', () => expect(mapToQuery(map), query)));
+  });
+
+  group('mapToQuery single with includeNullQueryVars', () {
+    <Map<String, dynamic>, String>{
+      {'foo': null}: 'foo=',
+      {'foo': ''}: 'foo=',
+      {'foo': ' '}: 'foo=%20',
+      {'foo': '  '}: 'foo=%20%20',
+      {'foo': '\t'}: 'foo=%09',
+      {'foo': '\t\t'}: 'foo=%09%09',
+      {'foo': 'null'}: 'foo=null',
+      {'foo': 'bar'}: 'foo=bar',
+      {'foo': ' bar '}: 'foo=%20bar%20',
+      {'foo': '\tbar\t'}: 'foo=%09bar%09',
+      {'foo': '\t\tbar\t\t'}: 'foo=%09%09bar%09%09',
+      {'foo': 123}: 'foo=123',
+      {'foo': 0}: 'foo=0',
+      {'foo': -0.01}: 'foo=-0.01',
+      {'foo': '0.00'}: 'foo=0.00',
+      {'foo': 123.456}: 'foo=123.456',
+      {'foo': 123.450}: 'foo=123.45',
+      {'foo': -123.456}: 'foo=-123.456',
+      {'foo': true}: 'foo=true',
+      {'foo': false}: 'foo=false',
     }.forEach(
       (map, query) => test(
         '$map -> $query',
-        () => expect(mapToQuery(map, ignoreNullQueryVars: true), query),
+        () => expect(mapToQuery(map, includeNullQueryVars: true), query),
       ),
     );
   });
 
   group('mapToQuery multiple', () {
-    <Map<String, dynamic>, String>{
-      {'foo': null, 'baz': null}: 'foo=&baz=',
-      {'foo': '', 'baz': ''}: 'foo=&baz=',
-      {'foo': null, 'baz': ''}: 'foo=&baz=',
-      {'foo': '', 'baz': null}: 'foo=&baz=',
-      {'foo': 'bar', 'baz': ''}: 'foo=bar&baz=',
-      {'foo': null, 'baz': 'etc'}: 'foo=&baz=etc',
-      {'foo': '', 'baz': 'etc'}: 'foo=&baz=etc',
-      {'foo': 'bar', 'baz': 'etc'}: 'foo=bar&baz=etc',
-      {'foo': 'null', 'baz': 'null'}: 'foo=null&baz=null',
-      {'foo': ' ', 'baz': ' '}: 'foo=%20&baz=%20',
-      {'foo': '\t', 'baz': '\t'}: 'foo=%09&baz=%09',
-      {'foo': 123, 'baz': 456}: 'foo=123&baz=456',
-      {'foo': 0, 'baz': 0}: 'foo=0&baz=0',
-      {'foo': '0.00', 'baz': '0.00'}: 'foo=0.00&baz=0.00',
-      {'foo': 123.456, 'baz': 789.012}: 'foo=123.456&baz=789.012',
-      {'foo': 123.450, 'baz': 789.010}: 'foo=123.45&baz=789.01',
-      {'foo': -123.456, 'baz': -789.012}: 'foo=-123.456&baz=-789.012',
-      {'foo': true, 'baz': true}: 'foo=true&baz=true',
-      {'foo': false, 'baz': false}: 'foo=false&baz=false',
-    }.forEach((map, query) =>
-        test('$map -> $query', () => expect(mapToQuery(map), query)));
-  });
-
-  group('mapToQuery multiple with ignoreNullQueryVars', () {
     <Map<String, dynamic>, String>{
       {'foo': null, 'baz': null}: '',
       {'foo': '', 'baz': ''}: 'foo=&baz=',
@@ -104,10 +79,35 @@ void main() {
       {'foo': -123.456, 'baz': -789.012}: 'foo=-123.456&baz=-789.012',
       {'foo': true, 'baz': true}: 'foo=true&baz=true',
       {'foo': false, 'baz': false}: 'foo=false&baz=false',
+    }.forEach((map, query) =>
+        test('$map -> $query', () => expect(mapToQuery(map), query)));
+  });
+
+  group('mapToQuery multiple with includeNullQueryVars', () {
+    <Map<String, dynamic>, String>{
+      {'foo': null, 'baz': null}: 'foo=&baz=',
+      {'foo': '', 'baz': ''}: 'foo=&baz=',
+      {'foo': null, 'baz': ''}: 'foo=&baz=',
+      {'foo': '', 'baz': null}: 'foo=&baz=',
+      {'foo': 'bar', 'baz': ''}: 'foo=bar&baz=',
+      {'foo': null, 'baz': 'etc'}: 'foo=&baz=etc',
+      {'foo': '', 'baz': 'etc'}: 'foo=&baz=etc',
+      {'foo': 'bar', 'baz': 'etc'}: 'foo=bar&baz=etc',
+      {'foo': 'null', 'baz': 'null'}: 'foo=null&baz=null',
+      {'foo': ' ', 'baz': ' '}: 'foo=%20&baz=%20',
+      {'foo': '\t', 'baz': '\t'}: 'foo=%09&baz=%09',
+      {'foo': 123, 'baz': 456}: 'foo=123&baz=456',
+      {'foo': 0, 'baz': 0}: 'foo=0&baz=0',
+      {'foo': '0.00', 'baz': '0.00'}: 'foo=0.00&baz=0.00',
+      {'foo': 123.456, 'baz': 789.012}: 'foo=123.456&baz=789.012',
+      {'foo': 123.450, 'baz': 789.010}: 'foo=123.45&baz=789.01',
+      {'foo': -123.456, 'baz': -789.012}: 'foo=-123.456&baz=-789.012',
+      {'foo': true, 'baz': true}: 'foo=true&baz=true',
+      {'foo': false, 'baz': false}: 'foo=false&baz=false',
     }.forEach(
       (map, query) => test(
         '$map -> $query',
-        () => expect(mapToQuery(map, ignoreNullQueryVars: true), query),
+        () => expect(mapToQuery(map, includeNullQueryVars: true), query),
       ),
     );
   });
@@ -149,12 +149,12 @@ void main() {
         'bar': 'baz',
         'etc': '',
         'xyz': null,
-      }: 'foo=bar&foo=baz&foo=etc&bar=baz&etc=&xyz=',
+      }: 'foo=bar&foo=baz&foo=etc&bar=baz&etc=',
     }.forEach((map, query) =>
         test('$map -> $query', () => expect(mapToQuery(map), query)));
   });
 
-  group('mapToQuery lists with ignoreNullQueryVars', () {
+  group('mapToQuery lists with includeNullQueryVars', () {
     <Map<String, dynamic>, String>{
       {
         'foo': ['bar', 'baz', 'etc'],
@@ -191,11 +191,11 @@ void main() {
         'bar': 'baz',
         'etc': '',
         'xyz': null,
-      }: 'foo=bar&foo=baz&foo=etc&bar=baz&etc=',
+      }: 'foo=bar&foo=baz&foo=etc&bar=baz&etc=&xyz=',
     }.forEach(
       (map, query) => test(
         '$map -> $query',
-        () => expect(mapToQuery(map, ignoreNullQueryVars: true), query),
+        () => expect(mapToQuery(map, includeNullQueryVars: true), query),
       ),
     );
   });
@@ -237,7 +237,7 @@ void main() {
         'bar': 'baz',
         'etc': '',
         'xyz': null,
-      }: 'foo%5B%5D=bar&foo%5B%5D=baz&foo%5B%5D=etc&bar=baz&etc=&xyz=',
+      }: 'foo%5B%5D=bar&foo%5B%5D=baz&foo%5B%5D=etc&bar=baz&etc=',
     }.forEach(
       (map, query) => test(
         '$map -> $query',
@@ -249,7 +249,7 @@ void main() {
     );
   });
 
-  group('mapToQuery lists with brackets with ignoreNullQueryVars', () {
+  group('mapToQuery lists with brackets with includeNullQueryVars', () {
     <Map<String, dynamic>, String>{
       {
         'foo': ['bar', 'baz', 'etc'],
@@ -286,12 +286,12 @@ void main() {
         'bar': 'baz',
         'etc': '',
         'xyz': null,
-      }: 'foo%5B%5D=bar&foo%5B%5D=baz&foo%5B%5D=etc&bar=baz&etc=',
+      }: 'foo%5B%5D=bar&foo%5B%5D=baz&foo%5B%5D=etc&bar=baz&etc=&xyz=',
     }.forEach(
       (map, query) => test(
         '$map -> $query',
         () => expect(
-          mapToQuery(map, useBrackets: true, ignoreNullQueryVars: true),
+          mapToQuery(map, useBrackets: true, includeNullQueryVars: true),
           query,
         ),
       ),
@@ -308,7 +308,7 @@ void main() {
       }: 'foo.bar=',
       {
         'foo': {'bar': null},
-      }: 'foo.bar=',
+      }: '',
       {
         'foo': {'bar': ' '},
       }: 'foo.bar=%20',
@@ -332,7 +332,7 @@ void main() {
           'tab': '\t',
           'list': ['a', 123, false],
         },
-      }: 'foo.bar=baz&foo.int=123&foo.double=456.789&foo.zero=0&foo.negInt=-123&foo.negDouble=-456.789&foo.emptyString=&foo.nullValue=&foo.space=%20&foo.tab=%09&foo.list=a&foo.list=123&foo.list=false',
+      }: 'foo.bar=baz&foo.int=123&foo.double=456.789&foo.zero=0&foo.negInt=-123&foo.negDouble=-456.789&foo.emptyString=&foo.space=%20&foo.tab=%09&foo.list=a&foo.list=123&foo.list=false',
       {
         'foo': {'bar': 'baz'},
         'etc': 'xyz',
@@ -360,7 +360,7 @@ void main() {
         test('$map -> $query', () => expect(mapToQuery(map), query)));
   });
 
-  group('mapToQuery maps with ignoreNullQueryVars', () {
+  group('mapToQuery maps with includeNullQueryVars', () {
     <Map<String, dynamic>, String>{
       {
         'foo': {'bar': 'baz'},
@@ -421,7 +421,7 @@ void main() {
     }.forEach(
       (map, query) => test(
         '$map -> $query',
-        () => expect(mapToQuery(map, ignoreNullQueryVars: true), query),
+        () => expect(mapToQuery(map, includeNullQueryVars: true), query),
       ),
     );
   });
@@ -436,7 +436,7 @@ void main() {
       }: 'foo%5Bbar%5D=',
       {
         'foo': {'bar': null},
-      }: 'foo%5Bbar%5D=',
+      }: '',
       {
         'foo': {'bar': ' '},
       }: 'foo%5Bbar%5D=%20',
@@ -460,7 +460,7 @@ void main() {
           'tab': '\t',
           'list': ['a', 123, false],
         },
-      }: 'foo%5Bbar%5D=baz&foo%5Bint%5D=123&foo%5Bdouble%5D=456.789&foo%5Bzero%5D=0&foo%5BnegInt%5D=-123&foo%5BnegDouble%5D=-456.789&foo%5BemptyString%5D=&foo%5BnullValue%5D=&foo%5Bspace%5D=%20&foo%5Btab%5D=%09&foo%5Blist%5D%5B%5D=a&foo%5Blist%5D%5B%5D=123&foo%5Blist%5D%5B%5D=false',
+      }: 'foo%5Bbar%5D=baz&foo%5Bint%5D=123&foo%5Bdouble%5D=456.789&foo%5Bzero%5D=0&foo%5BnegInt%5D=-123&foo%5BnegDouble%5D=-456.789&foo%5BemptyString%5D=&foo%5Bspace%5D=%20&foo%5Btab%5D=%09&foo%5Blist%5D%5B%5D=a&foo%5Blist%5D%5B%5D=123&foo%5Blist%5D%5B%5D=false',
       {
         'foo': {'bar': 'baz'},
         'etc': 'xyz',
@@ -495,7 +495,7 @@ void main() {
     );
   });
 
-  group('mapToQuery maps with brackets with ignoreNullQueryVars', () {
+  group('mapToQuery maps with brackets with includeNullQueryVars', () {
     <Map<String, dynamic>, String>{
       {
         'foo': {'bar': 'baz'},
@@ -557,7 +557,7 @@ void main() {
       (map, query) => test(
         '$map -> $query',
         () => expect(
-          mapToQuery(map, useBrackets: true, ignoreNullQueryVars: true),
+          mapToQuery(map, useBrackets: true, includeNullQueryVars: true),
           query,
         ),
       ),

--- a/chopper_generator/analysis_options.yaml
+++ b/chopper_generator/analysis_options.yaml
@@ -14,7 +14,7 @@ dart_code_metrics:
     cyclomatic-complexity: 20
     number-of-arguments: 4
     maximum-nesting-level: 5
-    number-of-parameters: 6
+    number-of-parameters: 10
     source-lines-of-code: 250
   metrics-exclude:
     - test/**

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -311,7 +311,7 @@ class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
 
       final bool useBrackets = getUseBrackets(method);
 
-      final bool ignoreNullQueryVars = getIgnoreNullQueryVars(method);
+      final bool includeNullQueryVars = getIncludeNullQueryVars(method);
 
       blocks.add(
         declareFinal(_requestVar, type: refer('Request'))
@@ -323,7 +323,7 @@ class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
                 useHeaders: headers != null,
                 hasParts: hasParts,
                 useBrackets: useBrackets,
-                ignoreNullQueryVars: ignoreNullQueryVars,
+                includeNullQueryVars: includeNullQueryVars,
               ),
             )
             .statement,
@@ -497,7 +497,7 @@ class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
     bool useQueries = false,
     bool useHeaders = false,
     bool useBrackets = false,
-    bool ignoreNullQueryVars = false,
+    bool includeNullQueryVars = false,
   }) {
     final List<Expression> params = [
       literal(getMethodName(method)),
@@ -528,8 +528,8 @@ class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
       namedParams['useBrackets'] = literalBool(useBrackets);
     }
 
-    if (ignoreNullQueryVars) {
-      namedParams['ignoreNullQueryVars'] = literalBool(ignoreNullQueryVars);
+    if (includeNullQueryVars) {
+      namedParams['includeNullQueryVars'] = literalBool(includeNullQueryVars);
     }
 
     return refer('Request').newInstance(params, namedParams);
@@ -639,8 +639,8 @@ String getMethodName(ConstantReader method) =>
 bool getUseBrackets(ConstantReader method) =>
     method.peek('useBrackets')?.boolValue ?? false;
 
-bool getIgnoreNullQueryVars(ConstantReader method) =>
-    method.peek('ignoreNullQueryVars')?.boolValue ?? false;
+bool getIncludeNullQueryVars(ConstantReader method) =>
+    method.peek('includeNullQueryVars')?.boolValue ?? false;
 
 extension DartTypeExtension on DartType {
   bool get isNullable => nullabilitySuffix != NullabilitySuffix.none;

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -311,6 +311,8 @@ class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
 
       final bool useBrackets = getUseBrackets(method);
 
+      final bool ignoreNullQueryVars = getIgnoreNullQueryVars(method);
+
       blocks.add(
         declareFinal(_requestVar, type: refer('Request'))
             .assign(
@@ -321,6 +323,7 @@ class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
                 useHeaders: headers != null,
                 hasParts: hasParts,
                 useBrackets: useBrackets,
+                ignoreNullQueryVars: ignoreNullQueryVars,
               ),
             )
             .statement,
@@ -494,6 +497,7 @@ class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
     bool useQueries = false,
     bool useHeaders = false,
     bool useBrackets = false,
+    bool ignoreNullQueryVars = false,
   }) {
     final List<Expression> params = [
       literal(getMethodName(method)),
@@ -522,6 +526,10 @@ class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
 
     if (useBrackets) {
       namedParams['useBrackets'] = literalBool(useBrackets);
+    }
+
+    if (ignoreNullQueryVars) {
+      namedParams['ignoreNullQueryVars'] = literalBool(ignoreNullQueryVars);
     }
 
     return refer('Request').newInstance(params, namedParams);
@@ -630,6 +638,9 @@ String getMethodName(ConstantReader method) =>
 
 bool getUseBrackets(ConstantReader method) =>
     method.peek('useBrackets')?.boolValue ?? false;
+
+bool getIgnoreNullQueryVars(ConstantReader method) =>
+    method.peek('ignoreNullQueryVars')?.boolValue ?? false;
 
 extension DartTypeExtension on DartType {
   bool get isNullable => nullabilitySuffix != NullabilitySuffix.none;


### PR DESCRIPTION
Fix #371 

Because some backends do not ignore `null` query parameters I have re-introduced the behaviour of excluding `null` query vars by default. This includes nested `null` query parameters inside maps.

This was the default behaviour prior to `v5.0.1` and the merge of https://github.com/lejard-h/chopper/pull/364.

Additionally, I have added a `@Method` annotation `bool includeNullQueryVars` which, if set to `true`, includes `null` query parameters when encoding them into the URL query. 

- Example with `includeNullQueryVars: false` (default; same behaviour as before `v5.0.1`)

  ```dart
  @Get(path: '/get_data')
  Future<Response<String>> getData({
    @Query('foo') String? foo,
    @Query('bar') String? bar,
    @Query('baz') String? baz,
  });
  
  final response = await service.getData(
    foo: 'foo_val',
    baz: 'baz_val',
  );
  ```
  
  Produces `/test/get_data&foo=foo_val&baz=baz_val`

- Example with `includeNullQueryVars: true` (the current default in `v5.0.1`)

  ```dart
  @Get(
    path: '/get_data', 
    includeNullQueryVars: true,
  )
  Future<Response<String>> getData({
    @Query('foo') String? foo,
    @Query('bar') String? bar,
    @Query('baz') String? baz,
  });
  
  final response = await service.getData(
    foo: 'foo_val',
    baz: 'baz_val',
  );
  ```
  
  Produces `/test/get_data&foo=foo_val&bar=&baz=baz_val`

**NOTE**: Empty `String`s are **always** included. If you do not want them to be included make them nullable, i.e. `String?`

```dart
@Get(path: '/get_data')
Future<Response<String>> getData({
  @Query('foo') String foo = '',
  @Query('bar') String? bar,
  @Query('baz') String? baz,
});

final response = await service.getData(
  bar: null,
  baz: 'baz_val',
);
```

Produces `/test/get_data&foo=&baz=baz_val`

**NOTE 2**: `null` values and empty `String`s inside query `List`s are **always** excluded.

```dart
@Get(path: '/get_data')
Future<Response<String>> getData({
  @Query('foo') List<String?> foo,
});

final response = await service.getData(
  foo: <String?>[
    'value1', 
    '', 
    null, 
    'value4',
  ],
);
```

Produces `/test/get_data&foo=value1&foo=value4`