### PR TITLE
:recycle: refactor chopper_generator

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -127,16 +127,16 @@ jobs:
       - job_001
       - job_002
   job_004:
-    name: "unit_test; PKGS: chopper, chopper_built_value; `dart pub global run coverage:test_with_coverage`"
+    name: "unit_test; PKGS: chopper, chopper_built_value, chopper_generator; `dart pub global run coverage:test_with_coverage`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:stable;packages:chopper-chopper_built_value;commands:test_with_coverage"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:stable;packages:chopper-chopper_built_value-chopper_generator;commands:test_with_coverage"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:stable;packages:chopper-chopper_built_value
+            os:ubuntu-latest;pub-cache-hosted;sdk:stable;packages:chopper-chopper_built_value-chopper_generator
             os:ubuntu-latest;pub-cache-hosted;sdk:stable
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -179,6 +179,21 @@ jobs:
           files: chopper_built_value/coverage/lcov.info
           fail_ci_if_error: true
           name: coverage_01
+      - id: chopper_generator_pub_upgrade
+        name: chopper_generator; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: chopper_generator
+      - name: "chopper_generator; dart pub global run coverage:test_with_coverage"
+        run: "dart pub global run coverage:test_with_coverage"
+        if: "always() && steps.chopper_generator_pub_upgrade.conclusion == 'success'"
+        working-directory: chopper_generator
+      - name: Upload coverage to codecov.io
+        uses: codecov/codecov-action@main
+        with:
+          files: chopper_generator/coverage/lcov.info
+          fail_ci_if_error: true
+          name: coverage_02
     needs:
       - job_001
       - job_002

--- a/chopper/pubspec.yaml
+++ b/chopper/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.0.0
   build_test: ^2.0.0
+  build_verify: ^3.1.0
   collection: ^1.16.0
   coverage: ^1.0.2
   dart_code_metrics: '>=4.8.1 <6.0.0'

