### PR TITLE
:sparkles: Generating files in different directories

### DIFF
--- a/chopper_generator/lib/chopper_generator.dart
+++ b/chopper_generator/lib/chopper_generator.dart
@@ -5,4 +5,4 @@ import 'package:build/build.dart';
 import 'src/generator.dart';
 
 Builder chopperGeneratorFactory(BuilderOptions options) =>
-    chopperGeneratorFactoryBuilder(header: options.config['header']);
+    chopperGeneratorFactoryBuilder(options);

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -634,10 +634,19 @@ class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
   }
 }
 
-Builder chopperGeneratorFactoryBuilder({String? header}) => PartBuilder(
+Builder chopperGeneratorFactoryBuilder(BuilderOptions options) => PartBuilder(
       [ChopperGenerator()],
       '.chopper.dart',
-      header: header,
+      header: options.config['header'],
+      formatOutput:
+          PartBuilder([ChopperGenerator()], '.chopper.dart').formatOutput,
+      options: !options.config.containsKey('build_extensions')
+          ? options.overrideWith(
+              BuilderOptions({
+                'build_extensions': {'.dart': '.chopper.dart'},
+              }),
+            )
+          : options,
     );
 
 bool getMethodOptionalBody(ConstantReader method) =>


### PR DESCRIPTION
Give the user the option for generating files in different directories, just as [described here](https://pub.dev/packages/source_gen#generating-files-in-different-directories).

Example of a `build.yml` that will put `*.chopper.dart` files in a custom `lib/generated` directory

```yaml
targets:
  $default:
    builders:
      chopper_generator:
        options:
          build_extensions:
            '^lib/{{}}.dart': 'lib/generated/{{}}.chopper.dart'
```

---

Addresses #443