### PR TITLE
:sparkles: implement Dart 3 class modifiers

### DIFF
--- a/chopper/lib/src/annotations.dart
+++ b/chopper/lib/src/annotations.dart
@@ -20,7 +20,7 @@ import 'package:meta/meta.dart';
 ///
 /// See [Method] to define an HTTP request
 @immutable
-class ChopperApi {
+final class ChopperApi {
   /// A part of a URL that every request defined inside a class annotated with [ChopperApi] will be prefixed with.
   final String baseUrl;
 
@@ -42,7 +42,7 @@ class ChopperApi {
 /// Future<Response> fetch(@Path() String param);
 /// ```
 @immutable
-class Path {
+final class Path {
   /// Name is used to bind a method parameter to
   /// a URL path parameter.
   /// ```dart
@@ -65,7 +65,7 @@ class Path {
 ///
 /// See [QueryMap] to pass an [Map<String, dynamic>] as value
 @immutable
-class Query {
+final class Query {
   /// Name is used to bind a method parameter to
   /// the query parameter.
   /// ```dart
@@ -90,7 +90,7 @@ class Query {
 /// // something?foo=bar&list=1&list=2
 /// ```
 @immutable
-class QueryMap {
+final class QueryMap {
   const QueryMap();
 }
 
@@ -104,7 +104,7 @@ class QueryMap {
 /// The body can be of any type, but chopper does not automatically convert it to JSON.
 /// See [Converter] to apply conversion to the body.
 @immutable
-class Body {
+final class Body {
   const Body();
 }
 
@@ -117,7 +117,7 @@ class Body {
 /// Future<Response> fetch(@Header() String foo);
 /// ```
 @immutable
-class Header {
+final class Header {
   /// Name is used to bind a method parameter to
   /// a header name.
   /// ```dart
@@ -147,7 +147,7 @@ class Header {
 /// However, chopper will not automatically convert the body response to your type.
 /// A [Converter] needs to be specified for conversion.
 @immutable
-class Method {
+sealed class Method {
   /// HTTP method for the request
   final String method;
 
@@ -207,7 +207,7 @@ class Method {
 
 /// Defines a method as an HTTP GET request.
 @immutable
-class Get extends Method {
+final class Get extends Method {
   const Get({
     super.optionalBody = true,
     super.path,
@@ -221,7 +221,7 @@ class Get extends Method {
 ///
 /// Use the [Body] annotation to pass data to send.
 @immutable
-class Post extends Method {
+final class Post extends Method {
   const Post({
     super.optionalBody,
     super.path,
@@ -233,7 +233,7 @@ class Post extends Method {
 
 /// Defines a method as an HTTP DELETE request.
 @immutable
-class Delete extends Method {
+final class Delete extends Method {
   const Delete({
     super.optionalBody = true,
     super.path,
@@ -247,7 +247,7 @@ class Delete extends Method {
 ///
 /// Use the [Body] annotation to pass data to send.
 @immutable
-class Put extends Method {
+final class Put extends Method {
   const Put({
     super.optionalBody,
     super.path,
@@ -260,7 +260,7 @@ class Put extends Method {
 /// Defines a method as an HTTP PATCH request.
 /// Use the [Body] annotation to pass data to send.
 @immutable
-class Patch extends Method {
+final class Patch extends Method {
   const Patch({
     super.optionalBody,
     super.path,
@@ -272,7 +272,7 @@ class Patch extends Method {
 
 /// Defines a method as an HTTP HEAD request.
 @immutable
-class Head extends Method {
+final class Head extends Method {
   const Head({
     super.optionalBody = true,
     super.path,
@@ -283,7 +283,7 @@ class Head extends Method {
 }
 
 @immutable
-class Options extends Method {
+final class Options extends Method {
   const Options({
     super.optionalBody = true,
     super.path,
@@ -330,7 +330,7 @@ typedef ConvertResponse<T> = FutureOr<Response> Function(Response response);
 /// }
 /// ```
 @immutable
-class FactoryConverter {
+final class FactoryConverter {
   final ConvertRequest? request;
   final ConvertResponse? response;
 
@@ -349,7 +349,7 @@ class FactoryConverter {
 /// ```
 /// Will be converted to `{ 'name': value }`.
 @immutable
-class Field {
+final class Field {
   /// Name can be use to specify the name of the field
   /// ```dart
   /// @Post(path: '/')
@@ -367,7 +367,7 @@ class Field {
 /// Future<Response> fetch(@FieldMap List<Map<String, dynamic>> query);
 /// ```
 @immutable
-class FieldMap {
+final class FieldMap {
   const FieldMap();
 }
 
@@ -382,7 +382,7 @@ class FieldMap {
 /// Use [Part] annotation to send simple data.
 /// Use [PartFile] annotation to send `File` or `List<int>`.
 @immutable
-class Multipart {
+final class Multipart {
   const Multipart();
 }
 
@@ -392,7 +392,7 @@ class Multipart {
 ///
 /// Also accepts `MultipartFile` (from package:http).
 @immutable
-class Part {
+final class Part {
   final String? name;
 
   const Part([this.name]);
@@ -406,7 +406,7 @@ class Part {
 /// Future<Response> fetch(@PartMap() List<PartValue> query);
 /// ```
 @immutable
-class PartMap {
+final class PartMap {
   const PartMap();
 }
 
@@ -423,7 +423,7 @@ class PartMap {
 ///   - [String] (path of your file)
 ///   - `MultipartFile` (from package:http)
 @immutable
-class PartFile {
+final class PartFile {
   final String? name;
 
   const PartFile([this.name]);
@@ -437,7 +437,7 @@ class PartFile {
 /// Future<Response> fetch(@PartFileMap() List<PartValueFile> query);
 /// ```
 @immutable
-class PartFileMap {
+final class PartFileMap {
   const PartFileMap();
 }
 

--- a/chopper/lib/src/base.dart
+++ b/chopper/lib/src/base.dart
@@ -26,7 +26,7 @@ final List<Type> allowedInterceptorsType = [
 ///
 /// It manages registered services, encodes and decodes data, and intercepts
 /// requests and responses.
-class ChopperClient {
+base class ChopperClient {
   /// Base URL of each request of the registered services.
   /// E.g., the hostname of your service.
   final Uri baseUrl;

--- a/chopper/lib/src/base.dart
+++ b/chopper/lib/src/base.dart
@@ -13,7 +13,7 @@ import 'package:meta/meta.dart';
 Type _typeOf<T>() => T;
 
 @visibleForTesting
-final List<Type> allowedInterceptorsType = [
+const List<Type> allowedInterceptorsType = [
   RequestInterceptor,
   RequestInterceptorFunc,
   ResponseInterceptor,

--- a/chopper/lib/src/constants.dart
+++ b/chopper/lib/src/constants.dart
@@ -7,7 +7,7 @@ const String formEncodedHeaders = 'application/x-www-form-urlencoded';
 // Represent the header for a json api response https://jsonapi.org/#mime-types
 const String jsonApiHeaders = 'application/vnd.api+json';
 
-abstract class HttpMethod {
+abstract final class HttpMethod {
   static const String Get = 'GET';
   static const String Post = 'POST';
   static const String Put = 'PUT';

--- a/chopper/lib/src/http_logging_interceptor.dart
+++ b/chopper/lib/src/http_logging_interceptor.dart
@@ -69,7 +69,7 @@ enum Level {
 /// in response bodies. This interceptor should only be used in a controlled way
 /// or in a non-production environment.
 @immutable
-class HttpLoggingInterceptor
+final class HttpLoggingInterceptor
     implements RequestInterceptor, ResponseInterceptor {
   const HttpLoggingInterceptor({this.level = Level.body})
       : _logBody = level == Level.body,

--- a/chopper/lib/src/http_logging_interceptor.dart
+++ b/chopper/lib/src/http_logging_interceptor.dart
@@ -69,7 +69,7 @@ enum Level {
 /// in response bodies. This interceptor should only be used in a controlled way
 /// or in a non-production environment.
 @immutable
-final class HttpLoggingInterceptor
+class HttpLoggingInterceptor
     implements RequestInterceptor, ResponseInterceptor {
   const HttpLoggingInterceptor({this.level = Level.body})
       : _logBody = level == Level.body,

--- a/chopper/lib/src/interceptor.dart
+++ b/chopper/lib/src/interceptor.dart
@@ -105,7 +105,7 @@ abstract interface class ErrorConverter {
 /// Note that this interceptor will overwrite existing headers having the same
 /// keys as [headers].
 @immutable
-final class HeadersInterceptor implements RequestInterceptor {
+class HeadersInterceptor implements RequestInterceptor {
   final Map<String, String> headers;
 
   const HeadersInterceptor(this.headers);
@@ -133,7 +133,7 @@ typedef RequestInterceptorFunc = FutureOr<Request> Function(Request request);
 ///
 /// Thanks, @edwardaux
 @immutable
-final class CurlInterceptor implements RequestInterceptor {
+class CurlInterceptor implements RequestInterceptor {
   @override
   Future<Request> onRequest(Request request) async {
     final http.BaseRequest baseRequest = await request.toBaseRequest();

--- a/chopper/lib/src/interceptor.dart
+++ b/chopper/lib/src/interceptor.dart
@@ -31,7 +31,7 @@ import 'package:meta/meta.dart';
 /// }
 /// ```
 @immutable
-abstract class ResponseInterceptor {
+abstract interface class ResponseInterceptor {
   FutureOr<Response> onResponse(Response response);
 }
 
@@ -58,7 +58,7 @@ abstract class ResponseInterceptor {
 ///
 /// (See [applyHeader(request, name, value)] and [applyHeaders(request, headers)].)
 @immutable
-abstract class RequestInterceptor {
+abstract interface class RequestInterceptor {
   FutureOr<Request> onRequest(Request request);
 }
 
@@ -72,7 +72,7 @@ abstract class RequestInterceptor {
 ///
 /// See [JsonConverter] and [FormUrlEncodedConverter] for example implementations.
 @immutable
-abstract class Converter {
+abstract interface class Converter {
   /// Converts the received [Request] to a [Request] which has a body with the
   /// HTTP representation of the original body.
   FutureOr<Request> convertRequest(Request request);
@@ -94,7 +94,7 @@ abstract class Converter {
 ///
 /// An `ErrorConverter` is called only on error responses
 /// (statusCode < 200 || statusCode >= 300) and before any [ResponseInterceptor]s.
-abstract class ErrorConverter {
+abstract interface class ErrorConverter {
   /// Converts the received [Response] to a [Response] which has a body with the
   /// HTTP representation of the original body.
   FutureOr<Response> convertError<BodyType, InnerType>(Response response);
@@ -105,7 +105,7 @@ abstract class ErrorConverter {
 /// Note that this interceptor will overwrite existing headers having the same
 /// keys as [headers].
 @immutable
-class HeadersInterceptor implements RequestInterceptor {
+final class HeadersInterceptor implements RequestInterceptor {
   final Map<String, String> headers;
 
   const HeadersInterceptor(this.headers);
@@ -133,7 +133,7 @@ typedef RequestInterceptorFunc = FutureOr<Request> Function(Request request);
 ///
 /// Thanks, @edwardaux
 @immutable
-class CurlInterceptor implements RequestInterceptor {
+final class CurlInterceptor implements RequestInterceptor {
   @override
   Future<Request> onRequest(Request request) async {
     final http.BaseRequest baseRequest = await request.toBaseRequest();

--- a/chopper/lib/src/request.dart
+++ b/chopper/lib/src/request.dart
@@ -7,7 +7,7 @@ import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 
 /// This class represents an HTTP request that can be made with Chopper.
-final class Request extends http.BaseRequest with EquatableMixin {
+base class Request extends http.BaseRequest with EquatableMixin {
   final Uri uri;
   final Uri baseUri;
   final dynamic body;
@@ -232,7 +232,7 @@ final class Request extends http.BaseRequest with EquatableMixin {
 
 /// Represents a part in a multipart request.
 @immutable
-class PartValue<T> with EquatableMixin {
+final class PartValue<T> with EquatableMixin {
   final T value;
   final String name;
 
@@ -258,6 +258,6 @@ class PartValue<T> with EquatableMixin {
 
 /// Represents a file [PartValue] in a multipart request.
 @immutable
-class PartValueFile<T> extends PartValue<T> {
+final class PartValueFile<T> extends PartValue<T> {
   const PartValueFile(super.name, super.value);
 }

--- a/chopper/lib/src/request.dart
+++ b/chopper/lib/src/request.dart
@@ -7,7 +7,7 @@ import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 
 /// This class represents an HTTP request that can be made with Chopper.
-class Request extends http.BaseRequest with EquatableMixin {
+final class Request extends http.BaseRequest with EquatableMixin {
   final Uri uri;
   final Uri baseUri;
   final dynamic body;

--- a/chopper/lib/src/response.dart
+++ b/chopper/lib/src/response.dart
@@ -16,7 +16,7 @@ import 'package:meta/meta.dart';
 /// Future<Response<Item>> fetchItem();
 /// ```
 @immutable
-final class Response<BodyType> with EquatableMixin {
+base class Response<BodyType> with EquatableMixin {
   /// The [http.BaseResponse] from `package:http` that this [Response] wraps.
   final http.BaseResponse base;
 

--- a/chopper/lib/src/response.dart
+++ b/chopper/lib/src/response.dart
@@ -16,7 +16,7 @@ import 'package:meta/meta.dart';
 /// Future<Response<Item>> fetchItem();
 /// ```
 @immutable
-class Response<BodyType> with EquatableMixin {
+final class Response<BodyType> with EquatableMixin {
   /// The [http.BaseResponse] from `package:http` that this [Response] wraps.
   final http.BaseResponse base;
 

--- a/chopper/lib/src/utils.dart
+++ b/chopper/lib/src/utils.dart
@@ -131,7 +131,7 @@ Iterable<_Pair<String, String>> _iterableToQuery(
 
 String _normalizeValue(value) => Uri.encodeComponent(value?.toString() ?? '');
 
-class _Pair<A, B> with EquatableMixin {
+final class _Pair<A, B> with EquatableMixin {
   final A first;
   final B second;
   final bool useBrackets;

--- a/chopper/pubspec.yaml
+++ b/chopper/pubspec.yaml
@@ -1,29 +1,29 @@
 name: chopper
 description: Chopper is an http client generator using source_gen, inspired by Retrofit
-version: 6.1.4
+version: 7.0.0
 documentation: https://hadrien-lejard.gitbook.io/chopper
 repository: https://github.com/lejard-h/chopper
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   equatable: ^2.0.5
-  http: ">=0.13.0 <2.0.0"
-  logging: ^1.0.0
-  meta: ^1.3.0
+  http: ^1.1.0
+  logging: ^1.2.0
+  meta: ^1.9.1
 
 dev_dependencies:
-  build_runner: ^2.0.0
-  build_test: ^2.0.0
+  build_runner: ^2.4.6
+  build_test: ^2.2.0
   build_verify: ^3.1.0
-  collection: ^1.16.0
-  coverage: ^1.0.2
+  collection: ^1.18.0
+  coverage: ^1.6.3
   data_fixture_dart: ^2.2.0
   faker: ^2.1.0
-  http_parser: ^4.0.0
-  lints: ^2.0.0
-  test: ^1.16.4
-  transparent_image: ^2.0.0
+  http_parser: ^4.0.2
+  lints: ^2.1.1
+  test: ^1.24.4
+  transparent_image: ^2.0.1
   chopper_generator:
     path: ../chopper_generator

--- a/chopper/test/fixtures/http_response_fixture.dart
+++ b/chopper/test/fixtures/http_response_fixture.dart
@@ -12,7 +12,7 @@ extension ResponseFixture on http.Response {
 }
 
 @internal
-class ResponseFactory extends FixtureFactory<http.Response> {
+final class ResponseFactory extends FixtureFactory<http.Response> {
   @override
   FixtureDefinition<http.Response> definition() => define(
         (Faker faker) => http.Response(

--- a/chopper/test/fixtures/payload_fixture.dart
+++ b/chopper/test/fixtures/payload_fixture.dart
@@ -8,7 +8,7 @@ extension PayloadFixture on Payload {
 }
 
 @internal
-class PayloadFactory extends FixtureFactory<Payload> {
+final class PayloadFactory extends FixtureFactory<Payload> {
   @override
   FixtureDefinition<Payload> definition() => define(
         (Faker faker) => Payload(

--- a/chopper/test/fixtures/request_fixture.dart
+++ b/chopper/test/fixtures/request_fixture.dart
@@ -9,7 +9,7 @@ extension RequestFixture on Request {
 }
 
 @internal
-class RequestFixtureFactory extends FixtureFactory<Request> {
+final class RequestFixtureFactory extends FixtureFactory<Request> {
   @override
   FixtureDefinition<Request> definition() {
     final String method =

--- a/chopper/test/fixtures/response_fixture.dart
+++ b/chopper/test/fixtures/response_fixture.dart
@@ -10,7 +10,7 @@ extension ResponseFixture on Response {
 }
 
 @internal
-class ResponseFixtureFactory<T> extends FixtureFactory<Response<T>> {
+final class ResponseFixtureFactory<T> extends FixtureFactory<Response<T>> {
   @override
   FixtureDefinition<Response<T>> definition() {
     final http.Response base =

--- a/chopper/test/helpers/payload.dart
+++ b/chopper/test/helpers/payload.dart
@@ -1,6 +1,6 @@
 import 'package:equatable/equatable.dart';
 
-class Payload with EquatableMixin {
+final class Payload with EquatableMixin {
   const Payload({
     this.statusCode = 200,
     this.message = 'OK',

--- a/chopper_built_value/pubspec.yaml
+++ b/chopper_built_value/pubspec.yaml
@@ -1,24 +1,24 @@
 name: chopper_built_value
 description: A built_value based Converter for Chopper.
-version: 1.2.2
+version: 2.0.0
 documentation: https://hadrien-lejard.gitbook.io/chopper/converters/built-value-converter
 repository: https://github.com/lejard-h/chopper
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  built_value: ^8.0.0
-  built_collection: ^5.0.0
-  chopper: ^6.0.0
-  http: ">=0.13.0 <2.0.0"
+  built_value: ^8.6.1
+  built_collection: ^5.1.1
+  chopper: ^7.0.0
+  http: ^1.1.0
 
 dev_dependencies:
-  test: ^1.16.4
-  build_runner: ^2.0.0
-  build_test: ^2.0.0
-  built_value_generator: ^8.0.6
-  lints: ^2.0.0
+  test: ^1.24.4
+  build_runner: ^2.4.6
+  build_test: ^2.2.0
+  built_value_generator: ^8.6.1
+  lints: ^2.1.1
 
 dependency_overrides:
   # Comment before publish

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -15,7 +15,8 @@ import 'package:logging/logging.dart';
 import 'package:source_gen/source_gen.dart';
 
 /// Code generator for [chopper.ChopperApi] annotated classes.
-class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
+final class ChopperGenerator
+    extends GeneratorForAnnotation<chopper.ChopperApi> {
   const ChopperGenerator();
 
   static final Logger _logger = Logger('Chopper Generator');

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -376,13 +376,11 @@ class ChopperGenerator extends GeneratorForAnnotation<chopper.ChopperApi> {
     });
   }
 
-  /// TODO: Upgrade to `Element.enclosingElement` when analyzer 6.0.0 is released; in the mean time ignore the deprecation warning
-  /// https://github.com/dart-lang/sdk/blob/main/pkg/analyzer/CHANGELOG.md#520
   static String _factoryForFunction(FunctionTypedElement function) =>
       // ignore: deprecated_member_use
-      function.enclosingElement3 is ClassElement
+      function.enclosingElement is ClassElement
           // ignore: deprecated_member_use
-          ? '${function.enclosingElement3!.name}.${function.name}'
+          ? '${function.enclosingElement!.name}.${function.name}'
           : function.name!;
 
   static Map<String, ConstantReader> _getAnnotation(

--- a/chopper_generator/lib/src/utils.dart
+++ b/chopper_generator/lib/src/utils.dart
@@ -3,7 +3,7 @@ import 'package:chopper_generator/src/extensions.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:source_gen/source_gen.dart';
 
-class Utils {
+final class Utils {
   static bool getMethodOptionalBody(ConstantReader method) =>
       method.read('optionalBody').boolValue;
 

--- a/chopper_generator/pubspec.yaml
+++ b/chopper_generator/pubspec.yaml
@@ -1,29 +1,29 @@
 name: chopper_generator
 description: Chopper is an http client generator using source_gen, inspired by Retrofit
-version: 6.0.3
+version: 7.0.0
 documentation: https://hadrien-lejard.gitbook.io/chopper
 repository: https://github.com/lejard-h/chopper
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  analyzer: '>=4.4.0 <6.0.0'
-  build: ^2.0.0
-  built_collection: ^5.0.0
-  chopper: ^6.0.0
-  code_builder: ^4.3.0
-  dart_style: ^2.0.0
-  logging: ^1.0.0
-  meta: ^1.3.0
-  source_gen: ^1.0.0
+  analyzer: ^6.0.0
+  build: ^2.4.1
+  built_collection: ^5.1.1
+  chopper: ^7.0.0
+  code_builder: ^4.5.0
+  dart_style: ^2.3.2
+  logging: ^1.2.0
+  meta: ^1.9.1
+  source_gen: ^1.4.0
 
 dev_dependencies:
-  build_runner: ^2.0.0
+  build_runner: ^2.4.6
   build_verify: ^3.1.0
-  http: ">=0.13.0 <2.0.0"
-  lints: ^2.0.0
-  test: ^1.16.4
+  http: ^1.1.0
+  lints: ^2.1.1
+  test: ^1.24.4
 
 dependency_overrides:
   # Comment before publish

--- a/chopper_generator/pubspec.yaml
+++ b/chopper_generator/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  analyzer: ^6.0.0
+  analyzer: ^5.13.0
   build: ^2.4.1
   built_collection: ^5.1.1
   chopper: ^7.0.0

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,7 +5,7 @@ documentation: https://hadrien-lejard.gitbook.io/chopper/
 #author: Hadrien Lejard <hadrien.lejard@gmail.com>
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   chopper:


### PR DESCRIPTION
- bump minimum Dart SDK version to 3.0.0
- bump dependencies to the latest (except `analyzer`)
- implement [Dart 3 class modifiers](https://dart.dev/language/class-modifiers)
- bump all package major versions:
  - chopper: 7.0.0
  - chopper_generator: 7.0.0
  - chopper_built_value: 2.0.0