### PR TITLE
Updated chopper version to 6.0.0 for chopper_built_value

### DIFF
--- a/chopper_built_value/pubspec.yaml
+++ b/chopper_built_value/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   built_value: ^8.0.0
   built_collection: ^5.0.0
-  chopper: ^5.0.0
+  chopper: ^6.0.0
   http: ^0.13.0
 
 dev_dependencies:


### PR DESCRIPTION
Updated `chopper_built_value` chopper version to `6.0.0`. As mentioned in #405 