### PR TITLE
:green_heart: add cleanup step to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,3 +81,8 @@ jobs:
         id: skip_publish
         if: ${{ env.IS_VERSION_GREATER == 0 }}
         run: echo "Skipping publish for ${{ matrix.package }} because the version is not greater than the one on pub.dev"
+      - name: Cleanup
+        id: cleanup
+        if: ${{ always() }}
+        run: |
+          rm -rf $XDG_CONFIG_HOME/dart/pub-credentials.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,4 +85,4 @@ jobs:
         id: cleanup
         if: ${{ always() }}
         run: |
-          rm -rf $XDG_CONFIG_HOME/dart/pub-credentials.json
+          rm -rf "$XDG_CONFIG_HOME/dart/pub-credentials.json"


### PR DESCRIPTION
To keep the credentials safe, I added a `cleanup` step that deletes the credentials file and **always** runs at the end of the `publish` workflow.

```yml
- name: Cleanup
  id: cleanup
  if: ${{ always() }}
  run: |
    rm -rf "$XDG_CONFIG_HOME/dart/pub-credentials.json"
```