### PR TITLE
:arrow_up: allow chopper_generator to use analyzer v6

### DIFF
--- a/chopper_generator/pubspec.yaml
+++ b/chopper_generator/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  analyzer: ^5.13.0
+  analyzer: ">=5.13.0 <7.0.0"
   build: ^2.4.1
   built_collection: ^5.1.1
   chopper: ^7.0.0


### PR DESCRIPTION
Change the `analyzer` constraint of `chopper_generator` to

```yaml
analyzer: ">=5.13.0 <7.0.0"
```

in order to allow a more graceful transition.

---

Supersedes https://github.com/lejard-h/chopper/pull/474