### PR TITLE
[Feature] Replace the String based path with Uri

### DIFF
--- a/chopper/example/definition.chopper.dart
+++ b/chopper/example/definition.chopper.dart
@@ -18,7 +18,7 @@ class _$MyService extends MyService {
 
   @override
   Future<Response<dynamic>> getResource(String id) {
-    final String $url = '/resources/${id}';
+    final Uri $url = Uri.parse('/resources/${id}');
     final Request $request = Request(
       'GET',
       $url,
@@ -29,7 +29,7 @@ class _$MyService extends MyService {
 
   @override
   Future<Response<Map<dynamic, dynamic>>> getMapResource(String id) {
-    final String $url = '/resources/';
+    final Uri $url = Uri.parse('/resources/');
     final Map<String, dynamic> $params = <String, dynamic>{'id': id};
     final Map<String, String> $headers = {
       'foo': 'bar',
@@ -46,7 +46,7 @@ class _$MyService extends MyService {
 
   @override
   Future<Response<List<Map<dynamic, dynamic>>>> getListResources() {
-    final String $url = '/resources/resources';
+    final Uri $url = Uri.parse('/resources/resources');
     final Request $request = Request(
       'GET',
       $url,
@@ -61,7 +61,7 @@ class _$MyService extends MyService {
     String toto,
     String b,
   ) {
-    final String $url = '/resources/';
+    final Uri $url = Uri.parse('/resources/');
     final $body = <String, dynamic>{
       'a': toto,
       'b': b,
@@ -81,7 +81,7 @@ class _$MyService extends MyService {
     Map<dynamic, dynamic> b,
     String c,
   ) {
-    final String $url = '/resources/multi';
+    final Uri $url = Uri.parse('/resources/multi');
     final List<PartValue> $parts = <PartValue>[
       PartValue<Map<dynamic, dynamic>>(
         '1',
@@ -108,7 +108,7 @@ class _$MyService extends MyService {
 
   @override
   Future<Response<dynamic>> postFile(List<int> bytes) {
-    final String $url = '/resources/file';
+    final Uri $url = Uri.parse('/resources/file');
     final List<PartValue> $parts = <PartValue>[
       PartValue<List<int>>(
         'file',

--- a/chopper/example/main.dart
+++ b/chopper/example/main.dart
@@ -4,7 +4,7 @@ import 'definition.dart';
 
 Future<void> main() async {
   final chopper = ChopperClient(
-    baseUrl: 'http://localhost:8000',
+    baseUrl: Uri.parse('http://localhost:8000'),
     services: [
       // the generated service
       MyService.create(ChopperClient()),

--- a/chopper/lib/src/base.dart
+++ b/chopper/lib/src/base.dart
@@ -341,35 +341,32 @@ class ChopperClient {
 
   /// Makes a HTTP GET request using the [send] function.
   Future<Response<BodyType>> get<BodyType, InnerType>(
-    String url, {
+    Uri url, {
     Map<String, String> headers = const {},
-    Map<String, dynamic> parameters = const {},
     String? baseUrl,
     dynamic body,
   }) =>
       send<BodyType, InnerType>(
-        Request(
+        Request.uri(
           HttpMethod.Get,
           url,
           baseUrl ?? this.baseUrl,
           body: body,
           headers: headers,
-          parameters: parameters,
         ),
       );
 
   /// Makes a HTTP POST request using the [send] function
   Future<Response<BodyType>> post<BodyType, InnerType>(
-    String url, {
+    Uri url, {
     dynamic body,
     List<PartValue> parts = const [],
     Map<String, String> headers = const {},
-    Map<String, dynamic> parameters = const {},
     bool multipart = false,
     String? baseUrl,
   }) =>
       send<BodyType, InnerType>(
-        Request(
+        Request.uri(
           HttpMethod.Post,
           url,
           baseUrl ?? this.baseUrl,
@@ -377,22 +374,20 @@ class ChopperClient {
           parts: parts,
           headers: headers,
           multipart: multipart,
-          parameters: parameters,
         ),
       );
 
   /// Makes a HTTP PUT request using the [send] function.
   Future<Response<BodyType>> put<BodyType, InnerType>(
-    String url, {
+    Uri url, {
     dynamic body,
     List<PartValue> parts = const [],
     Map<String, String> headers = const {},
-    Map<String, dynamic> parameters = const {},
     bool multipart = false,
     String? baseUrl,
   }) =>
       send<BodyType, InnerType>(
-        Request(
+        Request.uri(
           HttpMethod.Put,
           url,
           baseUrl ?? this.baseUrl,
@@ -400,22 +395,20 @@ class ChopperClient {
           parts: parts,
           headers: headers,
           multipart: multipart,
-          parameters: parameters,
         ),
       );
 
   /// Makes a HTTP PATCH request using the [send] function.
   Future<Response<BodyType>> patch<BodyType, InnerType>(
-    String url, {
+    Uri url, {
     dynamic body,
     List<PartValue> parts = const [],
     Map<String, String> headers = const {},
-    Map<String, dynamic> parameters = const {},
     bool multipart = false,
     String? baseUrl,
   }) =>
       send<BodyType, InnerType>(
-        Request(
+        Request.uri(
           HttpMethod.Patch,
           url,
           baseUrl ?? this.baseUrl,
@@ -423,58 +416,51 @@ class ChopperClient {
           parts: parts,
           headers: headers,
           multipart: multipart,
-          parameters: parameters,
         ),
       );
 
   /// Makes a HTTP DELETE request using the [send] function.
   Future<Response<BodyType>> delete<BodyType, InnerType>(
-    String url, {
+    Uri url, {
     Map<String, String> headers = const {},
-    Map<String, dynamic> parameters = const {},
     String? baseUrl,
   }) =>
       send<BodyType, InnerType>(
-        Request(
+        Request.uri(
           HttpMethod.Delete,
           url,
           baseUrl ?? this.baseUrl,
           headers: headers,
-          parameters: parameters,
         ),
       );
 
   /// Makes a HTTP HEAD request using the [send] function.
   Future<Response<BodyType>> head<BodyType, InnerType>(
-    String url, {
+    Uri url, {
     Map<String, String> headers = const {},
-    Map<String, dynamic> parameters = const {},
     String? baseUrl,
   }) =>
       send<BodyType, InnerType>(
-        Request(
+        Request.uri(
           HttpMethod.Head,
           url,
           baseUrl ?? this.baseUrl,
           headers: headers,
-          parameters: parameters,
         ),
       );
 
   /// Makes a HTTP OPTIONS request using the [send] function.
   Future<Response<BodyType>> options<BodyType, InnerType>(
-    String url, {
+    Uri url, {
     Map<String, String> headers = const {},
-    Map<String, dynamic> parameters = const {},
     String? baseUrl,
   }) =>
       send<BodyType, InnerType>(
-        Request(
+        Request.uri(
           HttpMethod.Options,
           url,
           baseUrl ?? this.baseUrl,
           headers: headers,
-          parameters: parameters,
         ),
       );
 

--- a/chopper/lib/src/base.dart
+++ b/chopper/lib/src/base.dart
@@ -123,7 +123,7 @@ class ChopperClient {
             baseUrl == null || !baseUrl.hasQuery,
             'baseUrl should not contain query parameters.'
             'Use a request interceptor to add default query parameters'),
-        baseUrl = baseUrl ?? Uri.parse(''),
+        baseUrl = baseUrl ?? Uri(),
         httpClient = client ?? http.Client(),
         _clientIsInternal = client == null {
     if (!interceptors.every(_isAnInterceptor)) {

--- a/chopper/lib/src/base.dart
+++ b/chopper/lib/src/base.dart
@@ -29,7 +29,7 @@ final List<Type> allowedInterceptorsType = [
 class ChopperClient {
   /// Base URL of each request of the registered services.
   /// E.g., the hostname of your service.
-  final String baseUrl;
+  final Uri baseUrl;
 
   /// The [http.Client] used to make network calls.
   final http.Client httpClient;
@@ -60,6 +60,7 @@ class ChopperClient {
   /// The base URL of each request of the registered services can be defined
   /// with the [baseUrl] parameter.
   ///  E.g., the hostname of your service.
+  ///  If not provided, a empty default [Uri] will be used.
   ///
   /// A custom HTTP client can be passed as the [client] parameter to be used
   /// with the created [ChopperClient].
@@ -70,7 +71,7 @@ class ChopperClient {
   ///
   /// ```dart
   /// final chopper = ChopperClient(
-  ///   baseUrl: 'localhost:8000',
+  ///   baseUrl: Uri.parse('localhost:8000'),
   ///   services: [
   ///     // Add a generated service
   ///     TodosListService.create()
@@ -111,14 +112,15 @@ class ChopperClient {
   ///   );
   /// ```
   ChopperClient({
-    this.baseUrl = '',
+    Uri? baseUrl,
     http.Client? client,
     Iterable interceptors = const [],
     this.authenticator,
     this.converter,
     this.errorConverter,
     Iterable<ChopperService> services = const [],
-  })  : httpClient = client ?? http.Client(),
+  })  : baseUrl = baseUrl ?? Uri.parse(''),
+        httpClient = client ?? http.Client(),
         _clientIsInternal = client == null {
     if (!interceptors.every(_isAnInterceptor)) {
       throw ArgumentError(
@@ -152,7 +154,7 @@ class ChopperClient {
   ///
   /// ```dart
   /// final chopper = ChopperClient(
-  ///   baseUrl: 'localhost:8000',
+  ///   baseUrl: Uri.parse('localhost:8000'),
   ///   services: [
   ///     // Add a generated service
   ///     TodosListService.create()
@@ -343,12 +345,12 @@ class ChopperClient {
   Future<Response<BodyType>> get<BodyType, InnerType>(
     Uri url, {
     Map<String, String> headers = const {},
-    String? baseUrl,
+    Uri? baseUrl,
     Map<String, dynamic> parameters = const {},
     dynamic body,
   }) =>
       send<BodyType, InnerType>(
-        Request.uri(
+        Request(
           HttpMethod.Get,
           url,
           baseUrl ?? this.baseUrl,
@@ -366,10 +368,10 @@ class ChopperClient {
     Map<String, String> headers = const {},
     Map<String, dynamic> parameters = const {},
     bool multipart = false,
-    String? baseUrl,
+    Uri? baseUrl,
   }) =>
       send<BodyType, InnerType>(
-        Request.uri(
+        Request(
           HttpMethod.Post,
           url,
           baseUrl ?? this.baseUrl,
@@ -389,10 +391,10 @@ class ChopperClient {
     Map<String, String> headers = const {},
     Map<String, dynamic> parameters = const {},
     bool multipart = false,
-    String? baseUrl,
+    Uri? baseUrl,
   }) =>
       send<BodyType, InnerType>(
-        Request.uri(
+        Request(
           HttpMethod.Put,
           url,
           baseUrl ?? this.baseUrl,
@@ -412,10 +414,10 @@ class ChopperClient {
     Map<String, String> headers = const {},
     Map<String, dynamic> parameters = const {},
     bool multipart = false,
-    String? baseUrl,
+    Uri? baseUrl,
   }) =>
       send<BodyType, InnerType>(
-        Request.uri(
+        Request(
           HttpMethod.Patch,
           url,
           baseUrl ?? this.baseUrl,
@@ -432,10 +434,10 @@ class ChopperClient {
     Uri url, {
     Map<String, String> headers = const {},
     Map<String, dynamic> parameters = const {},
-    String? baseUrl,
+    Uri? baseUrl,
   }) =>
       send<BodyType, InnerType>(
-        Request.uri(
+        Request(
           HttpMethod.Delete,
           url,
           baseUrl ?? this.baseUrl,
@@ -449,10 +451,10 @@ class ChopperClient {
     Uri url, {
     Map<String, String> headers = const {},
     Map<String, dynamic> parameters = const {},
-    String? baseUrl,
+    Uri? baseUrl,
   }) =>
       send<BodyType, InnerType>(
-        Request.uri(
+        Request(
           HttpMethod.Head,
           url,
           baseUrl ?? this.baseUrl,
@@ -466,10 +468,10 @@ class ChopperClient {
     Uri url, {
     Map<String, String> headers = const {},
     Map<String, dynamic> parameters = const {},
-    String? baseUrl,
+    Uri? baseUrl,
   }) =>
       send<BodyType, InnerType>(
-        Request.uri(
+        Request(
           HttpMethod.Options,
           url,
           baseUrl ?? this.baseUrl,

--- a/chopper/lib/src/base.dart
+++ b/chopper/lib/src/base.dart
@@ -119,7 +119,11 @@ class ChopperClient {
     this.converter,
     this.errorConverter,
     Iterable<ChopperService> services = const [],
-  })  : baseUrl = baseUrl ?? Uri.parse(''),
+  })  : assert(
+            baseUrl == null || !baseUrl.hasQuery,
+            'baseUrl should not contain query parameters.'
+            'Use a request interceptor to add default query parameters'),
+        baseUrl = baseUrl ?? Uri.parse(''),
         httpClient = client ?? http.Client(),
         _clientIsInternal = client == null {
     if (!interceptors.every(_isAnInterceptor)) {

--- a/chopper/lib/src/base.dart
+++ b/chopper/lib/src/base.dart
@@ -344,6 +344,7 @@ class ChopperClient {
     Uri url, {
     Map<String, String> headers = const {},
     String? baseUrl,
+    Map<String, dynamic> parameters = const {},
     dynamic body,
   }) =>
       send<BodyType, InnerType>(
@@ -353,6 +354,7 @@ class ChopperClient {
           baseUrl ?? this.baseUrl,
           body: body,
           headers: headers,
+          parameters: parameters,
         ),
       );
 
@@ -362,6 +364,7 @@ class ChopperClient {
     dynamic body,
     List<PartValue> parts = const [],
     Map<String, String> headers = const {},
+    Map<String, dynamic> parameters = const {},
     bool multipart = false,
     String? baseUrl,
   }) =>
@@ -373,6 +376,7 @@ class ChopperClient {
           body: body,
           parts: parts,
           headers: headers,
+          parameters: parameters,
           multipart: multipart,
         ),
       );
@@ -383,6 +387,7 @@ class ChopperClient {
     dynamic body,
     List<PartValue> parts = const [],
     Map<String, String> headers = const {},
+    Map<String, dynamic> parameters = const {},
     bool multipart = false,
     String? baseUrl,
   }) =>
@@ -394,6 +399,7 @@ class ChopperClient {
           body: body,
           parts: parts,
           headers: headers,
+          parameters: parameters,
           multipart: multipart,
         ),
       );
@@ -404,6 +410,7 @@ class ChopperClient {
     dynamic body,
     List<PartValue> parts = const [],
     Map<String, String> headers = const {},
+    Map<String, dynamic> parameters = const {},
     bool multipart = false,
     String? baseUrl,
   }) =>
@@ -415,6 +422,7 @@ class ChopperClient {
           body: body,
           parts: parts,
           headers: headers,
+          parameters: parameters,
           multipart: multipart,
         ),
       );
@@ -423,6 +431,7 @@ class ChopperClient {
   Future<Response<BodyType>> delete<BodyType, InnerType>(
     Uri url, {
     Map<String, String> headers = const {},
+    Map<String, dynamic> parameters = const {},
     String? baseUrl,
   }) =>
       send<BodyType, InnerType>(
@@ -431,6 +440,7 @@ class ChopperClient {
           url,
           baseUrl ?? this.baseUrl,
           headers: headers,
+          parameters: parameters,
         ),
       );
 
@@ -438,6 +448,7 @@ class ChopperClient {
   Future<Response<BodyType>> head<BodyType, InnerType>(
     Uri url, {
     Map<String, String> headers = const {},
+    Map<String, dynamic> parameters = const {},
     String? baseUrl,
   }) =>
       send<BodyType, InnerType>(
@@ -446,6 +457,7 @@ class ChopperClient {
           url,
           baseUrl ?? this.baseUrl,
           headers: headers,
+          parameters: parameters,
         ),
       );
 
@@ -453,6 +465,7 @@ class ChopperClient {
   Future<Response<BodyType>> options<BodyType, InnerType>(
     Uri url, {
     Map<String, String> headers = const {},
+    Map<String, dynamic> parameters = const {},
     String? baseUrl,
   }) =>
       send<BodyType, InnerType>(
@@ -461,6 +474,7 @@ class ChopperClient {
           url,
           baseUrl ?? this.baseUrl,
           headers: headers,
+          parameters: parameters,
         ),
       );
 

--- a/chopper/lib/src/request.dart
+++ b/chopper/lib/src/request.dart
@@ -49,6 +49,7 @@ class Request extends http.BaseRequest {
     String baseUrl, {
     this.body,
     Map<String, String> headers = const {},
+    Map<String, dynamic>? parameters,
     this.multipart = false,
     this.parts = const [],
     this.useBrackets = false,
@@ -57,7 +58,7 @@ class Request extends http.BaseRequest {
             ? url.origin
             : baseUrl,
         path = url.path,
-        parameters = url.queryParametersAll,
+        parameters = {...url.queryParametersAll, ...?parameters},
         super(
           method,
           buildUri(
@@ -65,7 +66,7 @@ class Request extends http.BaseRequest {
                 ? url.origin
                 : baseUrl,
             url.path,
-            url.queryParametersAll,
+            {...url.queryParametersAll, ...?parameters},
             useBrackets: useBrackets,
             includeNullQueryVars: includeNullQueryVars,
           ),

--- a/chopper/lib/src/request.dart
+++ b/chopper/lib/src/request.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:chopper/chopper.dart';
+import 'package:chopper/src/extensions.dart';
 import 'package:chopper/src/utils.dart';
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
@@ -90,9 +91,9 @@ class Request extends http.BaseRequest {
         : _mergeUri(baseUrl, url);
 
     // Check if parameter also has all the queryParameters from the url (not the merged uri)
-    final parametersContainsUriQuery = parameters.keys
+    final bool parametersContainsUriQuery = parameters.keys
         .every((element) => url.queryParametersAll.keys.contains(element));
-    final allParameters = parametersContainsUriQuery
+    final Map<String, dynamic> allParameters = parametersContainsUriQuery
         ? parameters
         : {...url.queryParametersAll, ...parameters};
 

--- a/chopper/lib/src/request.dart
+++ b/chopper/lib/src/request.dart
@@ -7,6 +7,8 @@ import 'package:meta/meta.dart';
 
 /// This class represents an HTTP request that can be made with Chopper.
 class Request extends http.BaseRequest {
+  final Uri uri;
+  final Uri baseUri;
   final dynamic body;
   final Map<String, dynamic> parameters;
   final bool multipart;
@@ -16,8 +18,8 @@ class Request extends http.BaseRequest {
 
   Request(
     String method,
-    Uri uri,
-    Uri baseUri, {
+    this.uri,
+    this.baseUri, {
     this.body,
     this.parameters = const {},
     Map<String, String> headers = const {},
@@ -41,7 +43,8 @@ class Request extends http.BaseRequest {
   /// Makes a copy of this [Request], replacing original values with the given ones.
   Request copyWith({
     String? method,
-    Uri? url,
+    Uri? uri,
+    Uri? baseUri,
     dynamic body,
     Map<String, dynamic>? parameters,
     Map<String, String>? headers,
@@ -52,9 +55,8 @@ class Request extends http.BaseRequest {
   }) =>
       Request(
         method ?? this.method,
-        url ?? this.url,
-        // baseUrl is not need because it was concatenated the first time create the Request.
-        Uri.parse(''),
+        uri ?? this.uri,
+        baseUri ?? this.baseUri,
         body: body ?? this.body,
         parameters: parameters ?? this.parameters,
         headers: headers ?? this.headers,

--- a/chopper/lib/src/request.dart
+++ b/chopper/lib/src/request.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:chopper/chopper.dart';
 import 'package:chopper/src/extensions.dart';
 import 'package:chopper/src/utils.dart';
 import 'package:http/http.dart' as http;

--- a/chopper/lib/src/request.dart
+++ b/chopper/lib/src/request.dart
@@ -27,7 +27,11 @@ class Request extends http.BaseRequest {
     this.parts = const [],
     this.useBrackets = false,
     this.includeNullQueryVars = false,
-  }) : super(
+  })  : assert(
+            !baseUri.hasQuery,
+            'baseUrl should not contain query parameters.'
+            'Use a request interceptor to add default query parameters'),
+        super(
           method,
           buildUri(
             baseUri,
@@ -80,7 +84,7 @@ class Request extends http.BaseRequest {
     // If the request's url is already a fully qualified URL, we can use it
     // as-is and ignore the baseUrl.
     final Uri uri = url.isScheme('HTTP') || url.isScheme('HTTPS')
-        ? _mergeUri(url, baseUrl, mergePaths: false)
+        ? url
         : _mergeUri(baseUrl, url);
 
     final String query = mapToQuery(
@@ -108,11 +112,9 @@ class Request extends http.BaseRequest {
       queries.add(addToUri.query);
     }
 
-    final path = mergePaths
-        ? mergeIntoUri.hasEmptyPath
-            ? addToUri.path
-            : '${mergeIntoUri.path.rightStrip('/')}/${addToUri.path.leftStrip('/')}'
-        : null;
+    final path = mergeIntoUri.hasEmptyPath
+        ? addToUri.path
+        : '${mergeIntoUri.path.rightStrip('/')}/${addToUri.path.leftStrip('/')}';
 
     return mergeIntoUri.replace(
       path: path,

--- a/chopper/lib/src/request.dart
+++ b/chopper/lib/src/request.dart
@@ -80,7 +80,7 @@ class Request extends http.BaseRequest {
     // If the request's url is already a fully qualified URL, we can use it
     // as-is and ignore the baseUrl.
     final Uri uri = url.isScheme('HTTP') || url.isScheme('HTTPS')
-        ? url
+        ? _mergeUri(url, baseUrl, mergePaths: false)
         : _mergeUri(baseUrl, url);
 
     final String query = mapToQuery(
@@ -94,20 +94,27 @@ class Request extends http.BaseRequest {
         : uri;
   }
 
-  static Uri _mergeUri(Uri baseUrl, Uri url) {
+  /// Merges Uri into another Uri preserving queries and paths
+  static Uri _mergeUri(
+    Uri mergeIntoUri,
+    Uri addToUri, {
+    bool mergePaths = true,
+  }) {
     final queries = [];
-    if (baseUrl.hasQuery) {
-      queries.add(baseUrl.query);
+    if (mergeIntoUri.hasQuery) {
+      queries.add(mergeIntoUri.query);
     }
-    if (url.hasQuery) {
-      queries.add(url.query);
+    if (addToUri.hasQuery) {
+      queries.add(addToUri.query);
     }
 
-    final path = baseUrl.hasEmptyPath
-        ? url.path
-        : '${baseUrl.path.rightStrip('/')}/${url.path.leftStrip('/')}';
+    final path = mergePaths
+        ? mergeIntoUri.hasEmptyPath
+            ? addToUri.path
+            : '${mergeIntoUri.path.rightStrip('/')}/${addToUri.path.leftStrip('/')}'
+        : null;
 
-    return baseUrl.replace(
+    return mergeIntoUri.replace(
       path: path,
       query: queries.isNotEmpty ? queries.join('&') : null,
     );

--- a/chopper/lib/src/request.dart
+++ b/chopper/lib/src/request.dart
@@ -53,13 +53,17 @@ class Request extends http.BaseRequest {
     this.parts = const [],
     this.useBrackets = false,
     this.includeNullQueryVars = false,
-  })  : origin = url.isScheme('HTTP') || url.isScheme('HTTPS') ? url.origin : baseUrl,
+  })  : origin = url.isScheme('HTTP') || url.isScheme('HTTPS')
+            ? url.origin
+            : baseUrl,
         path = url.path,
         parameters = url.queryParametersAll,
         super(
           method,
           buildUri(
-            url.isScheme('HTTP') || url.isScheme('HTTPS') ? url.origin : baseUrl,
+            url.isScheme('HTTP') || url.isScheme('HTTPS')
+                ? url.origin
+                : baseUrl,
             url.path,
             url.queryParametersAll,
             useBrackets: useBrackets,
@@ -118,7 +122,9 @@ class Request extends http.BaseRequest {
       includeNullQueryVars: includeNullQueryVars,
     );
 
-    return query.isNotEmpty ? uri.replace(query: uri.hasQuery ? '${uri.query}&$query' : query) : uri;
+    return query.isNotEmpty
+        ? uri.replace(query: uri.hasQuery ? '${uri.query}&$query' : query)
+        : uri;
   }
 
   /// Converts this Chopper Request into a [http.BaseRequest].
@@ -140,7 +146,8 @@ class Request extends http.BaseRequest {
   /// Convert this [Request] to a [http.Request]
   @visibleForTesting
   http.Request toHttpRequest() {
-    final http.Request request = http.Request(method, url)..headers.addAll(headers);
+    final http.Request request = http.Request(method, url)
+      ..headers.addAll(headers);
 
     if (body != null) {
       if (body is String) {
@@ -160,7 +167,8 @@ class Request extends http.BaseRequest {
   /// Convert this [Request] to a [http.MultipartRequest]
   @visibleForTesting
   Future<http.MultipartRequest> toMultipartRequest() async {
-    final http.MultipartRequest request = http.MultipartRequest(method, url)..headers.addAll(headers);
+    final http.MultipartRequest request = http.MultipartRequest(method, url)
+      ..headers.addAll(headers);
 
     for (final PartValue part in parts) {
       if (part.value == null) continue;
@@ -198,7 +206,8 @@ class Request extends http.BaseRequest {
   /// Convert this [Request] to a [http.StreamedRequest]
   @visibleForTesting
   http.StreamedRequest toStreamedRequest(Stream<List<int>> bodyStream) {
-    final http.StreamedRequest request = http.StreamedRequest(method, url)..headers.addAll(headers);
+    final http.StreamedRequest request = http.StreamedRequest(method, url)
+      ..headers.addAll(headers);
 
     bodyStream.listen(
       request.sink.add,
@@ -223,7 +232,8 @@ class PartValue<T> {
 
   /// Makes a copy of this PartValue, replacing original values with the given ones.
   /// This method can also alter the type of the request body.
-  PartValue<NewType> copyWith<NewType>({String? name, NewType? value}) => PartValue<NewType>(
+  PartValue<NewType> copyWith<NewType>({String? name, NewType? value}) =>
+      PartValue<NewType>(
         name ?? this.name,
         value ?? this.value as NewType,
       );

--- a/chopper/test/base_test.dart
+++ b/chopper/test/base_test.dart
@@ -539,7 +539,7 @@ void main() {
             'fourth': '012',
           },
         ).toString(),
-        equals('https://foo/bar?first=123&second=456&third=789&fourth=012'),
+        equals('https://foo/bar?third=789&fourth=012'),
       );
 
       expect(
@@ -552,7 +552,7 @@ void main() {
           },
         ).toString(),
         equals(
-          'https://foo/bar?first=123&second=456&third=789&fourth=012&fifth=345&sixth=678',
+          'https://foo/bar?third=789&fourth=012&fifth=345&sixth=678',
         ),
       );
 

--- a/chopper/test/base_test.dart
+++ b/chopper/test/base_test.dart
@@ -529,6 +529,41 @@ void main() {
       );
 
       expect(
+        Request.buildUri(
+          Uri.parse('https://foo?first=123&second=456'),
+          Uri.parse('/bar'),
+          {
+            'third': '789',
+            'fourth': '012',
+          },
+        ).toString(),
+        equals('https://foo/bar?first=123&second=456&third=789&fourth=012'),
+      );
+
+      expect(
+        Request.buildUri(
+          Uri.parse('https://foo?first=123&second=456'),
+          Uri.parse('/bar?third=789&fourth=012'),
+          {
+            'fifth': '345',
+            'sixth': '678',
+          },
+        ).toString(),
+        equals(
+          'https://foo/bar?first=123&second=456&third=789&fourth=012&fifth=345&sixth=678',
+        ),
+      );
+
+      expect(
+        Request.buildUri(
+          Uri.parse('https://foo.bar/foobar'),
+          Uri.parse('whatbar'),
+          {},
+        ).toString(),
+        equals('https://foo.bar/foobar/whatbar'),
+      );
+
+      expect(
         Request('GET', Uri(path: '/bar'), Uri.parse('foo')).url.toString(),
         equals('foo/bar'),
       );

--- a/chopper/test/base_test.dart
+++ b/chopper/test/base_test.dart
@@ -429,7 +429,8 @@ void main() {
     });
 
     test('applyHeaders', () {
-      final req1 = applyHeaders(Request('GET', Uri.parse('/'), baseUrl), {'foo': 'bar'});
+      final req1 =
+          applyHeaders(Request('GET', Uri.parse('/'), baseUrl), {'foo': 'bar'});
 
       expect(req1.headers, equals({'foo': 'bar'}));
 
@@ -491,22 +492,27 @@ void main() {
       );
 
       expect(
-        Request.buildUri(Uri.parse('http://foo'), Uri.parse('/bar'), {}).toString(),
+        Request.buildUri(Uri.parse('http://foo'), Uri.parse('/bar'), {})
+            .toString(),
         equals('http://foo/bar'),
       );
 
       expect(
-        Request.buildUri(Uri.parse('https://foo'), Uri.parse('/bar'), {}).toString(),
+        Request.buildUri(Uri.parse('https://foo'), Uri.parse('/bar'), {})
+            .toString(),
         equals('https://foo/bar'),
       );
 
       expect(
-        Request.buildUri(Uri.parse('https://foo/'), Uri.parse('/bar'), {}).toString(),
+        Request.buildUri(Uri.parse('https://foo/'), Uri.parse('/bar'), {})
+            .toString(),
         equals('https://foo/bar'),
       );
 
       expect(
-        Request.buildUri(Uri.parse('https://foo/'), Uri.parse('/bar'), {'abc': 'xyz'}).toString(),
+        Request.buildUri(
+                Uri.parse('https://foo/'), Uri.parse('/bar'), {'abc': 'xyz'})
+            .toString(),
         equals('https://foo/bar?abc=xyz'),
       );
 
@@ -533,14 +539,13 @@ void main() {
       );
 
       expect(
-        Request('GET', Uri.https('bar'), Uri.parse('foo'))
-            .url
-            .toString(),
+        Request('GET', Uri.https('bar'), Uri.parse('foo')).url.toString(),
         equals('https://bar'),
       );
 
       expect(
-        Request('GET', Uri(scheme: 'https', host: 'bar', port: 666), Uri.parse('foo'))
+        Request('GET', Uri(scheme: 'https', host: 'bar', port: 666),
+                Uri.parse('foo'))
             .url
             .toString(),
         equals('https://bar:666'),

--- a/chopper/test/base_test.dart
+++ b/chopper/test/base_test.dart
@@ -511,8 +511,10 @@ void main() {
 
       expect(
         Request.buildUri(
-                Uri.parse('https://foo/'), Uri.parse('/bar'), {'abc': 'xyz'})
-            .toString(),
+          Uri.parse('https://foo/'),
+          Uri.parse('/bar'),
+          {'abc': 'xyz'},
+        ).toString(),
         equals('https://foo/bar?abc=xyz'),
       );
 
@@ -564,6 +566,15 @@ void main() {
       );
 
       expect(
+        Request.buildUri(
+          Uri.parse('https://foo/bar?first=123&second=456'),
+          Uri.parse('https://bar/foo?fourth=789&fifth=012'),
+          {},
+        ).toString(),
+        equals('https://bar/foo?fourth=789&fifth=012&first=123&second=456'),
+      );
+
+      expect(
         Request('GET', Uri(path: '/bar'), Uri.parse('foo')).url.toString(),
         equals('foo/bar'),
       );
@@ -579,10 +590,11 @@ void main() {
       );
 
       expect(
-        Request('GET', Uri(scheme: 'https', host: 'bar', port: 666),
-                Uri.parse('foo'))
-            .url
-            .toString(),
+        Request(
+          'GET',
+          Uri(scheme: 'https', host: 'bar', port: 666),
+          Uri.parse('foo'),
+        ).url.toString(),
         equals('https://bar:666'),
       );
     });

--- a/chopper/test/base_test.dart
+++ b/chopper/test/base_test.dart
@@ -10,7 +10,7 @@ import 'package:test/test.dart';
 
 import 'test_service.dart';
 
-const baseUrl = 'http://localhost:8000';
+final baseUrl = Uri.parse('http://localhost:8000');
 
 void main() {
   ChopperClient buildClient([
@@ -404,7 +404,7 @@ void main() {
 
     test('applyHeader', () {
       final req1 = applyHeader(
-        Request('GET', '/', baseUrl),
+        Request('GET', Uri.parse('/'), baseUrl),
         'foo',
         'bar',
       );
@@ -412,7 +412,7 @@ void main() {
       expect(req1.headers, equals({'foo': 'bar'}));
 
       final req2 = applyHeader(
-        Request('GET', '/', baseUrl, headers: {'foo': 'bar'}),
+        Request('GET', Uri.parse('/'), baseUrl, headers: {'foo': 'bar'}),
         'bar',
         'foo',
       );
@@ -420,7 +420,7 @@ void main() {
       expect(req2.headers, equals({'foo': 'bar', 'bar': 'foo'}));
 
       final req3 = applyHeader(
-        Request('GET', '/', baseUrl, headers: {'foo': 'bar'}),
+        Request('GET', Uri.parse('/'), baseUrl, headers: {'foo': 'bar'}),
         'foo',
         'foo',
       );
@@ -429,19 +429,19 @@ void main() {
     });
 
     test('applyHeaders', () {
-      final req1 = applyHeaders(Request('GET', '/', baseUrl), {'foo': 'bar'});
+      final req1 = applyHeaders(Request('GET', Uri.parse('/'), baseUrl), {'foo': 'bar'});
 
       expect(req1.headers, equals({'foo': 'bar'}));
 
       final req2 = applyHeaders(
-        Request('GET', '/', baseUrl, headers: {'foo': 'bar'}),
+        Request('GET', Uri.parse('/'), baseUrl, headers: {'foo': 'bar'}),
         {'bar': 'foo'},
       );
 
       expect(req2.headers, equals({'foo': 'bar', 'bar': 'foo'}));
 
       final req3 = applyHeaders(
-        Request('GET', '/', baseUrl, headers: {'foo': 'bar'}),
+        Request('GET', Uri.parse('/'), baseUrl, headers: {'foo': 'bar'}),
         {'foo': 'foo'},
       );
 
@@ -471,49 +471,49 @@ void main() {
 
     test('url concatenation', () async {
       expect(
-        Request.buildUri('foo', 'bar', {}).toString(),
+        Request.buildUri(Uri.parse('foo'), Uri.parse('bar'), {}).toString(),
         equals('foo/bar'),
       );
 
       expect(
-        Request.buildUri('foo/', 'bar', {}).toString(),
+        Request.buildUri(Uri.parse('foo/'), Uri.parse('bar'), {}).toString(),
         equals('foo/bar'),
       );
 
       expect(
-        Request.buildUri('foo', '/bar', {}).toString(),
+        Request.buildUri(Uri.parse('foo'), Uri.parse('/bar'), {}).toString(),
         equals('foo/bar'),
       );
 
       expect(
-        Request.buildUri('foo/', '/bar', {}).toString(),
+        Request.buildUri(Uri.parse('foo/'), Uri.parse('/bar'), {}).toString(),
         equals('foo/bar'),
       );
 
       expect(
-        Request.buildUri('http://foo', '/bar', {}).toString(),
+        Request.buildUri(Uri.parse('http://foo'), Uri.parse('/bar'), {}).toString(),
         equals('http://foo/bar'),
       );
 
       expect(
-        Request.buildUri('https://foo', '/bar', {}).toString(),
+        Request.buildUri(Uri.parse('https://foo'), Uri.parse('/bar'), {}).toString(),
         equals('https://foo/bar'),
       );
 
       expect(
-        Request.buildUri('https://foo/', '/bar', {}).toString(),
+        Request.buildUri(Uri.parse('https://foo/'), Uri.parse('/bar'), {}).toString(),
         equals('https://foo/bar'),
       );
 
       expect(
-        Request.buildUri('https://foo/', '/bar', {'abc': 'xyz'}).toString(),
+        Request.buildUri(Uri.parse('https://foo/'), Uri.parse('/bar'), {'abc': 'xyz'}).toString(),
         equals('https://foo/bar?abc=xyz'),
       );
 
       expect(
         Request.buildUri(
-          'https://foo/',
-          '/bar?first=123&second=456',
+          Uri.parse('https://foo/'),
+          Uri.parse('/bar?first=123&second=456'),
           {
             'third': '789',
             'fourth': '012',
@@ -523,35 +523,35 @@ void main() {
       );
 
       expect(
-        Request.uri('GET', Uri(path: '/bar'), 'foo').url.toString(),
+        Request('GET', Uri(path: '/bar'), Uri.parse('foo')).url.toString(),
         equals('foo/bar'),
       );
 
       expect(
-        Request.uri('GET', Uri(host: 'bar'), 'foo').url.toString(),
+        Request('GET', Uri(host: 'bar'), Uri.parse('foo')).url.toString(),
         equals('foo/'),
       );
 
       expect(
-        Request.uri('GET', Uri(scheme: 'https', host: 'bar'), 'foo')
+        Request('GET', Uri.https('bar'), Uri.parse('foo'))
             .url
             .toString(),
-        equals('https://bar/'),
+        equals('https://bar'),
       );
 
       expect(
-        Request.uri('GET', Uri(scheme: 'https', host: 'bar', port: 666), 'foo')
+        Request('GET', Uri(scheme: 'https', host: 'bar', port: 666), Uri.parse('foo'))
             .url
             .toString(),
-        equals('https://bar:666/'),
+        equals('https://bar:666'),
       );
     });
 
     test('BodyBytes', () {
-      final request = Request.uri(
+      final request = Request(
         HttpMethod.Post,
         Uri.parse('https://foo/'),
-        '',
+        Uri.parse(''),
         body: [1, 2, 3],
       ).toHttpRequest();
 
@@ -559,10 +559,10 @@ void main() {
     });
 
     test('BodyFields', () {
-      final request = Request.uri(
+      final request = Request(
         HttpMethod.Post,
         Uri.parse('https://foo/'),
-        '',
+        Uri.parse(''),
         body: {'foo': 'bar'},
       ).toHttpRequest();
 
@@ -571,10 +571,10 @@ void main() {
 
     test('Wrong body', () {
       try {
-        Request.uri(
+        Request(
           HttpMethod.Post,
           Uri.parse('https://foo/'),
-          '',
+          Uri.parse(''),
           body: {'foo': 42},
         ).toHttpRequest();
       } on ArgumentError catch (e) {

--- a/chopper/test/base_test.dart
+++ b/chopper/test/base_test.dart
@@ -571,7 +571,7 @@ void main() {
           Uri.parse('https://bar/foo?fourth=789&fifth=012'),
           {},
         ).toString(),
-        equals('https://bar/foo?fourth=789&fifth=012&first=123&second=456'),
+        equals('https://bar/foo?fourth=789&fifth=012'),
       );
 
       expect(
@@ -1257,5 +1257,54 @@ void main() {
     expect(response.statusCode, equals(200));
 
     httpClient.close();
+  });
+
+  test('client baseUrl cannot contain query parameters', () {
+    expect(
+      () => ChopperClient(
+        baseUrl: Uri.http(
+          'foo',
+          'bar',
+          {
+            'first': '123',
+            'second': '456',
+          },
+        ),
+      ),
+      throwsA(
+        TypeMatcher<AssertionError>(),
+      ),
+    );
+
+    expect(
+      () => ChopperClient(
+        baseUrl: Uri.parse('foo/bar?first=123'),
+      ),
+      throwsA(
+        TypeMatcher<AssertionError>(),
+      ),
+    );
+
+    expect(
+      () => ChopperClient(
+        baseUrl: Uri(
+          queryParameters: {
+            'first': '123',
+            'second': '456',
+          },
+        ),
+      ),
+      throwsA(
+        TypeMatcher<AssertionError>(),
+      ),
+    );
+    expect(
+      () => ChopperClient(
+        baseUrl: Uri(query: 'first=123&second=456'),
+      ),
+      throwsA(
+        TypeMatcher<AssertionError>(),
+      ),
+    );
   });
 }

--- a/chopper/test/base_test.dart
+++ b/chopper/test/base_test.dart
@@ -164,8 +164,7 @@ void main() {
       final chopper = buildClient(httpClient);
       final service = chopper.getService<HttpTestService>();
 
-      final response =
-          await service.getQueryTest(name: 'Foo', def: 40, number: 18);
+      final response = await service.getQueryTest(name: 'Foo', def: 40, number: 18);
 
       expect(response.body, equals('get response'));
       expect(response.statusCode, equals(200));
@@ -521,12 +520,33 @@ void main() {
         ).toString(),
         equals('https://foo/bar?first=123&second=456&third=789&fourth=012'),
       );
+
+      expect(
+        Request.uri('GET', Uri(path: '/bar'), 'foo').url.toString(),
+        equals('foo/bar'),
+      );
+
+      expect(
+        Request.uri('GET', Uri(host: 'bar'), 'foo').url.toString(),
+        equals('foo/'),
+      );
+
+      expect(
+        Request.uri('GET', Uri(scheme: 'https', host: 'bar'), 'foo').url.toString(),
+        equals('https://bar/'),
+      );
+
+      expect(
+        Request.uri('GET', Uri(scheme: 'https', host: 'bar', port: 666), 'foo').url.toString(),
+        equals('https://bar:666/'),
+      );
     });
 
     test('BodyBytes', () {
       final request = Request.uri(
         HttpMethod.Post,
         Uri.parse('https://foo/'),
+        '',
         body: [1, 2, 3],
       ).toHttpRequest();
 
@@ -537,6 +557,7 @@ void main() {
       final request = Request.uri(
         HttpMethod.Post,
         Uri.parse('https://foo/'),
+        '',
         body: {'foo': 'bar'},
       ).toHttpRequest();
 
@@ -548,6 +569,7 @@ void main() {
         Request.uri(
           HttpMethod.Post,
           Uri.parse('https://foo/'),
+          '',
           body: {'foo': 42},
         ).toHttpRequest();
       } on ArgumentError catch (e) {
@@ -912,9 +934,7 @@ void main() {
     expect(
       () async {
         try {
-          await service
-              .getTest('1234', dynamicHeader: '')
-              .timeout(const Duration(seconds: 3));
+          await service.getTest('1234', dynamicHeader: '').timeout(const Duration(seconds: 3));
         } finally {
           httpClient.close();
         }
@@ -1075,8 +1095,7 @@ void main() {
     final chopper = buildClient(httpClient);
     final service = chopper.getService<HttpTestService>();
 
-    final response =
-        await service.getUsingMapQueryParamWithBrackets(<String, dynamic>{
+    final response = await service.getUsingMapQueryParamWithBrackets(<String, dynamic>{
       'bar': 'baz',
       'zap': 'abc',
       'etc': <String, dynamic>{
@@ -1159,8 +1178,7 @@ void main() {
     final chopper = buildClient(httpClient);
     final service = chopper.getService<HttpTestService>();
 
-    final response = await service
-        .getUsingMapQueryParamIncludeNullQueryVars(<String, dynamic>{
+    final response = await service.getUsingMapQueryParamIncludeNullQueryVars(<String, dynamic>{
       'bar': 'baz',
       'zap': null,
       'etc': <String, dynamic>{

--- a/chopper/test/base_test.dart
+++ b/chopper/test/base_test.dart
@@ -164,7 +164,8 @@ void main() {
       final chopper = buildClient(httpClient);
       final service = chopper.getService<HttpTestService>();
 
-      final response = await service.getQueryTest(name: 'Foo', def: 40, number: 18);
+      final response =
+          await service.getQueryTest(name: 'Foo', def: 40, number: 18);
 
       expect(response.body, equals('get response'));
       expect(response.statusCode, equals(200));
@@ -532,12 +533,16 @@ void main() {
       );
 
       expect(
-        Request.uri('GET', Uri(scheme: 'https', host: 'bar'), 'foo').url.toString(),
+        Request.uri('GET', Uri(scheme: 'https', host: 'bar'), 'foo')
+            .url
+            .toString(),
         equals('https://bar/'),
       );
 
       expect(
-        Request.uri('GET', Uri(scheme: 'https', host: 'bar', port: 666), 'foo').url.toString(),
+        Request.uri('GET', Uri(scheme: 'https', host: 'bar', port: 666), 'foo')
+            .url
+            .toString(),
         equals('https://bar:666/'),
       );
     });
@@ -934,7 +939,9 @@ void main() {
     expect(
       () async {
         try {
-          await service.getTest('1234', dynamicHeader: '').timeout(const Duration(seconds: 3));
+          await service
+              .getTest('1234', dynamicHeader: '')
+              .timeout(const Duration(seconds: 3));
         } finally {
           httpClient.close();
         }
@@ -1095,7 +1102,8 @@ void main() {
     final chopper = buildClient(httpClient);
     final service = chopper.getService<HttpTestService>();
 
-    final response = await service.getUsingMapQueryParamWithBrackets(<String, dynamic>{
+    final response =
+        await service.getUsingMapQueryParamWithBrackets(<String, dynamic>{
       'bar': 'baz',
       'zap': 'abc',
       'etc': <String, dynamic>{
@@ -1178,7 +1186,8 @@ void main() {
     final chopper = buildClient(httpClient);
     final service = chopper.getService<HttpTestService>();
 
-    final response = await service.getUsingMapQueryParamIncludeNullQueryVars(<String, dynamic>{
+    final response = await service
+        .getUsingMapQueryParamIncludeNullQueryVars(<String, dynamic>{
       'bar': 'baz',
       'zap': null,
       'etc': <String, dynamic>{

--- a/chopper/test/client_test.dart
+++ b/chopper/test/client_test.dart
@@ -33,9 +33,11 @@ void main() {
 
       final chopper = buildClient(httpClient);
       final response = await chopper.get(
-        '/test/get',
+        Uri(
+          path: '/test/get',
+          queryParameters: {'key': 'val'},
+        ),
         headers: {'int': '42'},
-        parameters: {'key': 'val'},
       );
 
       expect(response.body, equals('get response'));
@@ -59,10 +61,12 @@ void main() {
 
       final chopper = buildClient(httpClient);
       final response = await chopper.post(
-        '/test/post',
+        Uri(
+          path: '/test/post',
+          queryParameters: {'key': 'val'},
+        ),
         headers: {'int': '42'},
         body: {'content': 'body'},
-        parameters: {'key': 'val'},
       );
 
       expect(response.body, equals('post response'));
@@ -87,10 +91,12 @@ void main() {
 
       final chopper = buildClient(httpClient);
       final response = await chopper.put(
-        '/test/put',
+        Uri(
+          path: '/test/put',
+          queryParameters: {'key': 'val'},
+        ),
         headers: {'int': '42'},
         body: {'content': 'body'},
-        parameters: {'key': 'val'},
       );
 
       expect(response.body, equals('put response'));
@@ -115,10 +121,12 @@ void main() {
 
       final chopper = buildClient(httpClient);
       final response = await chopper.patch(
-        '/test/patch',
+        Uri(
+          path: '/test/patch',
+          queryParameters: {'key': 'val'},
+        ),
         headers: {'int': '42'},
         body: {'content': 'body'},
-        parameters: {'key': 'val'},
       );
 
       expect(response.body, equals('patch response'));
@@ -142,9 +150,11 @@ void main() {
 
       final chopper = buildClient(httpClient);
       final response = await chopper.delete(
-        '/test/delete',
+        Uri(
+          path: '/test/delete',
+          queryParameters: {'key': 'val'},
+        ),
         headers: {'int': '42'},
-        parameters: {'key': 'val'},
       );
 
       expect(response.body, equals('delete response'));
@@ -167,9 +177,11 @@ void main() {
 
       final chopper = buildClient(httpClient);
       final response = await chopper.options(
-        '/test/get',
+        Uri(
+          path: '/test/get',
+          queryParameters: {'key': 'val'},
+        ),
         headers: {'int': '42'},
-        parameters: {'key': 'val'},
       );
 
       expect(response.body, equals('get response'));

--- a/chopper/test/client_test.dart
+++ b/chopper/test/client_test.dart
@@ -5,7 +5,7 @@ import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:test/test.dart';
 
-const baseUrl = 'http://localhost:8000';
+final baseUrl = Uri.parse('http://localhost:8000');
 
 void main() {
   ChopperClient buildClient([http.Client? httpClient]) => ChopperClient(

--- a/chopper/test/converter_test.dart
+++ b/chopper/test/converter_test.dart
@@ -34,8 +34,12 @@ void main() {
       final converter = TestConverter();
 
       final encoded = converter.convertRequest(
-        Request('GET', Uri.parse('/'), baseUrl,
-            body: _Converted<String>('foo')),
+        Request(
+          'GET',
+          Uri.parse('/'),
+          baseUrl,
+          body: _Converted<String>('foo'),
+        ),
       );
 
       expect(encoded.body is String, isTrue);

--- a/chopper/test/converter_test.dart
+++ b/chopper/test/converter_test.dart
@@ -34,7 +34,8 @@ void main() {
       final converter = TestConverter();
 
       final encoded = converter.convertRequest(
-        Request('GET', Uri.parse('/'), baseUrl, body: _Converted<String>('foo')),
+        Request('GET', Uri.parse('/'), baseUrl,
+            body: _Converted<String>('foo')),
       );
 
       expect(encoded.body is String, isTrue);

--- a/chopper/test/converter_test.dart
+++ b/chopper/test/converter_test.dart
@@ -7,7 +7,7 @@ import 'package:test/test.dart';
 
 import 'test_service.dart';
 
-const baseUrl = 'http://localhost:8000';
+final baseUrl = Uri.parse('http://localhost:8000');
 
 void main() {
   group('Converter', () {
@@ -34,7 +34,7 @@ void main() {
       final converter = TestConverter();
 
       final encoded = converter.convertRequest(
-        Request('GET', '/', baseUrl, body: _Converted<String>('foo')),
+        Request('GET', Uri.parse('/'), baseUrl, body: _Converted<String>('foo')),
       );
 
       expect(encoded.body is String, isTrue);

--- a/chopper/test/interceptors_test.dart
+++ b/chopper/test/interceptors_test.dart
@@ -48,7 +48,7 @@ void main() {
       final chopper = ChopperClient(
         interceptors: [
           (Request request) => request.copyWith(
-                url: request.url.replace(path: '${request.url.path}/intercept'),
+                uri: request.uri.replace(path: '${request.uri.path}/intercept'),
               ),
         ],
         services: [
@@ -272,7 +272,7 @@ class ResponseIntercept implements ResponseInterceptor {
 class RequestIntercept implements RequestInterceptor {
   @override
   FutureOr<Request> onRequest(Request request) => request.copyWith(
-        url: request.url.replace(path: '${request.url}/intercept'),
+        uri: request.uri.replace(path: '${request.uri}/intercept'),
       );
 }
 

--- a/chopper/test/interceptors_test.dart
+++ b/chopper/test/interceptors_test.dart
@@ -47,8 +47,10 @@ void main() {
     test('RequestInterceptorFunc', () async {
       final chopper = ChopperClient(
         interceptors: [
-          (Request request) =>
-              request.copyWith(path: '${request.url}/intercept'),
+          (Request request) => request.copyWith(
+                url: request.url
+                    .replace(path: '${request.url.path}/intercept'),
+              ),
         ],
         services: [
           HttpTestService.create(),
@@ -184,8 +186,8 @@ void main() {
 
     final fakeRequest = Request(
       'POST',
-      '/',
-      'base',
+      Uri.parse('/'),
+      Uri.parse('base'),
       body: 'test',
       headers: {'foo': 'bar'},
     );
@@ -270,8 +272,9 @@ class ResponseIntercept implements ResponseInterceptor {
 
 class RequestIntercept implements RequestInterceptor {
   @override
-  FutureOr<Request> onRequest(Request request) =>
-      request.copyWith(path: '${request.url}/intercept');
+  FutureOr<Request> onRequest(Request request) => request.copyWith(
+        url: request.url.replace(path: '${request.url}/intercept'),
+      );
 }
 
 class _Intercepted<BodyType> {

--- a/chopper/test/interceptors_test.dart
+++ b/chopper/test/interceptors_test.dart
@@ -48,8 +48,7 @@ void main() {
       final chopper = ChopperClient(
         interceptors: [
           (Request request) => request.copyWith(
-                url: request.url
-                    .replace(path: '${request.url.path}/intercept'),
+                url: request.url.replace(path: '${request.url.path}/intercept'),
               ),
         ],
         services: [

--- a/chopper/test/multipart_test.dart
+++ b/chopper/test/multipart_test.dart
@@ -203,10 +203,10 @@ void main() {
   });
 
   test('PartValue', () async {
-    final req = await Request.uri(
+    final req = await Request(
       HttpMethod.Post,
       Uri.parse('https://foo/'),
-      '',
+      Uri.parse(''),
       parts: [
         PartValue<String>('foo', 'bar'),
         PartValue<int>('int', 42),
@@ -220,10 +220,10 @@ void main() {
   test(
     'PartFile',
     () async {
-      final req = await Request.uri(
+      final req = await Request(
         HttpMethod.Post,
         Uri.parse('https://foo/'),
-        '',
+        Uri.parse(''),
         parts: [
           PartValueFile<String>('foo', 'test/multipart_test.dart'),
           PartValueFile<List<int>>('int', [1, 2]),
@@ -259,10 +259,10 @@ void main() {
   });
 
   test('Multipart request non nullable', () async {
-    final req = await Request.uri(
+    final req = await Request(
       HttpMethod.Post,
       Uri.parse('https://foo/'),
-      '',
+      Uri.parse(''),
       parts: [
         PartValue<int>('int', 42),
         PartValueFile<List<int>>('list int', [1, 2]),
@@ -279,10 +279,10 @@ void main() {
   });
 
   test('PartValue with MultipartFile directly', () async {
-    final req = await Request.uri(
+    final req = await Request(
       HttpMethod.Post,
       Uri.parse('https://foo/'),
-      '',
+      Uri.parse(''),
       parts: [
         PartValue<http.MultipartFile>(
           '',
@@ -318,10 +318,10 @@ void main() {
 
   test('Throw exception', () async {
     expect(
-      () async => await Request.uri(
+      () async => await Request(
         HttpMethod.Post,
         Uri.parse('https://foo/'),
-        '',
+        Uri.parse(''),
         parts: [
           PartValueFile('', 123),
         ],

--- a/chopper/test/multipart_test.dart
+++ b/chopper/test/multipart_test.dart
@@ -206,6 +206,7 @@ void main() {
     final req = await Request.uri(
       HttpMethod.Post,
       Uri.parse('https://foo/'),
+      '',
       parts: [
         PartValue<String>('foo', 'bar'),
         PartValue<int>('int', 42),
@@ -222,6 +223,7 @@ void main() {
       final req = await Request.uri(
         HttpMethod.Post,
         Uri.parse('https://foo/'),
+        '',
         parts: [
           PartValueFile<String>('foo', 'test/multipart_test.dart'),
           PartValueFile<List<int>>('int', [1, 2]),
@@ -260,6 +262,7 @@ void main() {
     final req = await Request.uri(
       HttpMethod.Post,
       Uri.parse('https://foo/'),
+      '',
       parts: [
         PartValue<int>('int', 42),
         PartValueFile<List<int>>('list int', [1, 2]),
@@ -279,6 +282,7 @@ void main() {
     final req = await Request.uri(
       HttpMethod.Post,
       Uri.parse('https://foo/'),
+      '',
       parts: [
         PartValue<http.MultipartFile>(
           '',
@@ -317,6 +321,7 @@ void main() {
       () async => await Request.uri(
         HttpMethod.Post,
         Uri.parse('https://foo/'),
+        '',
         parts: [
           PartValueFile('', 123),
         ],

--- a/chopper/test/request_test.dart
+++ b/chopper/test/request_test.dart
@@ -9,34 +9,36 @@ void main() {
   group('Request', () {
     test('constructor produces a BaseRequest', () {
       expect(
-        Request('GET', '/bar', 'https://foo/'),
+        Request('GET', Uri.parse('/bar'), Uri.parse('https://foo/')),
         isA<http.BaseRequest>(),
       );
     });
 
     test('method gets preserved in BaseRequest', () {
       expect(
-        Request('GET', '/bar', 'https://foo/').method,
+        Request('GET', Uri.parse('/bar'), Uri.parse('https://foo/')).method,
         equals('GET'),
       );
     });
 
     test('url is correctly parsed and set in BaseRequest', () {
       expect(
-        Request('GET', '/bar', 'https://foo/').url,
+        Request('GET', Uri.parse('/bar'), Uri.parse('https://foo/')).url,
         equals(Uri.parse('https://foo/bar')),
       );
 
       expect(
-        Request('GET', '/bar?lorem=ipsum&dolor=123', 'https://foo/').url,
+        Request('GET', Uri.parse('/bar?lorem=ipsum&dolor=123'),
+                Uri.parse('https://foo/'),)
+            .url,
         equals(Uri.parse('https://foo/bar?lorem=ipsum&dolor=123')),
       );
 
       expect(
         Request(
           'GET',
-          '/bar',
-          'https://foo/',
+          Uri.parse('/bar'),
+          Uri.parse('https://foo/'),
           parameters: {
             'lorem': 'ipsum',
             'dolor': 123,
@@ -48,8 +50,8 @@ void main() {
       expect(
         Request(
           'GET',
-          '/bar?first=sit&second=amet&first_list=a&first_list=b',
-          'https://foo/',
+          Uri.parse('/bar?first=sit&second=amet&first_list=a&first_list=b'),
+          Uri.parse('https://foo/'),
           parameters: {
             'lorem': 'ipsum',
             'dolor': 123,
@@ -70,8 +72,8 @@ void main() {
 
       final Request request = Request(
         'GET',
-        '/bar',
-        'https://foo/',
+        Uri.parse('/bar'),
+        Uri.parse('https://foo/'),
         headers: headers,
       );
 
@@ -83,47 +85,48 @@ void main() {
 
     test('copyWith creates a BaseRequest', () {
       expect(
-        Request('GET', '/bar', 'https://foo/').copyWith(method: HttpMethod.Put),
+        Request('GET', Uri.parse('/bar'), Uri.parse('https://foo/'))
+            .copyWith(method: HttpMethod.Put),
         isA<http.BaseRequest>(),
       );
     });
   });
 
-  group('Request.uri', () {
+  group('Request', () {
     test('constructor produces a BaseRequest', () {
       expect(
-        Request.uri('GET', Uri.parse('https://foo/bar'), ''),
+        Request('GET', Uri.parse('https://foo/bar'), Uri.parse('')),
         isA<http.BaseRequest>(),
       );
     });
 
     test('method gets preserved in BaseRequest', () {
       expect(
-        Request.uri('GET', Uri.parse('https://foo/bar'), '').method,
+        Request('GET', Uri.parse('https://foo/bar'), Uri.parse('')).method,
         equals('GET'),
       );
     });
 
     test('url is correctly parsed and set in BaseRequest', () {
       expect(
-        Request.uri('GET', Uri.parse('https://foo/bar'), '').url,
+        Request('GET', Uri.parse('https://foo/bar'), Uri.parse('')).url,
         equals(Uri.parse('https://foo/bar')),
       );
 
       expect(
-        Request.uri(
+        Request(
           'GET',
           Uri.parse('https://foo/bar?lorem=ipsum&dolor=123'),
-          '',
+          Uri.parse(''),
         ).url,
         equals(Uri.parse('https://foo/bar?lorem=ipsum&dolor=123')),
       );
 
       expect(
-        Request.uri(
+        Request(
           'GET',
           Uri.parse('https://foo/bar'),
-          '',
+          Uri.parse(''),
           parameters: {
             'lorem': 'ipsum',
             'dolor': 123,
@@ -133,12 +136,12 @@ void main() {
       );
 
       expect(
-        Request.uri(
+        Request(
           'GET',
           Uri.parse(
             'https://foo/bar?first=sit&second=amet&first_list=a&first_list=b',
           ),
-          '',
+          Uri.parse(''),
           parameters: {
             'lorem': 'ipsum',
             'dolor': 123,
@@ -151,12 +154,12 @@ void main() {
       );
 
       expect(
-        Request.uri(
+        Request(
           'GET',
           Uri.parse(
             'https://chopper.dev/test3',
           ),
-          '',
+          Uri.parse(''),
           parameters: {
             'foo': 'bar',
             'foo_list': [
@@ -188,10 +191,10 @@ void main() {
         'accept': 'application/json; charset=utf-8',
       };
 
-      final Request request = Request.uri(
+      final Request request = Request(
         'GET',
         Uri.parse('https://foo/bar'),
-        '',
+        Uri.parse(''),
         headers: headers,
       );
 
@@ -203,7 +206,7 @@ void main() {
 
     test('copyWith creates a BaseRequest', () {
       expect(
-        Request.uri('GET', Uri.parse('https://foo/bar'), '')
+        Request('GET', Uri.parse('https://foo/bar'), Uri.parse(''))
             .copyWith(method: HttpMethod.Put),
         isA<http.BaseRequest>(),
       );

--- a/chopper/test/request_test.dart
+++ b/chopper/test/request_test.dart
@@ -1,9 +1,9 @@
 // ignore_for_file: long-method
 
 import 'package:chopper/chopper.dart';
-import 'package:test/test.dart';
-import 'package:http/http.dart' as http;
 import 'package:collection/collection.dart';
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
 
 void main() {
   group('Request', () {
@@ -92,38 +92,37 @@ void main() {
   group('Request.uri', () {
     test('constructor produces a BaseRequest', () {
       expect(
-        Request.uri('GET', Uri.parse('https://foo/bar')),
+        Request.uri('GET', Uri.parse('https://foo/bar'), ''),
         isA<http.BaseRequest>(),
       );
     });
 
     test('method gets preserved in BaseRequest', () {
       expect(
-        Request.uri('GET', Uri.parse('https://foo/bar')).method,
+        Request.uri('GET', Uri.parse('https://foo/bar'), '').method,
         equals('GET'),
       );
     });
 
     test('url is correctly parsed and set in BaseRequest', () {
       expect(
-        Request.uri('GET', Uri.parse('https://foo/bar')).url,
+        Request.uri('GET', Uri.parse('https://foo/bar'), '').url,
         equals(Uri.parse('https://foo/bar')),
       );
 
       expect(
-        Request.uri('GET', Uri.parse('https://foo/bar?lorem=ipsum&dolor=123'))
-            .url,
+        Request.uri('GET', Uri.parse('https://foo/bar?lorem=ipsum&dolor=123'), '').url,
         equals(Uri.parse('https://foo/bar?lorem=ipsum&dolor=123')),
       );
 
       expect(
         Request.uri(
           'GET',
-          Uri.parse('https://foo/bar'),
-          parameters: {
+          Uri(scheme: 'https', host: 'foo', path: 'bar', queryParameters: {
             'lorem': 'ipsum',
-            'dolor': 123,
-          },
+            'dolor': '123',
+          }),
+          '',
         ).url,
         equals(Uri.parse('https://foo/bar?lorem=ipsum&dolor=123')),
       );
@@ -131,14 +130,15 @@ void main() {
       expect(
         Request.uri(
           'GET',
-          Uri.parse(
-            'https://foo/bar?first=sit&second=amet&first_list=a&first_list=b',
-          ),
-          parameters: {
+          Uri(scheme: 'https', host: 'foo', path: 'bar', queryParameters: {
+            'first': 'sit',
+            'second': 'amet',
+            'first_list': ['a', 'b'],
             'lorem': 'ipsum',
-            'dolor': 123,
+            'dolor': '123',
             'second_list': ['a', 'b'],
-          },
+          }),
+          '',
         ).url,
         equals(Uri.parse(
           'https://foo/bar?first=sit&second=amet&first_list=a&first_list=b&lorem=ipsum&dolor=123&second_list=a&second_list=b',
@@ -155,6 +155,7 @@ void main() {
       final Request request = Request.uri(
         'GET',
         Uri.parse('https://foo/bar'),
+        '',
         headers: headers,
       );
 
@@ -166,8 +167,7 @@ void main() {
 
     test('copyWith creates a BaseRequest', () {
       expect(
-        Request.uri('GET', Uri.parse('https://foo/bar'))
-            .copyWith(method: HttpMethod.Put),
+        Request.uri('GET', Uri.parse('https://foo/bar'), '').copyWith(method: HttpMethod.Put),
         isA<http.BaseRequest>(),
       );
     });

--- a/chopper/test/request_test.dart
+++ b/chopper/test/request_test.dart
@@ -214,4 +214,61 @@ void main() {
       );
     });
   });
+
+  test('request baseUri cannot contain query parameters', () {
+    expect(
+      () => Request(
+        'GET',
+        Uri.parse('foo'),
+        Uri.http(
+          'foo',
+          'bar',
+          {
+            'first': '123',
+            'second': '456',
+          },
+        ),
+      ),
+      throwsA(
+        TypeMatcher<AssertionError>(),
+      ),
+    );
+
+    expect(
+      () => Request(
+        'GET',
+        Uri.parse('foo'),
+        Uri.parse('foo/bar?first=123'),
+      ),
+      throwsA(
+        TypeMatcher<AssertionError>(),
+      ),
+    );
+
+    expect(
+      () => Request(
+        'GET',
+        Uri.parse('foo'),
+        Uri(
+          queryParameters: {
+            'first': '123',
+            'second': '456',
+          },
+        ),
+      ),
+      throwsA(
+        TypeMatcher<AssertionError>(),
+      ),
+    );
+    expect(
+      () => Request(
+        'GET',
+        Uri.parse('foo'),
+        Uri(query: 'first=123&second=456'),
+      ),
+      throwsA(
+        TypeMatcher<AssertionError>(),
+      ),
+    );
+  });
 }

--- a/chopper/test/request_test.dart
+++ b/chopper/test/request_test.dart
@@ -28,9 +28,11 @@ void main() {
       );
 
       expect(
-        Request('GET', Uri.parse('/bar?lorem=ipsum&dolor=123'),
-                Uri.parse('https://foo/'),)
-            .url,
+        Request(
+          'GET',
+          Uri.parse('/bar?lorem=ipsum&dolor=123'),
+          Uri.parse('https://foo/'),
+        ).url,
         equals(Uri.parse('https://foo/bar?lorem=ipsum&dolor=123')),
       );
 

--- a/chopper/test/request_test.dart
+++ b/chopper/test/request_test.dart
@@ -112,8 +112,10 @@ void main() {
 
       expect(
         Request.uri(
-                'GET', Uri.parse('https://foo/bar?lorem=ipsum&dolor=123'), '')
-            .url,
+          'GET',
+          Uri.parse('https://foo/bar?lorem=ipsum&dolor=123'),
+          '',
+        ).url,
         equals(Uri.parse('https://foo/bar?lorem=ipsum&dolor=123')),
       );
 
@@ -146,6 +148,37 @@ void main() {
         equals(Uri.parse(
           'https://foo/bar?first=sit&second=amet&first_list=a&first_list=b&lorem=ipsum&dolor=123&second_list=a&second_list=b',
         )),
+      );
+
+      expect(
+        Request.uri(
+          'GET',
+          Uri.parse(
+            'https://chopper.dev/test3',
+          ),
+          '',
+          parameters: {
+            'foo': 'bar',
+            'foo_list': [
+              'one',
+              'two',
+              'three',
+            ],
+            'user': {
+              'name': 'john',
+              'surname': 'doe',
+            },
+          },
+        ).url.toString(),
+        equals(
+          'https://chopper.dev/test3'
+          '?foo=bar'
+          '&foo_list=one'
+          '&foo_list=two'
+          '&foo_list=three'
+          '&user.name=john'
+          '&user.surname=doe',
+        ),
       );
     });
 

--- a/chopper/test/request_test.dart
+++ b/chopper/test/request_test.dart
@@ -111,7 +111,9 @@ void main() {
       );
 
       expect(
-        Request.uri('GET', Uri.parse('https://foo/bar?lorem=ipsum&dolor=123'), '').url,
+        Request.uri(
+                'GET', Uri.parse('https://foo/bar?lorem=ipsum&dolor=123'), '')
+            .url,
         equals(Uri.parse('https://foo/bar?lorem=ipsum&dolor=123')),
       );
 
@@ -167,7 +169,8 @@ void main() {
 
     test('copyWith creates a BaseRequest', () {
       expect(
-        Request.uri('GET', Uri.parse('https://foo/bar'), '').copyWith(method: HttpMethod.Put),
+        Request.uri('GET', Uri.parse('https://foo/bar'), '')
+            .copyWith(method: HttpMethod.Put),
         isA<http.BaseRequest>(),
       );
     });

--- a/chopper/test/request_test.dart
+++ b/chopper/test/request_test.dart
@@ -120,11 +120,12 @@ void main() {
       expect(
         Request.uri(
           'GET',
-          Uri(scheme: 'https', host: 'foo', path: 'bar', queryParameters: {
-            'lorem': 'ipsum',
-            'dolor': '123',
-          }),
+          Uri.parse('https://foo/bar'),
           '',
+          parameters: {
+            'lorem': 'ipsum',
+            'dolor': 123,
+          },
         ).url,
         equals(Uri.parse('https://foo/bar?lorem=ipsum&dolor=123')),
       );
@@ -132,15 +133,15 @@ void main() {
       expect(
         Request.uri(
           'GET',
-          Uri(scheme: 'https', host: 'foo', path: 'bar', queryParameters: {
-            'first': 'sit',
-            'second': 'amet',
-            'first_list': ['a', 'b'],
-            'lorem': 'ipsum',
-            'dolor': '123',
-            'second_list': ['a', 'b'],
-          }),
+          Uri.parse(
+            'https://foo/bar?first=sit&second=amet&first_list=a&first_list=b',
+          ),
           '',
+          parameters: {
+            'lorem': 'ipsum',
+            'dolor': 123,
+            'second_list': ['a', 'b'],
+          },
         ).url,
         equals(Uri.parse(
           'https://foo/bar?first=sit&second=amet&first_list=a&first_list=b&lorem=ipsum&dolor=123&second_list=a&second_list=b',

--- a/chopper/test/test_service.chopper.dart
+++ b/chopper/test/test_service.chopper.dart
@@ -21,7 +21,7 @@ class _$HttpTestService extends HttpTestService {
     String id, {
     required String dynamicHeader,
   }) {
-    final String $url = '/test/get/${id}';
+    final Uri $url = Uri.parse('/test/get/${id}');
     final Map<String, String> $headers = {
       'test': dynamicHeader,
     };
@@ -36,7 +36,7 @@ class _$HttpTestService extends HttpTestService {
 
   @override
   Future<Response<dynamic>> headTest() {
-    final String $url = '/test/head';
+    final Uri $url = Uri.parse('/test/head');
     final Request $request = Request(
       'HEAD',
       $url,
@@ -47,7 +47,7 @@ class _$HttpTestService extends HttpTestService {
 
   @override
   Future<Response<dynamic>> optionsTest() {
-    final String $url = '/test/options';
+    final Uri $url = Uri.parse('/test/options');
     final Request $request = Request(
       'OPTIONS',
       $url,
@@ -58,7 +58,7 @@ class _$HttpTestService extends HttpTestService {
 
   @override
   Future<Response<Stream<List<int>>>> getStreamTest() {
-    final String $url = '/test/get';
+    final Uri $url = Uri.parse('/test/get');
     final Request $request = Request(
       'GET',
       $url,
@@ -69,7 +69,7 @@ class _$HttpTestService extends HttpTestService {
 
   @override
   Future<Response<dynamic>> getAll() {
-    final String $url = '/test';
+    final Uri $url = Uri.parse('/test');
     final Request $request = Request(
       'GET',
       $url,
@@ -80,7 +80,7 @@ class _$HttpTestService extends HttpTestService {
 
   @override
   Future<Response<dynamic>> getAllWithTrailingSlash() {
-    final String $url = '/test/';
+    final Uri $url = Uri.parse('/test/');
     final Request $request = Request(
       'GET',
       $url,
@@ -95,7 +95,7 @@ class _$HttpTestService extends HttpTestService {
     int? number,
     int? def = 42,
   }) {
-    final String $url = '/test/query';
+    final Uri $url = Uri.parse('/test/query');
     final Map<String, dynamic> $params = <String, dynamic>{
       'name': name,
       'int': number,
@@ -112,7 +112,7 @@ class _$HttpTestService extends HttpTestService {
 
   @override
   Future<Response<dynamic>> getQueryMapTest(Map<String, dynamic> query) {
-    final String $url = '/test/query_map';
+    final Uri $url = Uri.parse('/test/query_map');
     final Map<String, dynamic> $params = query;
     final Request $request = Request(
       'GET',
@@ -128,7 +128,7 @@ class _$HttpTestService extends HttpTestService {
     Map<String, dynamic> query, {
     bool? test,
   }) {
-    final String $url = '/test/query_map';
+    final Uri $url = Uri.parse('/test/query_map');
     final Map<String, dynamic> $params = <String, dynamic>{'test': test};
     $params.addAll(query);
     final Request $request = Request(
@@ -146,7 +146,7 @@ class _$HttpTestService extends HttpTestService {
     int? number,
     Map<String, dynamic> filters = const {},
   }) {
-    final String $url = '/test/query_map';
+    final Uri $url = Uri.parse('/test/query_map');
     final Map<String, dynamic> $params = <String, dynamic>{
       'name': name,
       'number': number,
@@ -167,7 +167,7 @@ class _$HttpTestService extends HttpTestService {
     int? number,
     Map<String, dynamic>? filters,
   }) {
-    final String $url = '/test/query_map';
+    final Uri $url = Uri.parse('/test/query_map');
     final Map<String, dynamic> $params = <String, dynamic>{
       'name': name,
       'number': number,
@@ -184,7 +184,7 @@ class _$HttpTestService extends HttpTestService {
 
   @override
   Future<Response<dynamic>> getQueryMapTest5({Map<String, dynamic>? filters}) {
-    final String $url = '/test/query_map';
+    final Uri $url = Uri.parse('/test/query_map');
     final Map<String, dynamic> $params = filters ?? const {};
     final Request $request = Request(
       'GET',
@@ -197,7 +197,7 @@ class _$HttpTestService extends HttpTestService {
 
   @override
   Future<Response<dynamic>> getBody(dynamic body) {
-    final String $url = '/test/get_body';
+    final Uri $url = Uri.parse('/test/get_body');
     final $body = body;
     final Request $request = Request(
       'GET',
@@ -210,7 +210,7 @@ class _$HttpTestService extends HttpTestService {
 
   @override
   Future<Response<dynamic>> postTest(String data) {
-    final String $url = '/test/post';
+    final Uri $url = Uri.parse('/test/post');
     final $body = data;
     final Request $request = Request(
       'POST',
@@ -223,7 +223,7 @@ class _$HttpTestService extends HttpTestService {
 
   @override
   Future<Response<dynamic>> postStreamTest(Stream<List<int>> byteStream) {
-    final String $url = '/test/post';
+    final Uri $url = Uri.parse('/test/post');
     final $body = byteStream;
     final Request $request = Request(
       'POST',
@@ -239,7 +239,7 @@ class _$HttpTestService extends HttpTestService {
     String test,
     String data,
   ) {
-    final String $url = '/test/put/${test}';
+    final Uri $url = Uri.parse('/test/put/${test}');
     final $body = data;
     final Request $request = Request(
       'PUT',
@@ -252,7 +252,7 @@ class _$HttpTestService extends HttpTestService {
 
   @override
   Future<Response<dynamic>> deleteTest(String id) {
-    final String $url = '/test/delete/${id}';
+    final Uri $url = Uri.parse('/test/delete/${id}');
     final Map<String, String> $headers = {
       'foo': 'bar',
     };
@@ -270,7 +270,7 @@ class _$HttpTestService extends HttpTestService {
     String id,
     String data,
   ) {
-    final String $url = '/test/patch/${id}';
+    final Uri $url = Uri.parse('/test/patch/${id}');
     final $body = data;
     final Request $request = Request(
       'PATCH',
@@ -283,7 +283,7 @@ class _$HttpTestService extends HttpTestService {
 
   @override
   Future<Response<dynamic>> mapTest(Map<String, String> map) {
-    final String $url = '/test/map';
+    final Uri $url = Uri.parse('/test/map');
     final $body = map;
     final Request $request = Request(
       'POST',
@@ -296,7 +296,7 @@ class _$HttpTestService extends HttpTestService {
 
   @override
   Future<Response<dynamic>> postForm(Map<String, String> fields) {
-    final String $url = '/test/form/body';
+    final Uri $url = Uri.parse('/test/form/body');
     final $body = fields;
     final Request $request = Request(
       'POST',
@@ -312,7 +312,7 @@ class _$HttpTestService extends HttpTestService {
 
   @override
   Future<Response<dynamic>> postFormUsingHeaders(Map<String, String> fields) {
-    final String $url = '/test/form/body';
+    final Uri $url = Uri.parse('/test/form/body');
     final Map<String, String> $headers = {
       'content-type': 'application/x-www-form-urlencoded',
     };
@@ -332,7 +332,7 @@ class _$HttpTestService extends HttpTestService {
     String foo,
     int bar,
   ) {
-    final String $url = '/test/form/body/fields';
+    final Uri $url = Uri.parse('/test/form/body/fields');
     final $body = <String, dynamic>{
       'foo': foo,
       'bar': bar,
@@ -351,7 +351,7 @@ class _$HttpTestService extends HttpTestService {
 
   @override
   Future<Response<dynamic>> forceJsonTest(Map<dynamic, dynamic> map) {
-    final String $url = '/test/map/json';
+    final Uri $url = Uri.parse('/test/map/json');
     final $body = map;
     final Request $request = Request(
       'POST',
@@ -371,7 +371,7 @@ class _$HttpTestService extends HttpTestService {
     Map<dynamic, dynamic> a,
     Map<dynamic, dynamic> b,
   ) {
-    final String $url = '/test/multi';
+    final Uri $url = Uri.parse('/test/multi');
     final List<PartValue> $parts = <PartValue>[
       PartValue<Map<dynamic, dynamic>>(
         '1',
@@ -394,7 +394,7 @@ class _$HttpTestService extends HttpTestService {
 
   @override
   Future<Response<dynamic>> postFile(List<int> bytes) {
-    final String $url = '/test/file';
+    final Uri $url = Uri.parse('/test/file');
     final List<PartValue> $parts = <PartValue>[
       PartValueFile<List<int>>(
         'file',
@@ -416,7 +416,7 @@ class _$HttpTestService extends HttpTestService {
     MultipartFile file, {
     String? id,
   }) {
-    final String $url = '/test/file';
+    final Uri $url = Uri.parse('/test/file');
     final List<PartValue> $parts = <PartValue>[
       PartValue<String?>(
         'id',
@@ -439,7 +439,7 @@ class _$HttpTestService extends HttpTestService {
 
   @override
   Future<Response<dynamic>> postListFiles(List<MultipartFile> files) {
-    final String $url = '/test/files';
+    final Uri $url = Uri.parse('/test/files');
     final List<PartValue> $parts = <PartValue>[
       PartValueFile<List<MultipartFile>>(
         'files',
@@ -458,7 +458,7 @@ class _$HttpTestService extends HttpTestService {
 
   @override
   Future<dynamic> fullUrl() {
-    final String $url = 'https://test.com';
+    final Uri $url = Uri.parse('https://test.com');
     final Request $request = Request(
       'GET',
       $url,
@@ -469,7 +469,7 @@ class _$HttpTestService extends HttpTestService {
 
   @override
   Future<Response<List<String>>> listString() {
-    final String $url = '/test/list/string';
+    final Uri $url = Uri.parse('/test/list/string');
     final Request $request = Request(
       'GET',
       $url,
@@ -480,7 +480,7 @@ class _$HttpTestService extends HttpTestService {
 
   @override
   Future<Response<dynamic>> noBody() {
-    final String $url = '/test/no-body';
+    final Uri $url = Uri.parse('/test/no-body');
     final Request $request = Request(
       'POST',
       $url,
@@ -495,7 +495,7 @@ class _$HttpTestService extends HttpTestService {
     String? bar,
     String? baz,
   }) {
-    final String $url = '/test/query_param_include_null_query_vars';
+    final Uri $url = Uri.parse('/test/query_param_include_null_query_vars');
     final Map<String, dynamic> $params = <String, dynamic>{
       'foo': foo,
       'bar': bar,
@@ -513,7 +513,7 @@ class _$HttpTestService extends HttpTestService {
 
   @override
   Future<Response<String>> getUsingListQueryParam(List<String> value) {
-    final String $url = '/test/list_query_param';
+    final Uri $url = Uri.parse('/test/list_query_param');
     final Map<String, dynamic> $params = <String, dynamic>{'value': value};
     final Request $request = Request(
       'GET',
@@ -527,7 +527,7 @@ class _$HttpTestService extends HttpTestService {
   @override
   Future<Response<String>> getUsingListQueryParamWithBrackets(
       List<String> value) {
-    final String $url = '/test/list_query_param_with_brackets';
+    final Uri $url = Uri.parse('/test/list_query_param_with_brackets');
     final Map<String, dynamic> $params = <String, dynamic>{'value': value};
     final Request $request = Request(
       'GET',
@@ -541,7 +541,7 @@ class _$HttpTestService extends HttpTestService {
 
   @override
   Future<Response<String>> getUsingMapQueryParam(Map<String, dynamic> value) {
-    final String $url = '/test/map_query_param';
+    final Uri $url = Uri.parse('/test/map_query_param');
     final Map<String, dynamic> $params = <String, dynamic>{'value': value};
     final Request $request = Request(
       'GET',
@@ -555,7 +555,7 @@ class _$HttpTestService extends HttpTestService {
   @override
   Future<Response<String>> getUsingMapQueryParamIncludeNullQueryVars(
       Map<String, dynamic> value) {
-    final String $url = '/test/map_query_param_include_null_query_vars';
+    final Uri $url = Uri.parse('/test/map_query_param_include_null_query_vars');
     final Map<String, dynamic> $params = <String, dynamic>{'value': value};
     final Request $request = Request(
       'GET',
@@ -570,7 +570,7 @@ class _$HttpTestService extends HttpTestService {
   @override
   Future<Response<String>> getUsingMapQueryParamWithBrackets(
       Map<String, dynamic> value) {
-    final String $url = '/test/map_query_param_with_brackets';
+    final Uri $url = Uri.parse('/test/map_query_param_with_brackets');
     final Map<String, dynamic> $params = <String, dynamic>{'value': value};
     final Request $request = Request(
       'GET',

--- a/chopper_built_value/test/converter_test.dart
+++ b/chopper_built_value/test/converter_test.dart
@@ -29,6 +29,7 @@ void main() {
       var request = Request.uri(
         HttpMethod.Post,
         Uri.parse('https://foo/'),
+        '',
         body: data,
       );
       request = converter.convertRequest(request);
@@ -72,6 +73,7 @@ void main() {
       var request = Request.uri(
         HttpMethod.Get,
         Uri.parse('https://foo/'),
+        '',
         body: data,
       );
       request = converter.convertRequest(request);

--- a/chopper_built_value/test/converter_test.dart
+++ b/chopper_built_value/test/converter_test.dart
@@ -26,10 +26,10 @@ void main() {
 
   group('BuiltValueConverter', () {
     test('convert request', () {
-      var request = Request.uri(
+      var request = Request(
         HttpMethod.Post,
         Uri.parse('https://foo/'),
-        '',
+        Uri.parse(''),
         body: data,
       );
       request = converter.convertRequest(request);
@@ -70,10 +70,10 @@ void main() {
     });
 
     test('has json headers', () {
-      var request = Request.uri(
+      var request = Request(
         HttpMethod.Get,
         Uri.parse('https://foo/'),
-        '',
+        Uri.parse(''),
         body: data,
       );
       request = converter.convertRequest(request);

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -174,7 +174,7 @@ class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
       );
 
       final List<Code> blocks = [
-        declareFinal(_urlVar, type: refer('String')).assign(url).statement,
+        declareFinal(_urlVar, type: refer('Uri')).assign(url).statement,
       ];
 
       if (queries.isNotEmpty) {
@@ -475,20 +475,25 @@ class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
     if (path.startsWith('http://') || path.startsWith('https://')) {
       // if the request's url is already a fully qualified URL, we can use
       // as-is and ignore the baseUrl
-      return literal(path);
+      return _generateUri(path);
     } else if (path.isEmpty && baseUrl.isEmpty) {
-      return literal('');
+      return _generateUri('');
     } else {
       if (path.isNotEmpty &&
           baseUrl.isNotEmpty &&
           !baseUrl.endsWith('/') &&
           !path.startsWith('/')) {
-        return literal('$baseUrl/$path');
+        return _generateUri('$baseUrl/$path');
       }
 
-      return literal('$baseUrl$path');
+      return _generateUri('$baseUrl$path');
     }
   }
+
+  Expression _generateUri(String url) => refer('Uri').newInstanceNamed(
+        'parse',
+        [literal(url)],
+      );
 
   Expression _generateRequest(
     ConstantReader method, {
@@ -571,7 +576,9 @@ class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
       ];
 
       list.add(
-        refer('PartValueFile<${p.type.getDisplayString(withNullability: p.type.isNullable)}>')
+        refer('PartValueFile<${p.type.getDisplayString(
+          withNullability: p.type.isNullable,
+        )}>')
             .newInstance(params),
       );
     });

--- a/example/bin/main_built_value.dart
+++ b/example/bin/main_built_value.dart
@@ -27,7 +27,7 @@ final client = MockClient((req) async {
 main() async {
   final chopper = ChopperClient(
     client: client,
-    baseUrl: 'http://localhost:8000',
+    baseUrl: Uri.parse('http://localhost:8000'),
     converter: BuiltValueConverter(),
     errorConverter: BuiltValueConverter(),
     services: [

--- a/example/bin/main_json_serializable.dart
+++ b/example/bin/main_json_serializable.dart
@@ -24,7 +24,7 @@ main() async {
 
   final chopper = ChopperClient(
     client: client,
-    baseUrl: 'http://localhost:8000',
+    baseUrl: Uri.parse('http://localhost:8000'),
     // bind your object factories here
     converter: converter,
     errorConverter: converter,

--- a/example/bin/main_json_serializable_squadron_worker_pool.dart
+++ b/example/bin/main_json_serializable_squadron_worker_pool.dart
@@ -126,7 +126,7 @@ Future<void> main() async {
 
   final chopper = ChopperClient(
     client: client,
-    baseUrl: 'http://localhost:8000',
+    baseUrl: Uri.parse('http://localhost:8000'),
     // bind your object factories here
     converter: converter,
     errorConverter: converter,

--- a/example/lib/built_value_resource.chopper.dart
+++ b/example/lib/built_value_resource.chopper.dart
@@ -18,7 +18,7 @@ class _$MyService extends MyService {
 
   @override
   Future<Response<dynamic>> getResource(String id) {
-    final String $url = '/resources/${id}/';
+    final Uri $url = Uri.parse('/resources/${id}/');
     final Request $request = Request(
       'GET',
       $url,
@@ -29,7 +29,7 @@ class _$MyService extends MyService {
 
   @override
   Future<Response<BuiltList<Resource>>> getBuiltListResources() {
-    final String $url = '/resources/list';
+    final Uri $url = Uri.parse('/resources/list');
     final Request $request = Request(
       'GET',
       $url,
@@ -40,7 +40,7 @@ class _$MyService extends MyService {
 
   @override
   Future<Response<Resource>> getTypedResource() {
-    final String $url = '/resources/';
+    final Uri $url = Uri.parse('/resources/');
     final Map<String, String> $headers = {
       'foo': 'bar',
     };
@@ -58,7 +58,7 @@ class _$MyService extends MyService {
     Resource resource, {
     String? name,
   }) {
-    final String $url = '/resources';
+    final Uri $url = Uri.parse('/resources');
     final Map<String, String> $headers = {
       if (name != null) 'name': name,
     };

--- a/example/lib/json_serializable.chopper.dart
+++ b/example/lib/json_serializable.chopper.dart
@@ -18,7 +18,7 @@ class _$MyService extends MyService {
 
   @override
   Future<Response<dynamic>> getResource(String id) {
-    final String $url = '/resources/${id}/';
+    final Uri $url = Uri.parse('/resources/${id}/');
     final Request $request = Request(
       'GET',
       $url,
@@ -29,7 +29,7 @@ class _$MyService extends MyService {
 
   @override
   Future<Response<List<Resource>>> getResources() {
-    final String $url = '/resources/all';
+    final Uri $url = Uri.parse('/resources/all');
     final Map<String, String> $headers = {
       'test': 'list',
     };
@@ -44,7 +44,7 @@ class _$MyService extends MyService {
 
   @override
   Future<Response<Map<dynamic, dynamic>>> getMapResource(String id) {
-    final String $url = '/resources/';
+    final Uri $url = Uri.parse('/resources/');
     final Map<String, dynamic> $params = <String, dynamic>{'id': id};
     final Request $request = Request(
       'GET',
@@ -57,7 +57,7 @@ class _$MyService extends MyService {
 
   @override
   Future<Response<Resource>> getTypedResource() {
-    final String $url = '/resources/';
+    final Uri $url = Uri.parse('/resources/');
     final Map<String, String> $headers = {
       'foo': 'bar',
     };
@@ -75,7 +75,7 @@ class _$MyService extends MyService {
     Resource resource, {
     String? name,
   }) {
-    final String $url = '/resources';
+    final Uri $url = Uri.parse('/resources');
     final Map<String, String> $headers = {
       if (name != null) 'name': name,
     };

--- a/faq.md
+++ b/faq.md
@@ -109,7 +109,7 @@ abstract class ApiService extends ChopperService {
         }
         return http.Response(json.encode(result), 200);
       }),
-      baseUrl: 'https://mysite.com/api',
+      baseUrl: Uri.parse('https://mysite.com/api'),
       services: [
         _$ApiService(),
       ],
@@ -332,7 +332,7 @@ Future<void> main() async {
   /// Instantiate a ChopperClient
   final chopper = ChopperClient(
     client: client,
-    baseUrl: 'http://localhost:8000',
+    baseUrl: Uri.parse('http://localhost:8000'),
     // bind your object factories here
     converter: converter,
     errorConverter: converter,

--- a/faq.md
+++ b/faq.md
@@ -2,17 +2,20 @@
 
 ## \*.chopper.dart not found ?
 
-If you have this error, you probably forgot to run the `build` package. To do that, simply run the following command in your shell.
+If you have this error, you probably forgot to run the `build` package. To do that, simply run the
+following command in your shell.
 
 `pub run build_runner build`
 
-It will generate the code that actually do the HTTP request \(YOUR_FILE.chopper.dart\). If you wish to update the code automatically when you change your definition run the `watch` command.
+It will generate the code that actually do the HTTP request \(YOUR_FILE.chopper.dart\). If you wish
+to update the code automatically when you change your definition run the `watch` command.
 
 `pub run build_runner watch`
 
 ## How to increase timeout ?
 
-Connection timeout is very limited for now due to http package \(see: [dart-lang/http\#21](https://github.com/dart-lang/http/issues/21)\)
+Connection timeout is very limited for now due to http package
+\(see: [dart-lang/http\#21](https://github.com/dart-lang/http/issues/21)\)
 
 But if you are on VM or Flutter you can set the `connectionTimeout` you want
 
@@ -21,10 +24,11 @@ import 'package:http/io_client.dart' as http;
 import 'dart:io';
 
 final chopper = ChopperClient(
-    client: http.IOClient(
-      HttpClient()..connectionTimeout = const Duration(seconds: 60),
-    ),
-  );
+  client: http.IOClient(
+    HttpClient()
+      ..connectionTimeout = const Duration(seconds: 60),
+  ),
+);
 ```
 
 ## Add query parameter to all requests
@@ -32,8 +36,9 @@ final chopper = ChopperClient(
 Possible using an interceptor.
 
 ```dart
+
 final chopper = ChopperClient(
-    interceptors: [_addQuery],
+  interceptors: [_addQuery],
 );
 
 Request _addQuery(Request req) {
@@ -46,16 +51,15 @@ Request _addQuery(Request req) {
 
 ## GZip converter example
 
-You can use converters for modifying requests and responses.
-For example, to use GZip for post request you can write something like this:
+You can use converters for modifying requests and responses. For example, to use GZip for post
+request you can write something like this:
 
 ```dart
 Request compressRequest(Request request) {
   request = applyHeader(request, 'Content-Encoding', 'gzip');
   request = request.replace(body: gzip.encode(request.body));
   return request;
-}
-...
+}...
 
 @FactoryConverter(request: compressRequest)
 @Post()
@@ -64,15 +68,20 @@ Future<Response> postRequest(@Body() Map<String, String> data);
 
 ## Runtime baseUrl change
 
-You may need to change the base URL of your network calls during runtime, for example, if you have to use different servers or routes dynamically in your app in case of a "regular" or a "paid" user. You can store the current server base url in your SharedPreferences (encrypt/decrypt it if needed) and use it in an interceptor like this:
+You may need to change the base URL of your network calls during runtime, for example, if you have
+to use different servers or routes dynamically in your app in case of a "regular" or a "paid" user.
+You can store the current server base url in your SharedPreferences (encrypt/decrypt it if needed)
+and use it in an interceptor like this:
 
 ```dart
-...
-(Request request) async =>
-              SharedPreferences.containsKey('baseUrl')
-                  ? request.copyWith(
-                      baseUrl: SharedPreferences.getString('baseUrl'))
-                  : request
+...(Request request) async =>
+SharedPreferences.containsKey('baseUrl')
+? request.copyWith(
+baseUri: Uri.parse(SharedPreferences.getString('baseUrl')
+)
+)
+:
+request
 ...
 ```
 
@@ -133,9 +142,20 @@ import 'dart:io';
 import 'package:http/io_client.dart' as http;
 
 final ioc = new HttpClient();
-ioc.findProxy = (url) => 'PROXY 192.168.0.102:9090';
-ioc.badCertificateCallback = (X509Certificate cert, String host, int port)
-  => true;
+ioc.findProxy = (
+url) =>
+'
+PROXY 192.168.0.102:9090
+';
+ioc.badCertificateCallback = (
+
+X509Certificate cert, String
+host,
+
+int port
+)
+=>
+true;
 
 final chopper = ChopperClient(
   client: http.IOClient(ioc),
@@ -146,35 +166,53 @@ final chopper = ChopperClient(
 
 Basically, the algorithm goes like this (credits to [stewemetal](https://github.com/stewemetal)):
 
-Add the authentication token to the request (by "Authorization" header, for example) -> try the request -> if it fails use the refresh token to get a new auth token ->
-if that succeeds, save the auth token and retry the original request with it
-if the refresh token is not valid anymore, drop the session (and navigate to the login screen, for example)
+Add the authentication token to the request (by "Authorization" header, for example) -> try the
+request -> if it fails use the refresh token to get a new auth token ->
+if that succeeds, save the auth token and retry the original request with it if the refresh token is
+not valid anymore, drop the session (and navigate to the login screen, for example)
 
 Simple code example:
 
 ```dart
 interceptors: [
-  // Auth Interceptor
-  (Request request) async => applyHeader(request, 'authorization',
-      SharedPrefs.localStorage.getString(tokenHeader),
-      override: false),
-  (Response response) async {
-    if (response?.statusCode == 401) {
-      SharedPrefs.localStorage.remove(tokenHeader);
-      // Navigate to some login page or just request new token
-    }
-    return response;
-  },
+// Auth Interceptor
+(
+
+Request request
+)
+async => applyHeader
+(
+request, '
+authorization
+'
+,
+SharedPrefs.localStorage.getString(tokenHeader),
+override: false
+)
+,
+(
+
+Response response
+)
+async {
+if (response?.statusCode == 401) {
+SharedPrefs.localStorage.remove(tokenHeader);
+// Navigate to some login page or just request new token
+}
+return response;
+},
 ]
 ```
 
-The actual implementation of the algorithm above may vary based on how the backend API - more precisely the login and session handling - of your app looks like.
+The actual implementation of the algorithm above may vary based on how the backend API - more
+precisely the login and session handling - of your app looks like.
 
 ## Decoding JSON using Isolates
 
-Sometimes you want to decode JSON outside the main thread in order to reduce janking. In this example we're going to go
-even further and implement a Worker Pool using [Squadron](https://pub.dev/packages/squadron/install) which can 
-dynamically spawn a maximum number of Workers as they become needed.
+Sometimes you want to decode JSON outside the main thread in order to reduce janking. In this
+example we're going to go even further and implement a Worker Pool
+using [Squadron](https://pub.dev/packages/squadron/install) which can dynamically spawn a maximum
+number of Workers as they become needed.
 
 #### Install the dependencies
 
@@ -185,7 +223,8 @@ dynamically spawn a maximum number of Workers as they become needed.
 
 #### Write a JSON decode service
 
-We'll leverage [squadron_builder](https://pub.dev/packages/squadron_builder) and the power of code generation.
+We'll leverage [squadron_builder](https://pub.dev/packages/squadron_builder) and the power of code
+generation.
 
 ```dart
 import 'dart:async';
@@ -209,7 +248,8 @@ Extracted from the [full example here](example/lib/json_decode_service.dart).
 
 #### Write a custom JsonConverter
 
-Using [json_serializable](https://pub.dev/packages/json_serializable) we'll create a [JsonConverter](https://github.com/lejard-h/chopper/blob/master/chopper/lib/src/interceptor.dart#L228) 
+Using [json_serializable](https://pub.dev/packages/json_serializable) we'll create
+a [JsonConverter](https://github.com/lejard-h/chopper/blob/master/chopper/lib/src/interceptor.dart#L228)
 which works with or without a [WorkerPool](https://github.com/d-markey/squadron#features).
 
 ```dart
@@ -226,7 +266,7 @@ class JsonSerializableWorkerPoolConverter extends JsonConverter {
   const JsonSerializableWorkerPoolConverter(this.factories, [this.workerPool]);
 
   final Map<Type, JsonFactory> factories;
-  
+
   /// Make the WorkerPool optional so that the JsonConverter still works without it
   final JsonDecodeServiceWorkerPool? workerPool;
 
@@ -246,7 +286,7 @@ class JsonSerializableWorkerPoolConverter extends JsonConverter {
       return data;
     }
   }
-  
+
   T? _decodeMap<T>(Map<String, dynamic> values) {
     final jsonFactory = factories[T];
     if (jsonFactory == null || jsonFactory is! JsonFactory<T>) {
@@ -268,9 +308,7 @@ class JsonSerializableWorkerPoolConverter extends JsonConverter {
   }
 
   @override
-  FutureOr<Response<ResultType>> convertResponse<ResultType, Item>(
-    Response response,
-  ) async {
+  FutureOr<Response<ResultType>> convertResponse<ResultType, Item>(Response response,) async {
     final jsonRes = await super.convertResponse(response);
 
     return jsonRes.copyWith<ResultType>(body: _decode<Item>(jsonRes.body));
@@ -287,7 +325,8 @@ class JsonSerializableWorkerPoolConverter extends JsonConverter {
 }
 ```
 
-Extracted from the [full example here](example/bin/main_json_serializable_squadron_worker_pool.dart).
+Extracted from the [full example here](example/bin/main_json_serializable_squadron_worker_pool.dart)
+.
 
 #### Code generation
 
@@ -325,6 +364,7 @@ Future<void> main() async {
     {
       Resource: Resource.fromJsonFactory,
     },
+
     /// make sure to provide the WorkerPool to the JsonConverter
     jsonDecodeServiceWorkerPool,
   );
@@ -346,7 +386,7 @@ Future<void> main() async {
 
   /// Do stuff with myService
   final myService = chopper.getService<MyService>();
-  
+
   /// ...stuff...
 
   /// stop the Worker Pool once done
@@ -358,8 +398,11 @@ Future<void> main() async {
 
 #### Further reading
 
-This barely scratches the surface. If you want to know more about [squadron](https://github.com/d-markey/squadron) and
-[squadron_builder](https://github.com/d-markey/squadron_builder) make sure to head over to their respective repositories.
+This barely scratches the surface. If you want to know more
+about [squadron](https://github.com/d-markey/squadron) and
+[squadron_builder](https://github.com/d-markey/squadron_builder) make sure to head over to their
+respective repositories.
 
-[David Markey](https://github.com/d-markey]), the author of squadron, was kind enough as to provide us with an [excellent Flutter example](https://github.com/d-markey/squadron_builder) using
-both packages.
+[David Markey](https://github.com/d-markey]), the author of squadron, was kind enough as to provide
+us with an [excellent Flutter example](https://github.com/d-markey/squadron_builder) using both
+packages.

--- a/faq.md
+++ b/faq.md
@@ -2,20 +2,17 @@
 
 ## \*.chopper.dart not found ?
 
-If you have this error, you probably forgot to run the `build` package. To do that, simply run the
-following command in your shell.
+If you have this error, you probably forgot to run the `build` package. To do that, simply run the following command in your shell.
 
 `pub run build_runner build`
 
-It will generate the code that actually do the HTTP request \(YOUR_FILE.chopper.dart\). If you wish
-to update the code automatically when you change your definition run the `watch` command.
+It will generate the code that actually do the HTTP request \(YOUR_FILE.chopper.dart\). If you wish to update the code automatically when you change your definition run the `watch` command.
 
 `pub run build_runner watch`
 
 ## How to increase timeout ?
 
-Connection timeout is very limited for now due to http package
-\(see: [dart-lang/http\#21](https://github.com/dart-lang/http/issues/21)\)
+Connection timeout is very limited for now due to http package \(see: [dart-lang/http\#21](https://github.com/dart-lang/http/issues/21)\)
 
 But if you are on VM or Flutter you can set the `connectionTimeout` you want
 
@@ -24,11 +21,10 @@ import 'package:http/io_client.dart' as http;
 import 'dart:io';
 
 final chopper = ChopperClient(
-  client: http.IOClient(
-    HttpClient()
-      ..connectionTimeout = const Duration(seconds: 60),
-  ),
-);
+    client: http.IOClient(
+      HttpClient()..connectionTimeout = const Duration(seconds: 60),
+    ),
+  );
 ```
 
 ## Add query parameter to all requests
@@ -36,9 +32,8 @@ final chopper = ChopperClient(
 Possible using an interceptor.
 
 ```dart
-
 final chopper = ChopperClient(
-  interceptors: [_addQuery],
+    interceptors: [_addQuery],
 );
 
 Request _addQuery(Request req) {
@@ -51,15 +46,16 @@ Request _addQuery(Request req) {
 
 ## GZip converter example
 
-You can use converters for modifying requests and responses. For example, to use GZip for post
-request you can write something like this:
+You can use converters for modifying requests and responses.
+For example, to use GZip for post request you can write something like this:
 
 ```dart
 Request compressRequest(Request request) {
   request = applyHeader(request, 'Content-Encoding', 'gzip');
   request = request.replace(body: gzip.encode(request.body));
   return request;
-}...
+}
+...
 
 @FactoryConverter(request: compressRequest)
 @Post()
@@ -68,20 +64,15 @@ Future<Response> postRequest(@Body() Map<String, String> data);
 
 ## Runtime baseUrl change
 
-You may need to change the base URL of your network calls during runtime, for example, if you have
-to use different servers or routes dynamically in your app in case of a "regular" or a "paid" user.
-You can store the current server base url in your SharedPreferences (encrypt/decrypt it if needed)
-and use it in an interceptor like this:
+You may need to change the base URL of your network calls during runtime, for example, if you have to use different servers or routes dynamically in your app in case of a "regular" or a "paid" user. You can store the current server base url in your SharedPreferences (encrypt/decrypt it if needed) and use it in an interceptor like this:
 
 ```dart
-...(Request request) async =>
-SharedPreferences.containsKey('baseUrl')
-? request.copyWith(
-baseUri: Uri.parse(SharedPreferences.getString('baseUrl')
-)
-)
-:
-request
+...
+(Request request) async =>
+              SharedPreferences.containsKey('baseUrl')
+                  ? request.copyWith(
+                      baseUri: Uri.parse(SharedPreferences.getString('baseUrl'))
+                  ): request
 ...
 ```
 
@@ -142,20 +133,9 @@ import 'dart:io';
 import 'package:http/io_client.dart' as http;
 
 final ioc = new HttpClient();
-ioc.findProxy = (
-url) =>
-'
-PROXY 192.168.0.102:9090
-';
-ioc.badCertificateCallback = (
-
-X509Certificate cert, String
-host,
-
-int port
-)
-=>
-true;
+ioc.findProxy = (url) => 'PROXY 192.168.0.102:9090';
+ioc.badCertificateCallback = (X509Certificate cert, String host, int port)
+  => true;
 
 final chopper = ChopperClient(
   client: http.IOClient(ioc),
@@ -166,53 +146,35 @@ final chopper = ChopperClient(
 
 Basically, the algorithm goes like this (credits to [stewemetal](https://github.com/stewemetal)):
 
-Add the authentication token to the request (by "Authorization" header, for example) -> try the
-request -> if it fails use the refresh token to get a new auth token ->
-if that succeeds, save the auth token and retry the original request with it if the refresh token is
-not valid anymore, drop the session (and navigate to the login screen, for example)
+Add the authentication token to the request (by "Authorization" header, for example) -> try the request -> if it fails use the refresh token to get a new auth token ->
+if that succeeds, save the auth token and retry the original request with it
+if the refresh token is not valid anymore, drop the session (and navigate to the login screen, for example)
 
 Simple code example:
 
 ```dart
 interceptors: [
-// Auth Interceptor
-(
-
-Request request
-)
-async => applyHeader
-(
-request, '
-authorization
-'
-,
-SharedPrefs.localStorage.getString(tokenHeader),
-override: false
-)
-,
-(
-
-Response response
-)
-async {
-if (response?.statusCode == 401) {
-SharedPrefs.localStorage.remove(tokenHeader);
-// Navigate to some login page or just request new token
-}
-return response;
-},
+  // Auth Interceptor
+  (Request request) async => applyHeader(request, 'authorization',
+      SharedPrefs.localStorage.getString(tokenHeader),
+      override: false),
+  (Response response) async {
+    if (response?.statusCode == 401) {
+      SharedPrefs.localStorage.remove(tokenHeader);
+      // Navigate to some login page or just request new token
+    }
+    return response;
+  },
 ]
 ```
 
-The actual implementation of the algorithm above may vary based on how the backend API - more
-precisely the login and session handling - of your app looks like.
+The actual implementation of the algorithm above may vary based on how the backend API - more precisely the login and session handling - of your app looks like.
 
 ## Decoding JSON using Isolates
 
-Sometimes you want to decode JSON outside the main thread in order to reduce janking. In this
-example we're going to go even further and implement a Worker Pool
-using [Squadron](https://pub.dev/packages/squadron/install) which can dynamically spawn a maximum
-number of Workers as they become needed.
+Sometimes you want to decode JSON outside the main thread in order to reduce janking. In this example we're going to go
+even further and implement a Worker Pool using [Squadron](https://pub.dev/packages/squadron/install) which can 
+dynamically spawn a maximum number of Workers as they become needed.
 
 #### Install the dependencies
 
@@ -223,8 +185,7 @@ number of Workers as they become needed.
 
 #### Write a JSON decode service
 
-We'll leverage [squadron_builder](https://pub.dev/packages/squadron_builder) and the power of code
-generation.
+We'll leverage [squadron_builder](https://pub.dev/packages/squadron_builder) and the power of code generation.
 
 ```dart
 import 'dart:async';
@@ -248,8 +209,7 @@ Extracted from the [full example here](example/lib/json_decode_service.dart).
 
 #### Write a custom JsonConverter
 
-Using [json_serializable](https://pub.dev/packages/json_serializable) we'll create
-a [JsonConverter](https://github.com/lejard-h/chopper/blob/master/chopper/lib/src/interceptor.dart#L228)
+Using [json_serializable](https://pub.dev/packages/json_serializable) we'll create a [JsonConverter](https://github.com/lejard-h/chopper/blob/master/chopper/lib/src/interceptor.dart#L228) 
 which works with or without a [WorkerPool](https://github.com/d-markey/squadron#features).
 
 ```dart
@@ -266,7 +226,7 @@ class JsonSerializableWorkerPoolConverter extends JsonConverter {
   const JsonSerializableWorkerPoolConverter(this.factories, [this.workerPool]);
 
   final Map<Type, JsonFactory> factories;
-
+  
   /// Make the WorkerPool optional so that the JsonConverter still works without it
   final JsonDecodeServiceWorkerPool? workerPool;
 
@@ -286,7 +246,7 @@ class JsonSerializableWorkerPoolConverter extends JsonConverter {
       return data;
     }
   }
-
+  
   T? _decodeMap<T>(Map<String, dynamic> values) {
     final jsonFactory = factories[T];
     if (jsonFactory == null || jsonFactory is! JsonFactory<T>) {
@@ -308,7 +268,9 @@ class JsonSerializableWorkerPoolConverter extends JsonConverter {
   }
 
   @override
-  FutureOr<Response<ResultType>> convertResponse<ResultType, Item>(Response response,) async {
+  FutureOr<Response<ResultType>> convertResponse<ResultType, Item>(
+    Response response,
+  ) async {
     final jsonRes = await super.convertResponse(response);
 
     return jsonRes.copyWith<ResultType>(body: _decode<Item>(jsonRes.body));
@@ -325,8 +287,7 @@ class JsonSerializableWorkerPoolConverter extends JsonConverter {
 }
 ```
 
-Extracted from the [full example here](example/bin/main_json_serializable_squadron_worker_pool.dart)
-.
+Extracted from the [full example here](example/bin/main_json_serializable_squadron_worker_pool.dart).
 
 #### Code generation
 
@@ -364,7 +325,6 @@ Future<void> main() async {
     {
       Resource: Resource.fromJsonFactory,
     },
-
     /// make sure to provide the WorkerPool to the JsonConverter
     jsonDecodeServiceWorkerPool,
   );
@@ -386,7 +346,7 @@ Future<void> main() async {
 
   /// Do stuff with myService
   final myService = chopper.getService<MyService>();
-
+  
   /// ...stuff...
 
   /// stop the Worker Pool once done
@@ -398,11 +358,8 @@ Future<void> main() async {
 
 #### Further reading
 
-This barely scratches the surface. If you want to know more
-about [squadron](https://github.com/d-markey/squadron) and
-[squadron_builder](https://github.com/d-markey/squadron_builder) make sure to head over to their
-respective repositories.
+This barely scratches the surface. If you want to know more about [squadron](https://github.com/d-markey/squadron) and
+[squadron_builder](https://github.com/d-markey/squadron_builder) make sure to head over to their respective repositories.
 
-[David Markey](https://github.com/d-markey]), the author of squadron, was kind enough as to provide
-us with an [excellent Flutter example](https://github.com/d-markey/squadron_builder) using both
-packages.
+[David Markey](https://github.com/d-markey]), the author of squadron, was kind enough as to provide us with an [excellent Flutter example](https://github.com/d-markey/squadron_builder) using
+both packages.


### PR DESCRIPTION
I took the liberty of replacing the `String` based url path in the client calls with an `Uri` as request in the #304 feature request.

This is now more in line with the underlying `Http.Client`. 

Any feedback is welcome :)