### PR TITLE
:passport_control: fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-* @Guldem @JEuler @lejard-h @meysam1717 @pixeltoast @stewemetal @techouse
+* @JEuler @lejard-h @meysam1717 @stewemetal @techouse


### PR DESCRIPTION
Fixes these 2 [CODEOWNERS](https://github.com/lejard-h/chopper/blob/develop/.github/CODEOWNERS) errors:

* Unknown owner on line 5: make sure @Guldem exists and has write access to the repository
* Unknown owner on line 5: make sure @pixeltoast exists and has write access to the repository