### PR TITLE
Update analyzer to >=4.4.0 <6.0.0

### DIFF
--- a/chopper_generator/pubspec.yaml
+++ b/chopper_generator/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  analyzer: ^4.4.0
+  analyzer: '>=4.4.0 <6.0.0'
   build: ^2.0.0
   built_collection: ^5.0.0
   chopper: ^5.0.0


### PR DESCRIPTION
Addresses https://github.com/lejard-h/chopper/issues/377

I think that bumping it up to `^5.0.0` is a bit harsh [because that version removed quite a few deprecated APIs](https://pub.dev/packages/analyzer/changelog#500). It would probably also warrant a minor version release rather than just a patch release, so I went with `analyzer: '>=4.4.0 <6.0.0'` which should give users a gentler transition.