### PR TITLE
:bulb: Clean up code in comments

### DIFF
--- a/chopper/lib/src/annotations.dart
+++ b/chopper/lib/src/annotations.dart
@@ -328,6 +328,7 @@ typedef ConvertResponse<T> = FutureOr<Response> Function(Response response);
 ///   )
 ///   Future<Response<Todo>> getTodo(@Path("id"));
 /// }
+/// ```
 @immutable
 class FactoryConverter {
   final ConvertRequest? request;
@@ -365,7 +366,6 @@ class Field {
 /// @Post(path: '/something')
 /// Future<Response> fetch(@FieldMap List<Map<String, dynamic>> query);
 /// ```
-///
 @immutable
 class FieldMap {
   const FieldMap();
@@ -405,7 +405,6 @@ class Part {
 /// @Multipart
 /// Future<Response> fetch(@PartMap() List<PartValue> query);
 /// ```
-///
 @immutable
 class PartMap {
   const PartMap();
@@ -413,7 +412,7 @@ class PartMap {
 
 /// Use [PartFile] to define a file field for a [Multipart] request.
 ///
-/// ```
+/// ```dart
 /// @Post(path: 'file')
 /// @multipart
 /// Future<Response> postFile(@PartFile('file') List<int> bytes);
@@ -437,7 +436,6 @@ class PartFile {
 /// @Multipart
 /// Future<Response> fetch(@PartFileMap() List<PartValueFile> query);
 /// ```
-///
 @immutable
 class PartFileMap {
   const PartFileMap();

--- a/chopper/lib/src/utils.dart
+++ b/chopper/lib/src/utils.dart
@@ -32,8 +32,8 @@ Request applyHeader(
 ///
 /// ```dart
 /// final newRequest = applyHeaders(request, {
-/// 'Authorization': 'Bearer <token>',
-/// 'Content-Type': 'application/json',
+///   'Authorization': 'Bearer <token>',
+///   'Content-Type': 'application/json',
 /// });
 /// ```
 Request applyHeaders(


### PR DESCRIPTION
I noticed that some code inside comment blocks (`///`) was annotated to start with ` ```dart ` but didn't end with ` ``` `.

As a result, the code wasn't properly highlighted on Github, for example [here](https://github.com/lejard-h/chopper/blob/develop/chopper/lib/src/annotations.dart#L330).

**NOTE** this is a cosmetic fix only. No code was changed, only comments.