--- a/chopper/test/ensure_build_test.dart
+++ b/chopper/test/ensure_build_test.dart
@@ -7,7 +7,7 @@ void main() {
   test(
     'ensure_build',
     () => expectBuildClean(
-      packageRelativeDirectory: 'chopper_generator',
+      packageRelativeDirectory: 'chopper',
       gitDiffPathArguments: [
         'test/test_service.chopper.dart',
       ],

--- a/chopper_generator/Makefile
+++ b/chopper_generator/Makefile
@@ -41,6 +41,10 @@ install:
 	@# Help: Install all the project's packages
 	dart pub get
 
+tests:
+	@# Help: Run Dart unit and widget tests for the current project.
+	dart test
+
 upgrade:
 	@# Help: Upgrade all the project's packages.
 	dart pub upgrade

--- a/chopper_generator/README.md
+++ b/chopper_generator/README.md
@@ -1,1 +1,10 @@
+# chopper_generator
+
+[![pub package](https://img.shields.io/pub/v/chopper_generator.svg)](https://pub.dartlang.org/packages/chopper_generator)
+
 This package provides the code generator for the [Chopper](https://github.com/lejard-h/chopper) package.
+
+## Usage
+
+For examples please refer to the main [Chopper](https://github.com/lejard-h/chopper) package and/or read the 
+[documentation](https://hadrien-lejard.gitbook.io/chopper).

--- a/chopper_generator/lib/chopper_generator.dart
+++ b/chopper_generator/lib/chopper_generator.dart
@@ -1,8 +1,3 @@
 library chopper_generator.dart;
 
-import 'package:build/build.dart';
-
-import 'src/generator.dart';
-
-Builder chopperGeneratorFactory(BuilderOptions options) =>
-    chopperGeneratorFactoryBuilder(options);
+export 'src/builder_factory.dart';

--- a/chopper_generator/lib/src/builder_factory.dart
+++ b/chopper_generator/lib/src/builder_factory.dart
@@ -3,8 +3,8 @@ import 'package:source_gen/source_gen.dart';
 
 import 'generator.dart';
 
-/// Creates a [PartBuilder] used to generate code for any [ChopperService].
-/// The [options] are provided by Dart's build system. It is read from the
+/// Creates a [PartBuilder] used to generate code for a [ChopperService].
+/// The [options] are provided by Dart's build system and read from the
 /// `build.yaml` file.
 Builder chopperGeneratorFactory(BuilderOptions options) => PartBuilder(
       [ChopperGenerator()],

--- a/chopper_generator/lib/src/builder_factory.dart
+++ b/chopper_generator/lib/src/builder_factory.dart
@@ -7,11 +7,11 @@ import 'generator.dart';
 /// The [options] are provided by Dart's build system and read from the
 /// `build.yaml` file.
 Builder chopperGeneratorFactory(BuilderOptions options) => PartBuilder(
-      [ChopperGenerator()],
+      [const ChopperGenerator()],
       '.chopper.dart',
       header: options.config['header'],
       formatOutput:
-          PartBuilder([ChopperGenerator()], '.chopper.dart').formatOutput,
+          PartBuilder([const ChopperGenerator()], '.chopper.dart').formatOutput,
       options: !options.config.containsKey('build_extensions')
           ? options.overrideWith(
               BuilderOptions({

--- a/chopper_generator/lib/src/builder_factory.dart
+++ b/chopper_generator/lib/src/builder_factory.dart
@@ -3,6 +3,9 @@ import 'package:source_gen/source_gen.dart';
 
 import 'generator.dart';
 
+/// Creates a [PartBuilder] used to generate code for any [ChopperService].
+/// The [options] are provided by Dart's build system. It is read from the
+/// `build.yaml` file.
 Builder chopperGeneratorFactory(BuilderOptions options) => PartBuilder(
       [ChopperGenerator()],
       '.chopper.dart',

--- a/chopper_generator/lib/src/builder_factory.dart
+++ b/chopper_generator/lib/src/builder_factory.dart
@@ -1,10 +1,11 @@
 import 'package:build/build.dart';
+import 'package:chopper/chopper.dart' show ChopperApi;
 import 'package:source_gen/source_gen.dart';
 
 import 'generator.dart';
 
-/// Creates a [PartBuilder] used to generate code for a [ChopperService].
-/// The [options] are provided by Dart's build system and read from the
+/// Creates a [PartBuilder] used to generate code for [ChopperApi] annotated
+/// classes. The [options] are provided by Dart's build system and read from the
 /// `build.yaml` file.
 Builder chopperGeneratorFactory(BuilderOptions options) => PartBuilder(
       [const ChopperGenerator()],

--- a/chopper_generator/lib/src/builder_factory.dart
+++ b/chopper_generator/lib/src/builder_factory.dart
@@ -1,0 +1,19 @@
+import 'package:build/build.dart';
+import 'package:source_gen/source_gen.dart';
+
+import 'generator.dart';
+
+Builder chopperGeneratorFactory(BuilderOptions options) => PartBuilder(
+      [ChopperGenerator()],
+      '.chopper.dart',
+      header: options.config['header'],
+      formatOutput:
+          PartBuilder([ChopperGenerator()], '.chopper.dart').formatOutput,
+      options: !options.config.containsKey('build_extensions')
+          ? options.overrideWith(
+              BuilderOptions({
+                'build_extensions': {'.dart': '.chopper.dart'},
+              }),
+            )
+          : options,
+    );

--- a/chopper_generator/lib/src/extensions.dart
+++ b/chopper_generator/lib/src/extensions.dart
@@ -1,0 +1,6 @@
+import 'package:analyzer/dart/element/nullability_suffix.dart';
+import 'package:analyzer/dart/element/type.dart';
+
+extension DartTypeExtension on DartType {
+  bool get isNullable => nullabilitySuffix != NullabilitySuffix.none;
+}

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -16,6 +16,8 @@ import 'package:logging/logging.dart';
 import 'package:source_gen/source_gen.dart';
 
 class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
+  const ChopperGenerator();
+
   static final Logger _logger = Logger('Chopper Generator');
 
   @override

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -25,10 +25,10 @@ class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
     BuildStep buildStep,
   ) {
     if (element is! ClassElement) {
-      final String friendlyName = element.displayName;
       throw InvalidGenerationSourceError(
-        'Generator cannot target `$friendlyName`.',
-        todo: 'Remove the [ChopperApi] annotation from `$friendlyName`.',
+        'Generator cannot target `${element.displayName}`.',
+        todo:
+            'Remove the [ChopperApi] annotation from `${element.displayName}`.',
       );
     }
 

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -1,5 +1,5 @@
 ///@nodoc
-import 'dart:async';
+import 'dart:async' show FutureOr;
 
 import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -1,4 +1,3 @@
-///@nodoc
 import 'dart:async' show FutureOr;
 
 import 'package:analyzer/dart/constant/value.dart';

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -15,6 +15,7 @@ import 'package:dart_style/dart_style.dart';
 import 'package:logging/logging.dart';
 import 'package:source_gen/source_gen.dart';
 
+/// Code generator for [chopper.ChopperApi] annotated classes.
 class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
   const ChopperGenerator();
 

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -72,8 +72,11 @@ class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
         ..methods.addAll(_parseMethods(element, baseUrl));
     });
 
-    final String ignore =
-        '// ignore_for_file: always_put_control_body_on_new_line, always_specify_types, prefer_const_declarations, unnecessary_brace_in_string_interps';
+    const String ignore = '// ignore_for_file: '
+        'always_put_control_body_on_new_line, '
+        'always_specify_types, '
+        'prefer_const_declarations, '
+        'unnecessary_brace_in_string_interps';
     final DartEmitter emitter = DartEmitter();
 
     return DartFormatter().format('$ignore\n${classBuilder.accept(emitter)}');

--- a/chopper_generator/lib/src/utils.dart
+++ b/chopper_generator/lib/src/utils.dart
@@ -1,0 +1,61 @@
+import 'package:analyzer/dart/element/element.dart';
+import 'package:chopper_generator/src/extensions.dart';
+import 'package:code_builder/code_builder.dart';
+import 'package:source_gen/source_gen.dart';
+
+class Utils {
+  static bool getMethodOptionalBody(ConstantReader method) =>
+      method.read('optionalBody').boolValue;
+
+  static String getMethodPath(ConstantReader method) =>
+      method.read('path').stringValue;
+
+  static String getMethodName(ConstantReader method) =>
+      method.read('method').stringValue;
+
+  static bool getUseBrackets(ConstantReader method) =>
+      method.peek('useBrackets')?.boolValue ?? false;
+
+  static bool getIncludeNullQueryVars(ConstantReader method) =>
+      method.peek('includeNullQueryVars')?.boolValue ?? false;
+
+  /// All positional required params must support nullability
+  static Parameter buildRequiredPositionalParam(ParameterElement p) =>
+      Parameter(
+        (ParameterBuilder pb) => pb
+          ..name = p.name
+          ..type = Reference(
+            p.type.getDisplayString(withNullability: p.type.isNullable),
+          ),
+      );
+
+  /// All optional positional params must support nullability
+  static Parameter buildOptionalPositionalParam(ParameterElement p) =>
+      Parameter((ParameterBuilder pb) {
+        pb
+          ..name = p.name
+          ..type = Reference(
+            p.type.getDisplayString(withNullability: p.type.isNullable),
+          );
+
+        if (p.defaultValueCode != null) {
+          pb.defaultTo = Code(p.defaultValueCode!);
+        }
+      });
+
+  /// Named params can be optional or required, they also need to support nullability
+  static Parameter buildNamedParam(ParameterElement p) =>
+      Parameter((ParameterBuilder pb) {
+        pb
+          ..named = true
+          ..name = p.name
+          ..required = p.isRequiredNamed
+          ..type = Reference(
+            p.type.getDisplayString(withNullability: p.type.isNullable),
+          );
+
+        if (p.defaultValueCode != null) {
+          pb.defaultTo = Code(p.defaultValueCode!);
+        }
+      });
+}

--- a/chopper_generator/lib/src/vars.dart
+++ b/chopper_generator/lib/src/vars.dart
@@ -1,0 +1,17 @@
+enum Vars {
+  client('client'),
+  baseUrl('baseUrl'),
+  parameters(r'$params'),
+  headers(r'$headers'),
+  request(r'$request'),
+  body(r'$body'),
+  parts(r'$parts'),
+  url(r'$url');
+
+  const Vars(this.name);
+
+  final String name;
+
+  @override
+  String toString() => name;
+}

--- a/chopper_generator/mono_pkg.yaml
+++ b/chopper_generator/mono_pkg.yaml
@@ -6,6 +6,8 @@ stages:
   - group:
     - format
     - analyze: --fatal-infos .
+- unit_test:
+  - test_with_coverage:
 
 cache:
   directories:

--- a/chopper_generator/pubspec.yaml
+++ b/chopper_generator/pubspec.yaml
@@ -19,9 +19,12 @@ dependencies:
   source_gen: ^1.0.0
 
 dev_dependencies:
-  test: ^1.16.4
+  build_runner: ^2.0.0
+  build_verify: ^3.1.0
   dart_code_metrics: '>=4.8.1 <6.0.0'
+  http: ">=0.13.0 <2.0.0"
   lints: ^2.0.0
+  test: ^1.16.4
 
 dependency_overrides:
   # Comment before publish

--- a/chopper_generator/test/ensure_build_test.dart
+++ b/chopper_generator/test/ensure_build_test.dart
@@ -1,5 +1,4 @@
 @TestOn('vm')
-
 import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart';
 

--- a/chopper_generator/test/ensure_build_test.dart
+++ b/chopper_generator/test/ensure_build_test.dart
@@ -1,0 +1,14 @@
+import 'package:build_verify/build_verify.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test(
+    'ensure_build',
+    () => expectBuildClean(
+      packageRelativeDirectory: 'chopper_generator',
+      gitDiffPathArguments: [
+        'test/test_service.chopper.dart',
+      ],
+    ),
+  );
+}

--- a/chopper_generator/test/ensure_build_test.dart
+++ b/chopper_generator/test/ensure_build_test.dart
@@ -1,3 +1,5 @@
+@TestOn('vm')
+
 import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart';
 

--- a/chopper_generator/test/test_service.chopper.dart
+++ b/chopper_generator/test/test_service.chopper.dart
@@ -1,0 +1,639 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'test_service.dart';
+
+// **************************************************************************
+// ChopperGenerator
+// **************************************************************************
+
+// ignore_for_file: always_put_control_body_on_new_line, always_specify_types, prefer_const_declarations, unnecessary_brace_in_string_interps
+class _$HttpTestService extends HttpTestService {
+  _$HttpTestService([ChopperClient? client]) {
+    if (client == null) return;
+    this.client = client;
+  }
+
+  @override
+  final definitionType = HttpTestService;
+
+  @override
+  Future<Response<String>> getTest(
+    String id, {
+    required String dynamicHeader,
+  }) {
+    final Uri $url = Uri.parse('/test/get/${id}');
+    final Map<String, String> $headers = {
+      'test': dynamicHeader,
+    };
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      headers: $headers,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> headTest() {
+    final Uri $url = Uri.parse('/test/head');
+    final Request $request = Request(
+      'HEAD',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> optionsTest() {
+    final Uri $url = Uri.parse('/test/options');
+    final Request $request = Request(
+      'OPTIONS',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<Stream<List<int>>>> getStreamTest() {
+    final Uri $url = Uri.parse('/test/get');
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<Stream<List<int>>, int>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getAll() {
+    final Uri $url = Uri.parse('/test');
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getAllWithTrailingSlash() {
+    final Uri $url = Uri.parse('/test/');
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getQueryTest({
+    String name = '',
+    int? number,
+    int? def = 42,
+  }) {
+    final Uri $url = Uri.parse('/test/query');
+    final Map<String, dynamic> $params = <String, dynamic>{
+      'name': name,
+      'int': number,
+      'default_value': def,
+    };
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getQueryMapTest(Map<String, dynamic> query) {
+    final Uri $url = Uri.parse('/test/query_map');
+    final Map<String, dynamic> $params = query;
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getQueryMapTest2(
+    Map<String, dynamic> query, {
+    bool? test,
+  }) {
+    final Uri $url = Uri.parse('/test/query_map');
+    final Map<String, dynamic> $params = <String, dynamic>{'test': test};
+    $params.addAll(query);
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getQueryMapTest3({
+    String name = '',
+    int? number,
+    Map<String, dynamic> filters = const {},
+  }) {
+    final Uri $url = Uri.parse('/test/query_map');
+    final Map<String, dynamic> $params = <String, dynamic>{
+      'name': name,
+      'number': number,
+    };
+    $params.addAll(filters);
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getQueryMapTest4({
+    String name = '',
+    int? number,
+    Map<String, dynamic>? filters,
+  }) {
+    final Uri $url = Uri.parse('/test/query_map');
+    final Map<String, dynamic> $params = <String, dynamic>{
+      'name': name,
+      'number': number,
+    };
+    $params.addAll(filters ?? const {});
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getQueryMapTest5({Map<String, dynamic>? filters}) {
+    final Uri $url = Uri.parse('/test/query_map');
+    final Map<String, dynamic> $params = filters ?? const {};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getBody(dynamic body) {
+    final Uri $url = Uri.parse('/test/get_body');
+    final $body = body;
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postTest(String data) {
+    final Uri $url = Uri.parse('/test/post');
+    final $body = data;
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postStreamTest(Stream<List<int>> byteStream) {
+    final Uri $url = Uri.parse('/test/post');
+    final $body = byteStream;
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> putTest(
+    String test,
+    String data,
+  ) {
+    final Uri $url = Uri.parse('/test/put/${test}');
+    final $body = data;
+    final Request $request = Request(
+      'PUT',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> deleteTest(String id) {
+    final Uri $url = Uri.parse('/test/delete/${id}');
+    final Map<String, String> $headers = {
+      'foo': 'bar',
+    };
+    final Request $request = Request(
+      'DELETE',
+      $url,
+      client.baseUrl,
+      headers: $headers,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> patchTest(
+    String id,
+    String data,
+  ) {
+    final Uri $url = Uri.parse('/test/patch/${id}');
+    final $body = data;
+    final Request $request = Request(
+      'PATCH',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> mapTest(Map<String, String> map) {
+    final Uri $url = Uri.parse('/test/map');
+    final $body = map;
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postForm(Map<String, String> fields) {
+    final Uri $url = Uri.parse('/test/form/body');
+    final $body = fields;
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>(
+      $request,
+      requestConverter: convertForm,
+    );
+  }
+
+  @override
+  Future<Response<dynamic>> postFormUsingHeaders(Map<String, String> fields) {
+    final Uri $url = Uri.parse('/test/form/body');
+    final Map<String, String> $headers = {
+      'content-type': 'application/x-www-form-urlencoded',
+    };
+    final $body = fields;
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      body: $body,
+      headers: $headers,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postFormFields(
+    String foo,
+    int bar,
+  ) {
+    final Uri $url = Uri.parse('/test/form/body/fields');
+    final $body = <String, dynamic>{
+      'foo': foo,
+      'bar': bar,
+    };
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>(
+      $request,
+      requestConverter: convertForm,
+    );
+  }
+
+  @override
+  Future<Response<dynamic>> forceJsonTest(Map<dynamic, dynamic> map) {
+    final Uri $url = Uri.parse('/test/map/json');
+    final $body = map;
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>(
+      $request,
+      requestConverter: customConvertRequest,
+      responseConverter: customConvertResponse,
+    );
+  }
+
+  @override
+  Future<Response<dynamic>> postResources(
+    Map<dynamic, dynamic> a,
+    Map<dynamic, dynamic> b,
+  ) {
+    final Uri $url = Uri.parse('/test/multi');
+    final List<PartValue> $parts = <PartValue>[
+      PartValue<Map<dynamic, dynamic>>(
+        '1',
+        a,
+      ),
+      PartValue<Map<dynamic, dynamic>>(
+        '2',
+        b,
+      ),
+    ];
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      parts: $parts,
+      multipart: true,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postFile(List<int> bytes) {
+    final Uri $url = Uri.parse('/test/file');
+    final List<PartValue> $parts = <PartValue>[
+      PartValueFile<List<int>>(
+        'file',
+        bytes,
+      )
+    ];
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      parts: $parts,
+      multipart: true,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postImage(List<int> imageData) {
+    final Uri $url = Uri.parse('/test/image');
+    final List<PartValue> $parts = <PartValue>[
+      PartValueFile<List<int>>(
+        'image',
+        imageData,
+      )
+    ];
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      parts: $parts,
+      multipart: true,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postMultipartFile(
+    MultipartFile file, {
+    String? id,
+  }) {
+    final Uri $url = Uri.parse('/test/file');
+    final List<PartValue> $parts = <PartValue>[
+      PartValue<String?>(
+        'id',
+        id,
+      ),
+      PartValueFile<MultipartFile>(
+        'file',
+        file,
+      ),
+    ];
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      parts: $parts,
+      multipart: true,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postListFiles(List<MultipartFile> files) {
+    final Uri $url = Uri.parse('/test/files');
+    final List<PartValue> $parts = <PartValue>[
+      PartValueFile<List<MultipartFile>>(
+        'files',
+        files,
+      )
+    ];
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      parts: $parts,
+      multipart: true,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postMultipartList({
+    required List<int> ints,
+    required List<double> doubles,
+    required List<num> nums,
+    required List<String> strings,
+  }) {
+    final Uri $url = Uri.parse('/test/multipart_list');
+    final List<PartValue> $parts = <PartValue>[
+      PartValue<List<int>>(
+        'ints',
+        ints,
+      ),
+      PartValue<List<double>>(
+        'doubles',
+        doubles,
+      ),
+      PartValue<List<num>>(
+        'nums',
+        nums,
+      ),
+      PartValue<List<String>>(
+        'strings',
+        strings,
+      ),
+    ];
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      parts: $parts,
+      multipart: true,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<dynamic> fullUrl() {
+    final Uri $url = Uri.parse('https://test.com');
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+    );
+    return client.send($request);
+  }
+
+  @override
+  Future<Response<List<String>>> listString() {
+    final Uri $url = Uri.parse('/test/list/string');
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<List<String>, String>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> noBody() {
+    final Uri $url = Uri.parse('/test/no-body');
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<String>> getUsingQueryParamIncludeNullQueryVars({
+    String? foo,
+    String? bar,
+    String? baz,
+  }) {
+    final Uri $url = Uri.parse('/test/query_param_include_null_query_vars');
+    final Map<String, dynamic> $params = <String, dynamic>{
+      'foo': foo,
+      'bar': bar,
+      'baz': baz,
+    };
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      includeNullQueryVars: true,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getUsingListQueryParam(List<String> value) {
+    final Uri $url = Uri.parse('/test/list_query_param');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getUsingListQueryParamWithBrackets(
+      List<String> value) {
+    final Uri $url = Uri.parse('/test/list_query_param_with_brackets');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      useBrackets: true,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getUsingMapQueryParam(Map<String, dynamic> value) {
+    final Uri $url = Uri.parse('/test/map_query_param');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getUsingMapQueryParamIncludeNullQueryVars(
+      Map<String, dynamic> value) {
+    final Uri $url = Uri.parse('/test/map_query_param_include_null_query_vars');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      includeNullQueryVars: true,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getUsingMapQueryParamWithBrackets(
+      Map<String, dynamic> value) {
+    final Uri $url = Uri.parse('/test/map_query_param_with_brackets');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      useBrackets: true,
+    );
+    return client.send<String, String>($request);
+  }
+}

--- a/chopper_generator/test/test_service.dart
+++ b/chopper_generator/test/test_service.dart
@@ -1,0 +1,218 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:chopper/chopper.dart';
+import 'package:http/http.dart' show MultipartFile;
+
+part 'test_service.chopper.dart';
+
+@ChopperApi(baseUrl: '/test')
+abstract class HttpTestService extends ChopperService {
+  static HttpTestService create([ChopperClient? client]) =>
+      _$HttpTestService(client);
+
+  @Get(path: 'get/{id}')
+  Future<Response<String>> getTest(
+    @Path() String id, {
+    @Header('test') required String dynamicHeader,
+  });
+
+  @Head(path: 'head')
+  Future<Response> headTest();
+
+  @Options(path: 'options')
+  Future<Response> optionsTest();
+
+  @Get(path: 'get')
+  Future<Response<Stream<List<int>>>> getStreamTest();
+
+  @Get(path: '')
+  Future<Response> getAll();
+
+  @Get(path: '/')
+  Future<Response> getAllWithTrailingSlash();
+
+  @Get(path: 'query')
+  Future<Response> getQueryTest({
+    @Query('name') String name = '',
+    @Query('int') int? number,
+    @Query('default_value') int? def = 42,
+  });
+
+  @Get(path: 'query_map')
+  Future<Response> getQueryMapTest(@QueryMap() Map<String, dynamic> query);
+
+  @Get(path: 'query_map')
+  Future<Response> getQueryMapTest2(
+    @QueryMap() Map<String, dynamic> query, {
+    @Query('test') bool? test,
+  });
+
+  @Get(path: 'query_map')
+  Future<Response> getQueryMapTest3({
+    @Query('name') String name = '',
+    @Query('number') int? number,
+    @QueryMap() Map<String, dynamic> filters = const {},
+  });
+
+  @Get(path: 'query_map')
+  Future<Response> getQueryMapTest4({
+    @Query('name') String name = '',
+    @Query('number') int? number,
+    @QueryMap() Map<String, dynamic>? filters,
+  });
+
+  @Get(path: 'query_map')
+  Future<Response> getQueryMapTest5({
+    @QueryMap() Map<String, dynamic>? filters,
+  });
+
+  @Get(path: 'get_body')
+  Future<Response> getBody(@Body() dynamic body);
+
+  @Post(path: 'post')
+  Future<Response> postTest(@Body() String data);
+
+  @Post(path: 'post')
+  Future<Response> postStreamTest(@Body() Stream<List<int>> byteStream);
+
+  @Put(path: 'put/{id}')
+  Future<Response> putTest(@Path('id') String test, @Body() String data);
+
+  @Delete(path: 'delete/{id}', headers: {'foo': 'bar'})
+  Future<Response> deleteTest(@Path() String id);
+
+  @Patch(path: 'patch/{id}')
+  Future<Response> patchTest(@Path() String id, @Body() String data);
+
+  @Post(path: 'map')
+  Future<Response> mapTest(@Body() Map<String, String> map);
+
+  @FactoryConverter(request: convertForm)
+  @Post(path: 'form/body')
+  Future<Response> postForm(@Body() Map<String, String> fields);
+
+  @Post(path: 'form/body', headers: {contentTypeKey: formEncodedHeaders})
+  Future<Response> postFormUsingHeaders(@Body() Map<String, String> fields);
+
+  @FactoryConverter(request: convertForm)
+  @Post(path: 'form/body/fields')
+  Future<Response> postFormFields(@Field() String foo, @Field() int bar);
+
+  @Post(path: 'map/json')
+  @FactoryConverter(
+    request: customConvertRequest,
+    response: customConvertResponse,
+  )
+  Future<Response> forceJsonTest(@Body() Map map);
+
+  @Post(path: 'multi')
+  @multipart
+  Future<Response> postResources(
+    @Part('1') Map a,
+    @Part('2') Map b,
+  );
+
+  @Post(path: 'file')
+  @multipart
+  Future<Response> postFile(
+    @PartFile('file') List<int> bytes,
+  );
+
+  @Post(path: 'image')
+  @multipart
+  Future<Response> postImage(
+    @PartFile('image') List<int> imageData,
+  );
+
+  @Post(path: 'file')
+  @multipart
+  Future<Response> postMultipartFile(
+    @PartFile() MultipartFile file, {
+    @Part() String? id,
+  });
+
+  @Post(path: 'files')
+  @multipart
+  Future<Response> postListFiles(@PartFile() List<MultipartFile> files);
+
+  @Post(path: 'multipart_list')
+  @multipart
+  Future<Response> postMultipartList({
+    @Part('ints') required List<int> ints,
+    @Part('doubles') required List<double> doubles,
+    @Part('nums') required List<num> nums,
+    @Part('strings') required List<String> strings,
+  });
+
+  @Get(path: 'https://test.com')
+  Future fullUrl();
+
+  @Get(path: '/list/string')
+  Future<Response<List<String>>> listString();
+
+  @Post(path: 'no-body')
+  Future<Response> noBody();
+
+  @Get(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
+  Future<Response<String>> getUsingQueryParamIncludeNullQueryVars({
+    @Query('foo') String? foo,
+    @Query('bar') String? bar,
+    @Query('baz') String? baz,
+  });
+
+  @Get(path: '/list_query_param')
+  Future<Response<String>> getUsingListQueryParam(
+    @Query('value') List<String> value,
+  );
+
+  @Get(path: '/list_query_param_with_brackets', useBrackets: true)
+  Future<Response<String>> getUsingListQueryParamWithBrackets(
+    @Query('value') List<String> value,
+  );
+
+  @Get(path: '/map_query_param')
+  Future<Response<String>> getUsingMapQueryParam(
+    @Query('value') Map<String, dynamic> value,
+  );
+
+  @Get(
+    path: '/map_query_param_include_null_query_vars',
+    includeNullQueryVars: true,
+  )
+  Future<Response<String>> getUsingMapQueryParamIncludeNullQueryVars(
+    @Query('value') Map<String, dynamic> value,
+  );
+
+  @Get(path: '/map_query_param_with_brackets', useBrackets: true)
+  Future<Response<String>> getUsingMapQueryParamWithBrackets(
+    @Query('value') Map<String, dynamic> value,
+  );
+}
+
+Request customConvertRequest(Request req) {
+  final r = JsonConverter().convertRequest(req);
+
+  return applyHeader(r, 'customConverter', 'true');
+}
+
+Response<T> customConvertResponse<T>(Response res) =>
+    res.copyWith(body: json.decode(res.body));
+
+Request convertForm(Request req) {
+  req = applyHeader(req, contentTypeKey, formEncodedHeaders);
+
+  if (req.body is Map) {
+    final body = <String, String>{};
+
+    req.body.forEach((key, val) {
+      if (val != null) {
+        body[key.toString()] = val.toString();
+      }
+    });
+
+    req = req.copyWith(body: body);
+  }
+
+  return req;
+}


### PR DESCRIPTION
# :recycle: refactor chopper_generator

- [x] simplify library export
- [x] extract `PartBuilder` into its own file
- [x] extract constant variables into an `enum` 
- [x] extract helper methods into a `Utils` class
- [x] use a `const` constructor
- [x] make all  methods `static`
- [x] ensure all immutable variables are `final`
- [x] simplify syntax 
- [x] add API documentation 
- [x] add [build_verify](https://github.com/kevmoo/build_verify) test
- [x] add [build_verify](https://github.com/kevmoo/build_verify) test to chopper as well because it also uses generated files in the test suite
- [x] update README 