### PR TITLE
Fix #388 Triggering Authenticator double encodes body in POST, PUT, PATCH

### DIFF
--- a/chopper/lib/src/base.dart
+++ b/chopper/lib/src/base.dart
@@ -293,9 +293,10 @@ class ChopperClient {
     ConvertRequest? requestConverter,
     ConvertResponse? responseConverter,
   }) async {
-    var req = await _interceptRequest(
+    final Request req = await _interceptRequest(
       await _handleRequestConverter(request, requestConverter),
     );
+
     _requestController.add(req);
 
     final streamRes = await httpClient.send(await req.toBaseRequest());
@@ -307,7 +308,11 @@ class ChopperClient {
     dynamic res = Response(response, response.body);
 
     if (authenticator != null) {
-      var updatedRequest = await authenticator!.authenticate(req, res, request);
+      final Request? updatedRequest = await authenticator!.authenticate(
+        request,
+        res,
+        request,
+      );
 
       if (updatedRequest != null) {
         res = await send<BodyType, InnerType>(

--- a/chopper/test/authenticator_test.dart
+++ b/chopper/test/authenticator_test.dart
@@ -6,7 +6,6 @@ import 'package:http/testing.dart';
 import 'package:test/test.dart';
 
 import 'fake_authenticator.dart';
-import 'test_service.dart';
 
 void main() async {
   final Uri baseUrl = Uri.parse('http://localhost:8000');
@@ -94,16 +93,12 @@ void main() async {
   group('With Authenticator', () {
     ChopperClient buildClient([http.Client? httpClient]) => ChopperClient(
           baseUrl: baseUrl,
-          services: [
-            // the generated service
-            HttpTestService.create(),
-          ],
+          client: httpClient,
           interceptors: [
             (Request req) => applyHeader(req, 'foo', 'bar'),
           ],
-          authenticator: FakeAuthenticator(),
-          client: httpClient,
           converter: JsonConverter(),
+          authenticator: FakeAuthenticator(),
         );
 
     late bool authenticated;

--- a/chopper/test/authenticator_test.dart
+++ b/chopper/test/authenticator_test.dart
@@ -120,7 +120,35 @@ void main() async {
       };
     });
 
-    test('GET', () async {
+    test('GET authorized', () async {
+      final httpClient = MockClient((request) async {
+        expect(
+          request.url.toString(),
+          equals('$baseUrl/test/get?key=val'),
+        );
+        expect(request.method, equals('GET'));
+        expect(request.headers['foo'], equals('bar'));
+        expect(request.headers['int'], equals('42'));
+
+        return http.Response('ok', 200);
+      });
+
+      final chopper = buildClient(httpClient);
+      final response = await chopper.get(
+        Uri(
+          path: '/test/get',
+          queryParameters: {'key': 'val'},
+        ),
+        headers: {'int': '42'},
+      );
+
+      expect(response.body, equals('ok'));
+      expect(response.statusCode, equals(200));
+
+      httpClient.close();
+    });
+
+    test('GET unauthorized', () async {
       final httpClient = MockClient((request) async {
         expect(
           request.url.toString(),
@@ -160,7 +188,48 @@ void main() async {
       httpClient.close();
     });
 
-    test('POST', () async {
+    test('POST authorized', () async {
+      final httpClient = MockClient((request) async {
+        expect(
+          request.url.toString(),
+          equals('$baseUrl/test/post?key=val'),
+        );
+        expect(request.method, equals('POST'));
+        expect(request.headers['foo'], equals('bar'));
+        expect(request.headers['int'], equals('42'));
+        expect(
+          request.body,
+          jsonEncode(
+            {
+              'name': 'john',
+              'surname': 'doe',
+            },
+          ),
+        );
+
+        return http.Response('ok', 200);
+      });
+
+      final chopper = buildClient(httpClient);
+      final response = await chopper.post(
+        Uri(
+          path: '/test/post',
+          queryParameters: {'key': 'val'},
+        ),
+        headers: {'int': '42'},
+        body: {
+          'name': 'john',
+          'surname': 'doe',
+        },
+      );
+
+      expect(response.body, equals('ok'));
+      expect(response.statusCode, equals(200));
+
+      httpClient.close();
+    });
+
+    test('POST unauthorized', () async {
       final httpClient = MockClient((request) async {
         expect(
           request.url.toString(),

--- a/chopper/test/authenticator_test.dart
+++ b/chopper/test/authenticator_test.dart
@@ -1,0 +1,221 @@
+import 'dart:convert';
+
+import 'package:chopper/chopper.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+import 'fake_authenticator.dart';
+import 'test_service.dart';
+
+void main() async {
+  final Uri baseUrl = Uri.parse('http://localhost:8000');
+
+  group('Without Authenticator', () {
+    ChopperClient buildClient([http.Client? httpClient]) => ChopperClient(
+          baseUrl: baseUrl,
+          client: httpClient,
+          interceptors: [
+            (Request req) => applyHeader(req, 'foo', 'bar'),
+          ],
+          converter: JsonConverter(),
+        );
+
+    test('GET', () async {
+      final httpClient = MockClient((request) async {
+        expect(
+          request.url.toString(),
+          equals('$baseUrl/test/get?key=val'),
+        );
+        expect(request.method, equals('GET'));
+        expect(request.headers['foo'], equals('bar'));
+        expect(request.headers['int'], equals('42'));
+
+        return http.Response('ok', 200);
+      });
+
+      final chopper = buildClient(httpClient);
+      final response = await chopper.get(
+        Uri(
+          path: '/test/get',
+          queryParameters: {'key': 'val'},
+        ),
+        headers: {'int': '42'},
+      );
+
+      expect(response.body, equals('ok'));
+      expect(response.statusCode, equals(200));
+
+      httpClient.close();
+    });
+
+    test('POST', () async {
+      final httpClient = MockClient((request) async {
+        expect(
+          request.url.toString(),
+          equals('$baseUrl/test/post?key=val'),
+        );
+        expect(request.method, equals('POST'));
+        expect(request.headers['foo'], equals('bar'));
+        expect(request.headers['int'], equals('42'));
+        expect(
+          request.body,
+          jsonEncode(
+            {
+              'name': 'john',
+              'surname': 'doe',
+            },
+          ),
+        );
+
+        return http.Response('ok', 200);
+      });
+
+      final chopper = buildClient(httpClient);
+      final response = await chopper.post(
+        Uri(
+          path: '/test/post',
+          queryParameters: {'key': 'val'},
+        ),
+        headers: {'int': '42'},
+        body: {
+          'name': 'john',
+          'surname': 'doe',
+        },
+      );
+
+      expect(response.body, equals('ok'));
+      expect(response.statusCode, equals(200));
+
+      httpClient.close();
+    });
+  });
+
+  group('With Authenticator', () {
+    ChopperClient buildClient([http.Client? httpClient]) => ChopperClient(
+          baseUrl: baseUrl,
+          services: [
+            // the generated service
+            HttpTestService.create(),
+          ],
+          interceptors: [
+            (Request req) => applyHeader(req, 'foo', 'bar'),
+          ],
+          authenticator: FakeAuthenticator(),
+          client: httpClient,
+          converter: JsonConverter(),
+        );
+
+    late bool authenticated;
+    late Map<String, bool> tested;
+
+    setUp(() {
+      authenticated = false;
+      tested = {
+        'unauthenticated': false,
+        'authenticated': false,
+      };
+    });
+
+    tearDown(() {
+      authenticated = false;
+      tested = {
+        'unauthenticated': false,
+        'authenticated': false,
+      };
+    });
+
+    test('GET', () async {
+      final httpClient = MockClient((request) async {
+        expect(
+          request.url.toString(),
+          equals('$baseUrl/test/get?key=val'),
+        );
+        expect(request.method, equals('GET'));
+        expect(request.headers['foo'], equals('bar'));
+        expect(request.headers['int'], equals('42'));
+
+        if (!authenticated) {
+          tested['unauthenticated'] = true;
+          authenticated = true;
+
+          return http.Response('unauthorized', 401);
+        } else {
+          tested['authenticated'] = true;
+          expect(request.headers['authorization'], equals('some_fake_token'));
+        }
+
+        return http.Response('ok', 200);
+      });
+
+      final chopper = buildClient(httpClient);
+      final response = await chopper.get(
+        Uri(
+          path: '/test/get',
+          queryParameters: {'key': 'val'},
+        ),
+        headers: {'int': '42'},
+      );
+
+      expect(response.body, equals('ok'));
+      expect(response.statusCode, equals(200));
+      expect(tested['authenticated'], equals(true));
+      expect(tested['unauthenticated'], equals(true));
+
+      httpClient.close();
+    });
+
+    test('POST', () async {
+      final httpClient = MockClient((request) async {
+        expect(
+          request.url.toString(),
+          equals('$baseUrl/test/post?key=val'),
+        );
+        expect(request.method, equals('POST'));
+        expect(request.headers['foo'], equals('bar'));
+        expect(request.headers['int'], equals('42'));
+        expect(
+          request.body,
+          jsonEncode(
+            {
+              'name': 'john',
+              'surname': 'doe',
+            },
+          ),
+        );
+
+        if (!authenticated) {
+          tested['unauthenticated'] = true;
+          authenticated = true;
+
+          return http.Response('unauthorized', 401);
+        } else {
+          tested['authenticated'] = true;
+          expect(request.headers['authorization'], equals('some_fake_token'));
+        }
+
+        return http.Response('ok', 200);
+      });
+
+      final chopper = buildClient(httpClient);
+      final response = await chopper.post(
+        Uri(
+          path: '/test/post',
+          queryParameters: {'key': 'val'},
+        ),
+        headers: {'int': '42'},
+        body: {
+          'name': 'john',
+          'surname': 'doe',
+        },
+      );
+
+      expect(response.body, equals('ok'));
+      expect(response.statusCode, equals(200));
+      expect(tested['authenticated'], equals(true));
+      expect(tested['unauthenticated'], equals(true));
+
+      httpClient.close();
+    });
+  });
+}

--- a/chopper/test/authenticator_test.dart
+++ b/chopper/test/authenticator_test.dart
@@ -1,4 +1,4 @@
-import 'dart:convert';
+import 'dart:convert' show jsonEncode;
 
 import 'package:chopper/chopper.dart';
 import 'package:http/http.dart' as http;
@@ -180,6 +180,198 @@ void main() async {
       final response = await chopper.post(
         Uri(
           path: '/test/post',
+          queryParameters: {'key': 'val'},
+        ),
+        headers: {'int': '42'},
+        body: {
+          'name': 'john',
+          'surname': 'doe',
+        },
+      );
+
+      expect(response.body, equals('ok'));
+      expect(response.statusCode, equals(200));
+      expect(tested['authenticated'], equals(true));
+      expect(tested['unauthenticated'], equals(true));
+
+      httpClient.close();
+    });
+  });
+
+  group('PUT', () {
+    test('authorized', () async {
+      final httpClient = MockClient((request) async {
+        expect(
+          request.url.toString(),
+          equals('$baseUrl/test/put?key=val'),
+        );
+        expect(request.method, equals('PUT'));
+        expect(request.headers['foo'], equals('bar'));
+        expect(request.headers['int'], equals('42'));
+        expect(
+          request.body,
+          jsonEncode(
+            {
+              'name': 'john',
+              'surname': 'doe',
+            },
+          ),
+        );
+
+        return http.Response('ok', 200);
+      });
+
+      final chopper = buildClient(httpClient);
+      final response = await chopper.put(
+        Uri(
+          path: '/test/put',
+          queryParameters: {'key': 'val'},
+        ),
+        headers: {'int': '42'},
+        body: {
+          'name': 'john',
+          'surname': 'doe',
+        },
+      );
+
+      expect(response.body, equals('ok'));
+      expect(response.statusCode, equals(200));
+
+      httpClient.close();
+    });
+
+    test('unauthorized', () async {
+      final httpClient = MockClient((request) async {
+        expect(
+          request.url.toString(),
+          equals('$baseUrl/test/put?key=val'),
+        );
+        expect(request.method, equals('PUT'));
+        expect(request.headers['foo'], equals('bar'));
+        expect(request.headers['int'], equals('42'));
+        expect(
+          request.body,
+          jsonEncode(
+            {
+              'name': 'john',
+              'surname': 'doe',
+            },
+          ),
+        );
+
+        if (!authenticated) {
+          tested['unauthenticated'] = true;
+          authenticated = true;
+
+          return http.Response('unauthorized', 401);
+        } else {
+          tested['authenticated'] = true;
+          expect(request.headers['authorization'], equals('some_fake_token'));
+        }
+
+        return http.Response('ok', 200);
+      });
+
+      final chopper = buildClient(httpClient);
+      final response = await chopper.put(
+        Uri(
+          path: '/test/put',
+          queryParameters: {'key': 'val'},
+        ),
+        headers: {'int': '42'},
+        body: {
+          'name': 'john',
+          'surname': 'doe',
+        },
+      );
+
+      expect(response.body, equals('ok'));
+      expect(response.statusCode, equals(200));
+      expect(tested['authenticated'], equals(true));
+      expect(tested['unauthenticated'], equals(true));
+
+      httpClient.close();
+    });
+  });
+
+  group('PATCH', () {
+    test('authorized', () async {
+      final httpClient = MockClient((request) async {
+        expect(
+          request.url.toString(),
+          equals('$baseUrl/test/patch?key=val'),
+        );
+        expect(request.method, equals('PATCH'));
+        expect(request.headers['foo'], equals('bar'));
+        expect(request.headers['int'], equals('42'));
+        expect(
+          request.body,
+          jsonEncode(
+            {
+              'name': 'john',
+              'surname': 'doe',
+            },
+          ),
+        );
+
+        return http.Response('ok', 200);
+      });
+
+      final chopper = buildClient(httpClient);
+      final response = await chopper.patch(
+        Uri(
+          path: '/test/patch',
+          queryParameters: {'key': 'val'},
+        ),
+        headers: {'int': '42'},
+        body: {
+          'name': 'john',
+          'surname': 'doe',
+        },
+      );
+
+      expect(response.body, equals('ok'));
+      expect(response.statusCode, equals(200));
+
+      httpClient.close();
+    });
+
+    test('unauthorized', () async {
+      final httpClient = MockClient((request) async {
+        expect(
+          request.url.toString(),
+          equals('$baseUrl/test/patch?key=val'),
+        );
+        expect(request.method, equals('PATCH'));
+        expect(request.headers['foo'], equals('bar'));
+        expect(request.headers['int'], equals('42'));
+        expect(
+          request.body,
+          jsonEncode(
+            {
+              'name': 'john',
+              'surname': 'doe',
+            },
+          ),
+        );
+
+        if (!authenticated) {
+          tested['unauthenticated'] = true;
+          authenticated = true;
+
+          return http.Response('unauthorized', 401);
+        } else {
+          tested['authenticated'] = true;
+          expect(request.headers['authorization'], equals('some_fake_token'));
+        }
+
+        return http.Response('ok', 200);
+      });
+
+      final chopper = buildClient(httpClient);
+      final response = await chopper.patch(
+        Uri(
+          path: '/test/patch',
           queryParameters: {'key': 'val'},
         ),
         headers: {'int': '42'},

--- a/chopper/test/fake_authenticator.dart
+++ b/chopper/test/fake_authenticator.dart
@@ -1,0 +1,23 @@
+import 'dart:async' show FutureOr;
+
+import 'package:chopper/chopper.dart';
+
+class FakeAuthenticator extends Authenticator {
+  @override
+  FutureOr<Request?> authenticate(
+    Request request,
+    Response response, [
+    Request? originalRequest,
+  ]) async {
+    if (response.statusCode == 401) {
+      return request.copyWith(
+        headers: <String, String>{
+          ...request.headers,
+          'authorization': 'some_fake_token',
+        },
+      );
+    }
+
+    return null;
+  }
+}


### PR DESCRIPTION
This fixes #388

When `ChopperClient` is configured with an `Authenticator` and when `Authenticator.authenticate` returns a non-null value, `ChopperClient.send` recursively passes an already converted `Request` to `ChopperClient.send` again. This results in double-encoded JSON.

```
Expected: '{"name":"john","surname":"doe"}'
  Actual: '"{\\"name\\":\\"john\\",\\"surname\\":\\"doe\\"}"'
   Which: is different.
          Expected: {"name":"j ...
            Actual: "{\\"name\ ...
                    ^
           Differ at offset 0
```

As previously mentioned, the issue only manifests itself when`Authenticator.authenticate` returns a non-null value, in essence when the client receives an `HTTP ERROR: 401`. It works perfectly fine when the client is authenticated and/or the Auth token hasn't expired. That's why it probably flew under the radar for so long.

This PR fixes it [by passing the original `Request` to `ChopperClient.send` in that case](https://github.com/lejard-h/chopper/pull/390/files#diff-bbe00a156f110aeeb0d7c803bef086b8d2b47e55959cf5ea3fa2c08d4a2d5b19R312).