### PR TITLE
Made apply headers field name case insensitive.

### DIFF
--- a/chopper/lib/src/utils.dart
+++ b/chopper/lib/src/utils.dart
@@ -1,3 +1,5 @@
+import 'dart:collection';
+
 import 'package:chopper/chopper.dart';
 import 'package:logging/logging.dart';
 
@@ -39,13 +41,15 @@ Request applyHeaders(
   Map<String, String> headers, {
   bool override = true,
 }) {
-  final Map<String, String> headersCopy = {...request.headers};
+  final LinkedHashMap<String, String> headersCopy = LinkedHashMap(
+    equals: (a, b) => a.toLowerCase() == b.toLowerCase(),
+    hashCode: (e) => e.toLowerCase().hashCode,
+  );
+  headersCopy.addAll(request.headers);
 
-  for (String key in headers.keys) {
-    String? value = headers[key];
-    if (value == null) continue;
-    if (!override && headersCopy.containsKey(key)) continue;
-    headersCopy[key] = value;
+  for (final entry in headers.entries) {
+    if (!override && headersCopy.containsKey(entry.key)) continue;
+    headersCopy[entry.key] = entry.value;
   }
 
   return request.copyWith(headers: headersCopy);

--- a/chopper/test/converter_test.dart
+++ b/chopper/test/converter_test.dart
@@ -112,6 +112,20 @@ void main() {
       expect(converted.body, equals({'foo': 'bar'}));
     });
   });
+
+  test('respects content-type headers', () {
+    final jsonConverter = JsonConverter();
+    final testRequest = Request(
+      'POST',
+      Uri.parse('foo'),
+      Uri.parse('bar'),
+      headers: {'Content-Type': 'application/vnd.api+json'},
+    );
+
+    final result = jsonConverter.convertRequest(testRequest);
+
+    expect(result.headers['content-type'], 'application/vnd.api+json');
+  });
 }
 
 class TestConverter implements Converter {

--- a/chopper/test/utils_test.dart
+++ b/chopper/test/utils_test.dart
@@ -566,7 +566,7 @@ void main() {
   });
 
   Request createRequest(Map<String, String> headers) => Request(
-        "POST",
+        'POST',
         Uri.parse('foo'),
         Uri.parse('bar'),
         headers: headers,

--- a/chopper/test/utils_test.dart
+++ b/chopper/test/utils_test.dart
@@ -1,3 +1,4 @@
+import 'package:chopper/src/request.dart';
 import 'package:chopper/src/utils.dart';
 import 'package:test/test.dart';
 
@@ -561,6 +562,169 @@ void main() {
           query,
         ),
       ),
+    );
+  });
+
+  Request createRequest(Map<String, String> headers) => Request(
+        "POST",
+        Uri.parse('foo'),
+        Uri.parse('bar'),
+        headers: headers,
+      );
+
+  group('applyHeader tests', () {
+    test('request apply single header', () {
+      final testRequest = createRequest({});
+
+      final result = applyHeader(testRequest, 'foo', 'bar');
+
+      expect(result.headers['foo'], 'bar');
+    });
+
+    test('request apply single header overrides existing', () {
+      final testRequest = createRequest({'foo': 'bar'});
+
+      final result = applyHeader(testRequest, 'foo', 'whut');
+
+      expect(result.headers['foo'], 'whut');
+    });
+
+    test(
+      'request apply single header overrides existing field name case insensitive',
+      () {
+        final testRequest = createRequest({'Foo': 'bar'});
+
+        final result = applyHeader(testRequest, 'foo', 'whut');
+
+        expect(result.headers['foo'], 'whut');
+      },
+    );
+
+    test('request apply single header doesn\'t overrides existing', () {
+      final testRequest = createRequest({'foo': 'bar'});
+
+      final result = applyHeader(testRequest, 'foo', 'whut', override: false);
+
+      expect(result.headers['foo'], 'bar');
+    });
+
+    test(
+      'request apply single header doesn\'t overrides existing field name case insensitive',
+      () {
+        final testRequest = createRequest({'Foo': 'bar'});
+
+        final result = applyHeader(testRequest, 'foo', 'whut', override: false);
+
+        expect(result.headers['Foo'], 'bar');
+      },
+    );
+  });
+
+  group('applyHeaders tests', () {
+    test('request apply headers', () {
+      final testRequest = createRequest({});
+
+      final result = applyHeaders(testRequest, {'foo': 'bar'});
+
+      expect(result.headers['foo'], 'bar');
+    });
+
+    test('request apply headers overrides existing', () {
+      final testRequest = createRequest({'foo': 'bar'});
+
+      final result = applyHeaders(testRequest, {'foo': 'whut'});
+
+      expect(result.headers['foo'], 'whut');
+    });
+
+    test(
+      'request apply headers overrides existing field name case insensitive',
+      () {
+        final testRequest = createRequest({'Foo': 'bar'});
+
+        final result = applyHeaders(testRequest, {'foo': 'whut'});
+
+        expect(result.headers['foo'], 'whut');
+      },
+    );
+
+    test('request apply headers doesn\'t overrides existing', () {
+      final testRequest = createRequest({'foo': 'bar'});
+
+      final result =
+          applyHeaders(testRequest, {'foo': 'whut'}, override: false);
+
+      expect(result.headers['foo'], 'bar');
+    });
+
+    test(
+      'request apply headers doesn\'t overrides existing field name case insensitive',
+      () {
+        final testRequest = createRequest({'Foo': 'bar'});
+
+        final result =
+            applyHeaders(testRequest, {'foo': 'whut'}, override: false);
+
+        expect(result.headers['Foo'], 'bar');
+      },
+    );
+
+    test(
+      'request apply headers multiple headers with override false',
+      () {
+        final testRequest = createRequest(
+          {
+            'Foo': 'bar',
+            'tomato': 'apple',
+            'phone': 'tablet',
+          },
+        );
+
+        final result = applyHeaders(
+          testRequest,
+          {
+            'foo': 'whut',
+            'phone': 'computer',
+            'chair': 'table',
+          },
+          override: false,
+        );
+
+        expect(result.headers['Foo'], 'bar');
+        expect(result.headers['tomato'], 'apple');
+        expect(result.headers['chair'], 'table');
+        expect(result.headers['phone'], 'tablet');
+        expect(result.headers.length, 4);
+      },
+    );
+
+    test(
+      'request apply headers multiple headers with override true',
+      () {
+        final testRequest = createRequest(
+          {
+            'Foo': 'bar',
+            'tomato': 'apple',
+            'phone': 'tablet',
+          },
+        );
+
+        final result = applyHeaders(
+          testRequest,
+          {
+            'foo': 'whut',
+            'phone': 'computer',
+            'chair': 'table',
+          },
+          override: true,
+        );
+
+        expect(result.headers['Foo'], 'whut');
+        expect(result.headers['tomato'], 'apple');
+        expect(result.headers['chair'], 'table');
+        expect(result.headers['phone'], 'computer');
+        expect(result.headers.length, 4);
+      },
     );
   });
 }


### PR DESCRIPTION
Fixes #398

`applyHeaders` would override headers with different cases. But the header field names should be case-insensitive according to the [RFC 7540](https://www.rfc-editor.org/rfc/rfc7540#section-8.1.2).

This MR makes applying headers case insensitive. Also added bunch of tests for verifying `applyHeaders`.