### PR TITLE
:arrow_up: update http constraint to ">=0.13.0 <2.0.0"

### DIFF
--- a/chopper/pubspec.yaml
+++ b/chopper/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   equatable: ^2.0.5
-  http: ">=0.13.0 <1.0.0"
+  http: ">=0.13.0 <2.0.0"
   logging: ^1.0.0
   meta: ^1.3.0
 

--- a/chopper/pubspec.yaml
+++ b/chopper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chopper
 description: Chopper is an http client generator using source_gen, inspired by Retrofit
-version: 6.1.3
+version: 6.1.2
 documentation: https://hadrien-lejard.gitbook.io/chopper
 repository: https://github.com/lejard-h/chopper
 

--- a/chopper/pubspec.yaml
+++ b/chopper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chopper
 description: Chopper is an http client generator using source_gen, inspired by Retrofit
-version: 6.1.2
+version: 6.1.3
 documentation: https://hadrien-lejard.gitbook.io/chopper
 repository: https://github.com/lejard-h/chopper
 

--- a/chopper_built_value/pubspec.yaml
+++ b/chopper_built_value/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chopper_built_value
 description: A built_value based Converter for Chopper.
-version: 1.2.1
+version: 1.2.2
 documentation: https://hadrien-lejard.gitbook.io/chopper/converters/built-value-converter
 repository: https://github.com/lejard-h/chopper
 

--- a/chopper_built_value/pubspec.yaml
+++ b/chopper_built_value/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   built_value: ^8.0.0
   built_collection: ^5.0.0
   chopper: ^6.0.0
-  http: ^0.13.0
+  http: ">=0.13.0 <2.0.0"
 
 dev_dependencies:
   test: ^1.16.4

--- a/chopper_built_value/pubspec.yaml
+++ b/chopper_built_value/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chopper_built_value
 description: A built_value based Converter for Chopper.
-version: 1.2.2
+version: 1.2.1
 documentation: https://hadrien-lejard.gitbook.io/chopper/converters/built-value-converter
 repository: https://github.com/lejard-h/chopper
 


### PR DESCRIPTION
[http](https://pub.dev/packages/http) recently got bumped to `v1.0.0` and since it's backwards compatible with `v0.13.0` we should bump the constraint