### PR TITLE
:sparkles: add final class modifier to generated Chopper API implementation

### DIFF
--- a/chopper/example/definition.chopper.dart
+++ b/chopper/example/definition.chopper.dart
@@ -7,7 +7,7 @@ part of 'definition.dart';
 // **************************************************************************
 
 // ignore_for_file: always_put_control_body_on_new_line, always_specify_types, prefer_const_declarations, unnecessary_brace_in_string_interps
-class _$MyService extends MyService {
+final class _$MyService extends MyService {
   _$MyService([ChopperClient? client]) {
     if (client == null) return;
     this.client = client;

--- a/chopper/test/test_service.chopper.dart
+++ b/chopper/test/test_service.chopper.dart
@@ -7,7 +7,7 @@ part of 'test_service.dart';
 // **************************************************************************
 
 // ignore_for_file: always_put_control_body_on_new_line, always_specify_types, prefer_const_declarations, unnecessary_brace_in_string_interps
-class _$HttpTestService extends HttpTestService {
+final class _$HttpTestService extends HttpTestService {
   _$HttpTestService([ChopperClient? client]) {
     if (client == null) return;
     this.client = client;

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -68,6 +68,7 @@ final class ChopperGenerator
 
     final Class classBuilder = Class((builder) {
       builder
+        ..modifier = ClassModifier.final$
         ..name = name
         ..extend = refer(friendlyName)
         ..fields.add(_buildDefinitionTypeMethod(friendlyName))

--- a/chopper_generator/test/test_service.chopper.dart
+++ b/chopper_generator/test/test_service.chopper.dart
@@ -7,7 +7,7 @@ part of 'test_service.dart';
 // **************************************************************************
 
 // ignore_for_file: always_put_control_body_on_new_line, always_specify_types, prefer_const_declarations, unnecessary_brace_in_string_interps
-class _$HttpTestService extends HttpTestService {
+final class _$HttpTestService extends HttpTestService {
   _$HttpTestService([ChopperClient? client]) {
     if (client == null) return;
     this.client = client;

--- a/example/lib/built_value_resource.chopper.dart
+++ b/example/lib/built_value_resource.chopper.dart
@@ -7,7 +7,7 @@ part of 'built_value_resource.dart';
 // **************************************************************************
 
 // ignore_for_file: always_put_control_body_on_new_line, always_specify_types, prefer_const_declarations, unnecessary_brace_in_string_interps
-class _$MyService extends MyService {
+final class _$MyService extends MyService {
   _$MyService([ChopperClient? client]) {
     if (client == null) return;
     this.client = client;

--- a/example/lib/json_serializable.chopper.dart
+++ b/example/lib/json_serializable.chopper.dart
@@ -7,7 +7,7 @@ part of 'json_serializable.dart';
 // **************************************************************************
 
 // ignore_for_file: always_put_control_body_on_new_line, always_specify_types, prefer_const_declarations, unnecessary_brace_in_string_interps
-class _$MyService extends MyService {
+final class _$MyService extends MyService {
   _$MyService([ChopperClient? client]) {
     if (client == null) return;
     this.client = client;


### PR DESCRIPTION
This PR adds the [`final` class modifier](https://dart.dev/language/class-modifiers#final) to the generated Chopper API implementation, i.e.

**before**

```dart
class _$MyService extends MyService {
  _$MyService([ChopperClient? client]) {
    if (client == null) return;
    this.client = client;
  }
  
  // ... stuff
}
```

**after**

```dart
final class _$MyService extends MyService {
  _$MyService([ChopperClient? client]) {
    if (client == null) return;
    this.client = client;
  }
  
  // ... stuff
}
```