### PR TITLE
:green_heart: fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,8 @@ jobs:
       - id: checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 2
+      - run: git checkout HEAD^
       - name: Load base version
         id: load_base_version
         run: |

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -457,6 +457,7 @@ class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
         _typeChecker(Map).isExactlyType(type) ||
         _typeChecker(BuiltMap).isExactlyType(type)) return type;
 
+    // ignore: deprecated_member_use
     if (generic.isDynamic) return null;
 
     if (_typeChecker(List).isExactlyType(type) ||


### PR DESCRIPTION
In the previous PR https://github.com/lejard-h/chopper/pull/424 I forgot that the `publish.yaml` workflow does not operate from a pull request but directly on the master branch. That will obviously fail to acquire the previous version. To fix it I changed the checkout process to checkout the master from 1 commit before (`HEAD^`).

```yaml
- id: checkout
  uses: actions/checkout@v3
  with:
    fetch-depth: 2
- run: git checkout HEAD^
```