### PR TITLE
:construction_worker: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
 *       @global-owner1 @global-owner2
-@JEuler @lejard-h @meysam1717 @pixeltoast @stewemetal @techouse
+@Guldem @JEuler @lejard-h @meysam1717 @pixeltoast @stewemetal @techouse

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*       @global-owner1 @global-owner2
+@JEuler @lejard-h @meysam1717 @pixeltoast @stewemetal @techouse

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @global-owner1 @global-owner2
 * @Guldem @JEuler @lejard-h @meysam1717 @pixeltoast @stewemetal @techouse

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
 *       @global-owner1 @global-owner2
-@Guldem @JEuler @lejard-h @meysam1717 @pixeltoast @stewemetal @techouse
+* @Guldem @JEuler @lejard-h @meysam1717 @pixeltoast @stewemetal @techouse


### PR DESCRIPTION
Addresses #413

Currently adds these as **global** [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners):

* @Guldem 
* @JEuler 
* @lejard-h 
* @meysam1717
* @pixeltoast 
* @stewemetal 
* @techouse

Anyone else who wants to be added or wants to be removed from this preliminary list, please post a comment below.