### PR TITLE
Adding support for top level variables

### DIFF
--- a/chopper/lib/src/annotations.dart
+++ b/chopper/lib/src/annotations.dart
@@ -22,6 +22,8 @@ import 'package:meta/meta.dart';
 @immutable
 final class ChopperApi {
   /// A part of a URL that every request defined inside a class annotated with [ChopperApi] will be prefixed with.
+  ///
+  /// The `baseUrl` can be a top level constant string variable.
   final String baseUrl;
 
   const ChopperApi({

--- a/chopper/test/base_test.dart
+++ b/chopper/test/base_test.dart
@@ -9,8 +9,10 @@ import 'package:http/testing.dart';
 import 'package:test/test.dart';
 
 import 'test_service.dart';
+import 'test_service_variable.dart';
 
 final baseUrl = Uri.parse('http://localhost:8000');
+const String testEnv = 'https://localhost:4000';
 
 void main() {
   ChopperClient buildClient([
@@ -22,6 +24,7 @@ void main() {
         services: [
           // the generated service
           HttpTestService.create(),
+          HttpTestServiceVariable.create(),
         ],
         client: httpClient,
         errorConverter: errorConverter,
@@ -35,9 +38,12 @@ void main() {
 
       final chopper = buildClient(httpClient);
       final service = chopper.getService<HttpTestService>();
+      final serviceVariable = chopper.getService<HttpTestServiceVariable>();
 
       expect(service, isNotNull);
+      expect(serviceVariable, isNotNull);
       expect(service, isA<HttpTestService>());
+      expect(serviceVariable, isA<HttpTestServiceVariable>());
     });
 
     test('get service errors', () async {
@@ -77,6 +83,28 @@ void main() {
 
       final chopper = buildClient(httpClient);
       final service = chopper.getService<HttpTestService>();
+
+      final response = await service.getTest('1234', dynamicHeader: '');
+
+      expect(response.body, equals('get response'));
+      expect(response.statusCode, equals(200));
+
+      httpClient.close();
+    });
+
+    test('GET Variable', () async {
+      final httpClient = MockClient((request) async {
+        expect(
+          request.url.toString(),
+          equals('$testEnv/get/1234'),
+        );
+        expect(request.method, equals('GET'));
+
+        return http.Response('get response', 200);
+      });
+
+      final chopper = buildClient(httpClient);
+      final service = chopper.getService<HttpTestServiceVariable>();
 
       final response = await service.getTest('1234', dynamicHeader: '');
 
@@ -231,6 +259,29 @@ void main() {
       httpClient.close();
     });
 
+    test('POST Variable', () async {
+      final httpClient = MockClient((request) async {
+        expect(
+          request.url.toString(),
+          equals('$testEnv/post'),
+        );
+        expect(request.method, equals('POST'));
+        expect(request.body, equals('post body'));
+
+        return http.Response('post response', 200);
+      });
+
+      final chopper = buildClient(httpClient);
+      final service = chopper.getService<HttpTestServiceVariable>();
+
+      final response = await service.postTest('post body');
+
+      expect(response.body, equals('post response'));
+      expect(response.statusCode, equals(200));
+
+      httpClient.close();
+    });
+
     test('POST with streamed body', () async {
       final httpClient = MockClient((request) async {
         expect(
@@ -282,6 +333,29 @@ void main() {
       httpClient.close();
     });
 
+    test('PUT Variable', () async {
+      final httpClient = MockClient((request) async {
+        expect(
+          request.url.toString(),
+          equals('$testEnv/put/1234'),
+        );
+        expect(request.method, equals('PUT'));
+        expect(request.body, equals('put body'));
+
+        return http.Response('put response', 200);
+      });
+
+      final chopper = buildClient(httpClient);
+      final service = chopper.getService<HttpTestServiceVariable>();
+
+      final response = await service.putTest('1234', 'put body');
+
+      expect(response.body, equals('put response'));
+      expect(response.statusCode, equals(200));
+
+      httpClient.close();
+    });
+
     test('PATCH', () async {
       final httpClient = MockClient((request) async {
         expect(
@@ -296,6 +370,29 @@ void main() {
 
       final chopper = buildClient(httpClient);
       final service = chopper.getService<HttpTestService>();
+
+      final response = await service.patchTest('1234', 'patch body');
+
+      expect(response.body, equals('patch response'));
+      expect(response.statusCode, equals(200));
+
+      httpClient.close();
+    });
+
+    test('PATCH Variable', () async {
+      final httpClient = MockClient((request) async {
+        expect(
+          request.url.toString(),
+          equals('$testEnv/patch/1234'),
+        );
+        expect(request.method, equals('PATCH'));
+        expect(request.body, equals('patch body'));
+
+        return http.Response('patch response', 200);
+      });
+
+      final chopper = buildClient(httpClient);
+      final service = chopper.getService<HttpTestServiceVariable>();
 
       final response = await service.patchTest('1234', 'patch body');
 
@@ -327,6 +424,28 @@ void main() {
       httpClient.close();
     });
 
+    test('DELETE Variable', () async {
+      final httpClient = MockClient((request) async {
+        expect(
+          request.url.toString(),
+          equals('$testEnv/delete/1234'),
+        );
+        expect(request.method, equals('DELETE'));
+
+        return http.Response('delete response', 200);
+      });
+
+      final chopper = buildClient(httpClient);
+      final service = chopper.getService<HttpTestServiceVariable>();
+
+      final response = await service.deleteTest('1234');
+
+      expect(response.body, equals('delete response'));
+      expect(response.statusCode, equals(200));
+
+      httpClient.close();
+    });
+
     test('Head', () async {
       final httpClient = MockClient((request) async {
         expect(
@@ -340,6 +459,28 @@ void main() {
 
       final chopper = buildClient(httpClient);
       final service = chopper.getService<HttpTestService>();
+
+      final response = await service.headTest();
+
+      expect(response.body, equals('head response'));
+      expect(response.statusCode, equals(200));
+
+      httpClient.close();
+    });
+
+    test('Head Variable', () async {
+      final httpClient = MockClient((request) async {
+        expect(
+          request.url.toString(),
+          equals('$testEnv/head'),
+        );
+        expect(request.method, equals('HEAD'));
+
+        return http.Response('head response', 200);
+      });
+
+      final chopper = buildClient(httpClient);
+      final service = chopper.getService<HttpTestServiceVariable>();
 
       final response = await service.headTest();
 

--- a/chopper/test/ensure_build_test.dart
+++ b/chopper/test/ensure_build_test.dart
@@ -6,11 +6,19 @@ import 'package:test/test.dart';
 void main() {
   test(
     'ensure_build',
-    () => expectBuildClean(
-      packageRelativeDirectory: 'chopper',
-      gitDiffPathArguments: [
-        'test/test_service.chopper.dart',
-      ],
-    ),
+    () {
+      expectBuildClean(
+        packageRelativeDirectory: 'chopper',
+        gitDiffPathArguments: [
+          'test/test_service.chopper.dart',
+        ],
+      );
+      expectBuildClean(
+        packageRelativeDirectory: 'chopper',
+        gitDiffPathArguments: [
+          'test/test_service_variable.chopper.dart',
+        ],
+      );
+    },
   );
 }

--- a/chopper/test/test_service_variable.chopper.dart
+++ b/chopper/test/test_service_variable.chopper.dart
@@ -1,0 +1,641 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'test_service_variable.dart';
+
+// **************************************************************************
+// ChopperGenerator
+// **************************************************************************
+
+// ignore_for_file: always_put_control_body_on_new_line, always_specify_types, prefer_const_declarations, unnecessary_brace_in_string_interps
+final class _$HttpTestServiceVariable extends HttpTestServiceVariable {
+  _$HttpTestServiceVariable([ChopperClient? client]) {
+    if (client == null) return;
+    this.client = client;
+  }
+
+  @override
+  final definitionType = HttpTestServiceVariable;
+
+  @override
+  Future<Response<String>> getTest(
+    String id, {
+    required String dynamicHeader,
+  }) {
+    final Uri $url = Uri.parse('${service}/get/${id}');
+    final Map<String, String> $headers = {
+      'test': dynamicHeader,
+    };
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      headers: $headers,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> headTest() {
+    final Uri $url = Uri.parse('${service}/head');
+    final Request $request = Request(
+      'HEAD',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> optionsTest() {
+    final Uri $url = Uri.parse('${service}/options');
+    final Request $request = Request(
+      'OPTIONS',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<Stream<List<int>>>> getStreamTest() {
+    final Uri $url = Uri.parse('${service}/get');
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<Stream<List<int>>, int>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getAll() {
+    final Uri $url = Uri.parse('${service}');
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getAllWithTrailingSlash() {
+    final Uri $url = Uri.parse('${service}/');
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getQueryTest({
+    String name = '',
+    int? number,
+    int? def = 42,
+  }) {
+    final Uri $url = Uri.parse('${service}/query');
+    final Map<String, dynamic> $params = <String, dynamic>{
+      'name': name,
+      'int': number,
+      'default_value': def,
+    };
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getQueryMapTest(Map<String, dynamic> query) {
+    final Uri $url = Uri.parse('${service}/query_map');
+    final Map<String, dynamic> $params = query;
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getQueryMapTest2(
+    Map<String, dynamic> query, {
+    bool? test,
+  }) {
+    final Uri $url = Uri.parse('${service}/query_map');
+    final Map<String, dynamic> $params = <String, dynamic>{'test': test};
+    $params.addAll(query);
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getQueryMapTest3({
+    String name = '',
+    int? number,
+    Map<String, dynamic> filters = const {},
+  }) {
+    final Uri $url = Uri.parse('${service}/query_map');
+    final Map<String, dynamic> $params = <String, dynamic>{
+      'name': name,
+      'number': number,
+    };
+    $params.addAll(filters);
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getQueryMapTest4({
+    String name = '',
+    int? number,
+    Map<String, dynamic>? filters,
+  }) {
+    final Uri $url = Uri.parse('${service}/query_map');
+    final Map<String, dynamic> $params = <String, dynamic>{
+      'name': name,
+      'number': number,
+    };
+    $params.addAll(filters ?? const {});
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getQueryMapTest5({Map<String, dynamic>? filters}) {
+    final Uri $url = Uri.parse('${service}/query_map');
+    final Map<String, dynamic> $params = filters ?? const {};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getBody(dynamic body) {
+    final Uri $url = Uri.parse('${service}/get_body');
+    final $body = body;
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postTest(String data) {
+    final Uri $url = Uri.parse('${service}/post');
+    final $body = data;
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postStreamTest(Stream<List<int>> byteStream) {
+    final Uri $url = Uri.parse('${service}/post');
+    final $body = byteStream;
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> putTest(
+    String test,
+    String data,
+  ) {
+    final Uri $url = Uri.parse('${service}/put/${test}');
+    final $body = data;
+    final Request $request = Request(
+      'PUT',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> deleteTest(String id) {
+    final Uri $url = Uri.parse('${service}/delete/${id}');
+    final Map<String, String> $headers = {
+      'foo': 'bar',
+    };
+    final Request $request = Request(
+      'DELETE',
+      $url,
+      client.baseUrl,
+      headers: $headers,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> patchTest(
+    String id,
+    String data,
+  ) {
+    final Uri $url = Uri.parse('${service}/patch/${id}');
+    final $body = data;
+    final Request $request = Request(
+      'PATCH',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> mapTest(Map<String, String> map) {
+    final Uri $url = Uri.parse('${service}/map');
+    final $body = map;
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postForm(Map<String, String> fields) {
+    final Uri $url = Uri.parse('${service}/form/body');
+    final $body = fields;
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>(
+      $request,
+      requestConverter: convertForm,
+    );
+  }
+
+  @override
+  Future<Response<dynamic>> postFormUsingHeaders(Map<String, String> fields) {
+    final Uri $url = Uri.parse('${service}/form/body');
+    final Map<String, String> $headers = {
+      'content-type': 'application/x-www-form-urlencoded',
+    };
+    final $body = fields;
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      body: $body,
+      headers: $headers,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postFormFields(
+    String foo,
+    int bar,
+  ) {
+    final Uri $url = Uri.parse('${service}/form/body/fields');
+    final $body = <String, dynamic>{
+      'foo': foo,
+      'bar': bar,
+    };
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>(
+      $request,
+      requestConverter: convertForm,
+    );
+  }
+
+  @override
+  Future<Response<dynamic>> forceJsonTest(Map<dynamic, dynamic> map) {
+    final Uri $url = Uri.parse('${service}/map/json');
+    final $body = map;
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>(
+      $request,
+      requestConverter: customConvertRequest,
+      responseConverter: customConvertResponse,
+    );
+  }
+
+  @override
+  Future<Response<dynamic>> postResources(
+    Map<dynamic, dynamic> a,
+    Map<dynamic, dynamic> b,
+  ) {
+    final Uri $url = Uri.parse('${service}/multi');
+    final List<PartValue> $parts = <PartValue>[
+      PartValue<Map<dynamic, dynamic>>(
+        '1',
+        a,
+      ),
+      PartValue<Map<dynamic, dynamic>>(
+        '2',
+        b,
+      ),
+    ];
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      parts: $parts,
+      multipart: true,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postFile(List<int> bytes) {
+    final Uri $url = Uri.parse('${service}/file');
+    final List<PartValue> $parts = <PartValue>[
+      PartValueFile<List<int>>(
+        'file',
+        bytes,
+      )
+    ];
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      parts: $parts,
+      multipart: true,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postImage(List<int> imageData) {
+    final Uri $url = Uri.parse('${service}/image');
+    final List<PartValue> $parts = <PartValue>[
+      PartValueFile<List<int>>(
+        'image',
+        imageData,
+      )
+    ];
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      parts: $parts,
+      multipart: true,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postMultipartFile(
+    MultipartFile file, {
+    String? id,
+  }) {
+    final Uri $url = Uri.parse('${service}/file');
+    final List<PartValue> $parts = <PartValue>[
+      PartValue<String?>(
+        'id',
+        id,
+      ),
+      PartValueFile<MultipartFile>(
+        'file',
+        file,
+      ),
+    ];
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      parts: $parts,
+      multipart: true,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postListFiles(List<MultipartFile> files) {
+    final Uri $url = Uri.parse('${service}/files');
+    final List<PartValue> $parts = <PartValue>[
+      PartValueFile<List<MultipartFile>>(
+        'files',
+        files,
+      )
+    ];
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      parts: $parts,
+      multipart: true,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postMultipartList({
+    required List<int> ints,
+    required List<double> doubles,
+    required List<num> nums,
+    required List<String> strings,
+  }) {
+    final Uri $url = Uri.parse('${service}/multipart_list');
+    final List<PartValue> $parts = <PartValue>[
+      PartValue<List<int>>(
+        'ints',
+        ints,
+      ),
+      PartValue<List<double>>(
+        'doubles',
+        doubles,
+      ),
+      PartValue<List<num>>(
+        'nums',
+        nums,
+      ),
+      PartValue<List<String>>(
+        'strings',
+        strings,
+      ),
+    ];
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      parts: $parts,
+      multipart: true,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<dynamic> fullUrl() {
+    final Uri $url = Uri.parse('https://test.com');
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+    );
+    return client.send($request);
+  }
+
+  @override
+  Future<Response<List<String>>> listString() {
+    final Uri $url = Uri.parse('${service}/list/string');
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<List<String>, String>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> noBody() {
+    final Uri $url = Uri.parse('${service}/no-body');
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<String>> getUsingQueryParamIncludeNullQueryVars({
+    String? foo,
+    String? bar,
+    String? baz,
+  }) {
+    final Uri $url =
+        Uri.parse('${service}/query_param_include_null_query_vars');
+    final Map<String, dynamic> $params = <String, dynamic>{
+      'foo': foo,
+      'bar': bar,
+      'baz': baz,
+    };
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      includeNullQueryVars: true,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getUsingListQueryParam(List<String> value) {
+    final Uri $url = Uri.parse('${service}/list_query_param');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getUsingListQueryParamWithBrackets(
+      List<String> value) {
+    final Uri $url = Uri.parse('${service}/list_query_param_with_brackets');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      useBrackets: true,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getUsingMapQueryParam(Map<String, dynamic> value) {
+    final Uri $url = Uri.parse('${service}/map_query_param');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getUsingMapQueryParamIncludeNullQueryVars(
+      Map<String, dynamic> value) {
+    final Uri $url =
+        Uri.parse('${service}/map_query_param_include_null_query_vars');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      includeNullQueryVars: true,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getUsingMapQueryParamWithBrackets(
+      Map<String, dynamic> value) {
+    final Uri $url = Uri.parse('${service}/map_query_param_with_brackets');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      useBrackets: true,
+    );
+    return client.send<String, String>($request);
+  }
+}

--- a/chopper/test/test_service_variable.dart
+++ b/chopper/test/test_service_variable.dart
@@ -1,0 +1,220 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:chopper/chopper.dart';
+import 'package:http/http.dart' show MultipartFile;
+
+part 'test_service_variable.chopper.dart';
+
+const String service = 'https://localhost:4000';
+
+@ChopperApi(baseUrl: service)
+abstract class HttpTestServiceVariable extends ChopperService {
+  static HttpTestServiceVariable create([ChopperClient? client]) =>
+      _$HttpTestServiceVariable(client);
+
+  @Get(path: 'get/{id}')
+  Future<Response<String>> getTest(
+    @Path() String id, {
+    @Header('test') required String dynamicHeader,
+  });
+
+  @Head(path: 'head')
+  Future<Response> headTest();
+
+  @Options(path: 'options')
+  Future<Response> optionsTest();
+
+  @Get(path: 'get')
+  Future<Response<Stream<List<int>>>> getStreamTest();
+
+  @Get(path: '')
+  Future<Response> getAll();
+
+  @Get(path: '/')
+  Future<Response> getAllWithTrailingSlash();
+
+  @Get(path: 'query')
+  Future<Response> getQueryTest({
+    @Query('name') String name = '',
+    @Query('int') int? number,
+    @Query('default_value') int? def = 42,
+  });
+
+  @Get(path: 'query_map')
+  Future<Response> getQueryMapTest(@QueryMap() Map<String, dynamic> query);
+
+  @Get(path: 'query_map')
+  Future<Response> getQueryMapTest2(
+    @QueryMap() Map<String, dynamic> query, {
+    @Query('test') bool? test,
+  });
+
+  @Get(path: 'query_map')
+  Future<Response> getQueryMapTest3({
+    @Query('name') String name = '',
+    @Query('number') int? number,
+    @QueryMap() Map<String, dynamic> filters = const {},
+  });
+
+  @Get(path: 'query_map')
+  Future<Response> getQueryMapTest4({
+    @Query('name') String name = '',
+    @Query('number') int? number,
+    @QueryMap() Map<String, dynamic>? filters,
+  });
+
+  @Get(path: 'query_map')
+  Future<Response> getQueryMapTest5({
+    @QueryMap() Map<String, dynamic>? filters,
+  });
+
+  @Get(path: 'get_body')
+  Future<Response> getBody(@Body() dynamic body);
+
+  @Post(path: 'post')
+  Future<Response> postTest(@Body() String data);
+
+  @Post(path: 'post')
+  Future<Response> postStreamTest(@Body() Stream<List<int>> byteStream);
+
+  @Put(path: 'put/{id}')
+  Future<Response> putTest(@Path('id') String test, @Body() String data);
+
+  @Delete(path: 'delete/{id}', headers: {'foo': 'bar'})
+  Future<Response> deleteTest(@Path() String id);
+
+  @Patch(path: 'patch/{id}')
+  Future<Response> patchTest(@Path() String id, @Body() String data);
+
+  @Post(path: 'map')
+  Future<Response> mapTest(@Body() Map<String, String> map);
+
+  @FactoryConverter(request: convertForm)
+  @Post(path: 'form/body')
+  Future<Response> postForm(@Body() Map<String, String> fields);
+
+  @Post(path: 'form/body', headers: {contentTypeKey: formEncodedHeaders})
+  Future<Response> postFormUsingHeaders(@Body() Map<String, String> fields);
+
+  @FactoryConverter(request: convertForm)
+  @Post(path: 'form/body/fields')
+  Future<Response> postFormFields(@Field() String foo, @Field() int bar);
+
+  @Post(path: 'map/json')
+  @FactoryConverter(
+    request: customConvertRequest,
+    response: customConvertResponse,
+  )
+  Future<Response> forceJsonTest(@Body() Map map);
+
+  @Post(path: 'multi')
+  @multipart
+  Future<Response> postResources(
+    @Part('1') Map a,
+    @Part('2') Map b,
+  );
+
+  @Post(path: 'file')
+  @multipart
+  Future<Response> postFile(
+    @PartFile('file') List<int> bytes,
+  );
+
+  @Post(path: 'image')
+  @multipart
+  Future<Response> postImage(
+    @PartFile('image') List<int> imageData,
+  );
+
+  @Post(path: 'file')
+  @multipart
+  Future<Response> postMultipartFile(
+    @PartFile() MultipartFile file, {
+    @Part() String? id,
+  });
+
+  @Post(path: 'files')
+  @multipart
+  Future<Response> postListFiles(@PartFile() List<MultipartFile> files);
+
+  @Post(path: 'multipart_list')
+  @multipart
+  Future<Response> postMultipartList({
+    @Part('ints') required List<int> ints,
+    @Part('doubles') required List<double> doubles,
+    @Part('nums') required List<num> nums,
+    @Part('strings') required List<String> strings,
+  });
+
+  @Get(path: 'https://test.com')
+  Future fullUrl();
+
+  @Get(path: '/list/string')
+  Future<Response<List<String>>> listString();
+
+  @Post(path: 'no-body')
+  Future<Response> noBody();
+
+  @Get(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
+  Future<Response<String>> getUsingQueryParamIncludeNullQueryVars({
+    @Query('foo') String? foo,
+    @Query('bar') String? bar,
+    @Query('baz') String? baz,
+  });
+
+  @Get(path: '/list_query_param')
+  Future<Response<String>> getUsingListQueryParam(
+    @Query('value') List<String> value,
+  );
+
+  @Get(path: '/list_query_param_with_brackets', useBrackets: true)
+  Future<Response<String>> getUsingListQueryParamWithBrackets(
+    @Query('value') List<String> value,
+  );
+
+  @Get(path: '/map_query_param')
+  Future<Response<String>> getUsingMapQueryParam(
+    @Query('value') Map<String, dynamic> value,
+  );
+
+  @Get(
+    path: '/map_query_param_include_null_query_vars',
+    includeNullQueryVars: true,
+  )
+  Future<Response<String>> getUsingMapQueryParamIncludeNullQueryVars(
+    @Query('value') Map<String, dynamic> value,
+  );
+
+  @Get(path: '/map_query_param_with_brackets', useBrackets: true)
+  Future<Response<String>> getUsingMapQueryParamWithBrackets(
+    @Query('value') Map<String, dynamic> value,
+  );
+}
+
+Request customConvertRequest(Request req) {
+  final r = JsonConverter().convertRequest(req);
+
+  return applyHeader(r, 'customConverter', 'true');
+}
+
+Response<T> customConvertResponse<T>(Response res) =>
+    res.copyWith(body: json.decode(res.body));
+
+Request convertForm(Request req) {
+  req = applyHeader(req, contentTypeKey, formEncodedHeaders);
+
+  if (req.body is Map) {
+    final body = <String, String>{};
+
+    req.body.forEach((key, val) {
+      if (val != null) {
+        body[key.toString()] = val.toString();
+      }
+    });
+
+    req = req.copyWith(body: body);
+  }
+
+  return req;
+}

--- a/chopper_generator/test/ensure_build_test.dart
+++ b/chopper_generator/test/ensure_build_test.dart
@@ -6,11 +6,20 @@ import 'package:test/test.dart';
 void main() {
   test(
     'ensure_build',
-    () => expectBuildClean(
-      packageRelativeDirectory: 'chopper_generator',
-      gitDiffPathArguments: [
-        'test/test_service.chopper.dart',
-      ],
-    ),
+    () {
+      expectBuildClean(
+        packageRelativeDirectory: 'chopper_generator',
+        gitDiffPathArguments: [
+          'test/test_service.chopper.dart',
+        ],
+      );
+
+      expectBuildClean(
+        packageRelativeDirectory: 'chopper_generator',
+        gitDiffPathArguments: [
+          'test/test_service_variable.chopper.dart',
+        ],
+      );
+    },
   );
 }

--- a/chopper_generator/test/test_service_variable.chopper.dart
+++ b/chopper_generator/test/test_service_variable.chopper.dart
@@ -1,0 +1,641 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'test_service_variable.dart';
+
+// **************************************************************************
+// ChopperGenerator
+// **************************************************************************
+
+// ignore_for_file: always_put_control_body_on_new_line, always_specify_types, prefer_const_declarations, unnecessary_brace_in_string_interps
+final class _$HttpTestServiceVariable extends HttpTestServiceVariable {
+  _$HttpTestServiceVariable([ChopperClient? client]) {
+    if (client == null) return;
+    this.client = client;
+  }
+
+  @override
+  final definitionType = HttpTestServiceVariable;
+
+  @override
+  Future<Response<String>> getTest(
+    String id, {
+    required String dynamicHeader,
+  }) {
+    final Uri $url = Uri.parse('${service}/get/${id}');
+    final Map<String, String> $headers = {
+      'test': dynamicHeader,
+    };
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      headers: $headers,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> headTest() {
+    final Uri $url = Uri.parse('${service}/head');
+    final Request $request = Request(
+      'HEAD',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> optionsTest() {
+    final Uri $url = Uri.parse('${service}/options');
+    final Request $request = Request(
+      'OPTIONS',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<Stream<List<int>>>> getStreamTest() {
+    final Uri $url = Uri.parse('${service}/get');
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<Stream<List<int>>, int>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getAll() {
+    final Uri $url = Uri.parse('${service}');
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getAllWithTrailingSlash() {
+    final Uri $url = Uri.parse('${service}/');
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getQueryTest({
+    String name = '',
+    int? number,
+    int? def = 42,
+  }) {
+    final Uri $url = Uri.parse('${service}/query');
+    final Map<String, dynamic> $params = <String, dynamic>{
+      'name': name,
+      'int': number,
+      'default_value': def,
+    };
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getQueryMapTest(Map<String, dynamic> query) {
+    final Uri $url = Uri.parse('${service}/query_map');
+    final Map<String, dynamic> $params = query;
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getQueryMapTest2(
+    Map<String, dynamic> query, {
+    bool? test,
+  }) {
+    final Uri $url = Uri.parse('${service}/query_map');
+    final Map<String, dynamic> $params = <String, dynamic>{'test': test};
+    $params.addAll(query);
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getQueryMapTest3({
+    String name = '',
+    int? number,
+    Map<String, dynamic> filters = const {},
+  }) {
+    final Uri $url = Uri.parse('${service}/query_map');
+    final Map<String, dynamic> $params = <String, dynamic>{
+      'name': name,
+      'number': number,
+    };
+    $params.addAll(filters);
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getQueryMapTest4({
+    String name = '',
+    int? number,
+    Map<String, dynamic>? filters,
+  }) {
+    final Uri $url = Uri.parse('${service}/query_map');
+    final Map<String, dynamic> $params = <String, dynamic>{
+      'name': name,
+      'number': number,
+    };
+    $params.addAll(filters ?? const {});
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getQueryMapTest5({Map<String, dynamic>? filters}) {
+    final Uri $url = Uri.parse('${service}/query_map');
+    final Map<String, dynamic> $params = filters ?? const {};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getBody(dynamic body) {
+    final Uri $url = Uri.parse('${service}/get_body');
+    final $body = body;
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postTest(String data) {
+    final Uri $url = Uri.parse('${service}/post');
+    final $body = data;
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postStreamTest(Stream<List<int>> byteStream) {
+    final Uri $url = Uri.parse('${service}/post');
+    final $body = byteStream;
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> putTest(
+    String test,
+    String data,
+  ) {
+    final Uri $url = Uri.parse('${service}/put/${test}');
+    final $body = data;
+    final Request $request = Request(
+      'PUT',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> deleteTest(String id) {
+    final Uri $url = Uri.parse('${service}/delete/${id}');
+    final Map<String, String> $headers = {
+      'foo': 'bar',
+    };
+    final Request $request = Request(
+      'DELETE',
+      $url,
+      client.baseUrl,
+      headers: $headers,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> patchTest(
+    String id,
+    String data,
+  ) {
+    final Uri $url = Uri.parse('${service}/patch/${id}');
+    final $body = data;
+    final Request $request = Request(
+      'PATCH',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> mapTest(Map<String, String> map) {
+    final Uri $url = Uri.parse('${service}/map');
+    final $body = map;
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postForm(Map<String, String> fields) {
+    final Uri $url = Uri.parse('${service}/form/body');
+    final $body = fields;
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>(
+      $request,
+      requestConverter: convertForm,
+    );
+  }
+
+  @override
+  Future<Response<dynamic>> postFormUsingHeaders(Map<String, String> fields) {
+    final Uri $url = Uri.parse('${service}/form/body');
+    final Map<String, String> $headers = {
+      'content-type': 'application/x-www-form-urlencoded',
+    };
+    final $body = fields;
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      body: $body,
+      headers: $headers,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postFormFields(
+    String foo,
+    int bar,
+  ) {
+    final Uri $url = Uri.parse('${service}/form/body/fields');
+    final $body = <String, dynamic>{
+      'foo': foo,
+      'bar': bar,
+    };
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>(
+      $request,
+      requestConverter: convertForm,
+    );
+  }
+
+  @override
+  Future<Response<dynamic>> forceJsonTest(Map<dynamic, dynamic> map) {
+    final Uri $url = Uri.parse('${service}/map/json');
+    final $body = map;
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>(
+      $request,
+      requestConverter: customConvertRequest,
+      responseConverter: customConvertResponse,
+    );
+  }
+
+  @override
+  Future<Response<dynamic>> postResources(
+    Map<dynamic, dynamic> a,
+    Map<dynamic, dynamic> b,
+  ) {
+    final Uri $url = Uri.parse('${service}/multi');
+    final List<PartValue> $parts = <PartValue>[
+      PartValue<Map<dynamic, dynamic>>(
+        '1',
+        a,
+      ),
+      PartValue<Map<dynamic, dynamic>>(
+        '2',
+        b,
+      ),
+    ];
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      parts: $parts,
+      multipart: true,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postFile(List<int> bytes) {
+    final Uri $url = Uri.parse('${service}/file');
+    final List<PartValue> $parts = <PartValue>[
+      PartValueFile<List<int>>(
+        'file',
+        bytes,
+      )
+    ];
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      parts: $parts,
+      multipart: true,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postImage(List<int> imageData) {
+    final Uri $url = Uri.parse('${service}/image');
+    final List<PartValue> $parts = <PartValue>[
+      PartValueFile<List<int>>(
+        'image',
+        imageData,
+      )
+    ];
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      parts: $parts,
+      multipart: true,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postMultipartFile(
+    MultipartFile file, {
+    String? id,
+  }) {
+    final Uri $url = Uri.parse('${service}/file');
+    final List<PartValue> $parts = <PartValue>[
+      PartValue<String?>(
+        'id',
+        id,
+      ),
+      PartValueFile<MultipartFile>(
+        'file',
+        file,
+      ),
+    ];
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      parts: $parts,
+      multipart: true,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postListFiles(List<MultipartFile> files) {
+    final Uri $url = Uri.parse('${service}/files');
+    final List<PartValue> $parts = <PartValue>[
+      PartValueFile<List<MultipartFile>>(
+        'files',
+        files,
+      )
+    ];
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      parts: $parts,
+      multipart: true,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postMultipartList({
+    required List<int> ints,
+    required List<double> doubles,
+    required List<num> nums,
+    required List<String> strings,
+  }) {
+    final Uri $url = Uri.parse('${service}/multipart_list');
+    final List<PartValue> $parts = <PartValue>[
+      PartValue<List<int>>(
+        'ints',
+        ints,
+      ),
+      PartValue<List<double>>(
+        'doubles',
+        doubles,
+      ),
+      PartValue<List<num>>(
+        'nums',
+        nums,
+      ),
+      PartValue<List<String>>(
+        'strings',
+        strings,
+      ),
+    ];
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      parts: $parts,
+      multipart: true,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<dynamic> fullUrl() {
+    final Uri $url = Uri.parse('https://test.com');
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+    );
+    return client.send($request);
+  }
+
+  @override
+  Future<Response<List<String>>> listString() {
+    final Uri $url = Uri.parse('${service}/list/string');
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<List<String>, String>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> noBody() {
+    final Uri $url = Uri.parse('${service}/no-body');
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<String>> getUsingQueryParamIncludeNullQueryVars({
+    String? foo,
+    String? bar,
+    String? baz,
+  }) {
+    final Uri $url =
+        Uri.parse('${service}/query_param_include_null_query_vars');
+    final Map<String, dynamic> $params = <String, dynamic>{
+      'foo': foo,
+      'bar': bar,
+      'baz': baz,
+    };
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      includeNullQueryVars: true,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getUsingListQueryParam(List<String> value) {
+    final Uri $url = Uri.parse('${service}/list_query_param');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getUsingListQueryParamWithBrackets(
+      List<String> value) {
+    final Uri $url = Uri.parse('${service}/list_query_param_with_brackets');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      useBrackets: true,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getUsingMapQueryParam(Map<String, dynamic> value) {
+    final Uri $url = Uri.parse('${service}/map_query_param');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getUsingMapQueryParamIncludeNullQueryVars(
+      Map<String, dynamic> value) {
+    final Uri $url =
+        Uri.parse('${service}/map_query_param_include_null_query_vars');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      includeNullQueryVars: true,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getUsingMapQueryParamWithBrackets(
+      Map<String, dynamic> value) {
+    final Uri $url = Uri.parse('${service}/map_query_param_with_brackets');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      useBrackets: true,
+    );
+    return client.send<String, String>($request);
+  }
+}

--- a/chopper_generator/test/test_service_variable.dart
+++ b/chopper_generator/test/test_service_variable.dart
@@ -1,0 +1,220 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:chopper/chopper.dart';
+import 'package:http/http.dart' show MultipartFile;
+
+part 'test_service_variable.chopper.dart';
+
+const String service = 'https://localhost:4000';
+
+@ChopperApi(baseUrl: service)
+abstract class HttpTestServiceVariable extends ChopperService {
+  static HttpTestServiceVariable create([ChopperClient? client]) =>
+      _$HttpTestServiceVariable(client);
+
+  @Get(path: 'get/{id}')
+  Future<Response<String>> getTest(
+    @Path() String id, {
+    @Header('test') required String dynamicHeader,
+  });
+
+  @Head(path: 'head')
+  Future<Response> headTest();
+
+  @Options(path: 'options')
+  Future<Response> optionsTest();
+
+  @Get(path: 'get')
+  Future<Response<Stream<List<int>>>> getStreamTest();
+
+  @Get(path: '')
+  Future<Response> getAll();
+
+  @Get(path: '/')
+  Future<Response> getAllWithTrailingSlash();
+
+  @Get(path: 'query')
+  Future<Response> getQueryTest({
+    @Query('name') String name = '',
+    @Query('int') int? number,
+    @Query('default_value') int? def = 42,
+  });
+
+  @Get(path: 'query_map')
+  Future<Response> getQueryMapTest(@QueryMap() Map<String, dynamic> query);
+
+  @Get(path: 'query_map')
+  Future<Response> getQueryMapTest2(
+    @QueryMap() Map<String, dynamic> query, {
+    @Query('test') bool? test,
+  });
+
+  @Get(path: 'query_map')
+  Future<Response> getQueryMapTest3({
+    @Query('name') String name = '',
+    @Query('number') int? number,
+    @QueryMap() Map<String, dynamic> filters = const {},
+  });
+
+  @Get(path: 'query_map')
+  Future<Response> getQueryMapTest4({
+    @Query('name') String name = '',
+    @Query('number') int? number,
+    @QueryMap() Map<String, dynamic>? filters,
+  });
+
+  @Get(path: 'query_map')
+  Future<Response> getQueryMapTest5({
+    @QueryMap() Map<String, dynamic>? filters,
+  });
+
+  @Get(path: 'get_body')
+  Future<Response> getBody(@Body() dynamic body);
+
+  @Post(path: 'post')
+  Future<Response> postTest(@Body() String data);
+
+  @Post(path: 'post')
+  Future<Response> postStreamTest(@Body() Stream<List<int>> byteStream);
+
+  @Put(path: 'put/{id}')
+  Future<Response> putTest(@Path('id') String test, @Body() String data);
+
+  @Delete(path: 'delete/{id}', headers: {'foo': 'bar'})
+  Future<Response> deleteTest(@Path() String id);
+
+  @Patch(path: 'patch/{id}')
+  Future<Response> patchTest(@Path() String id, @Body() String data);
+
+  @Post(path: 'map')
+  Future<Response> mapTest(@Body() Map<String, String> map);
+
+  @FactoryConverter(request: convertForm)
+  @Post(path: 'form/body')
+  Future<Response> postForm(@Body() Map<String, String> fields);
+
+  @Post(path: 'form/body', headers: {contentTypeKey: formEncodedHeaders})
+  Future<Response> postFormUsingHeaders(@Body() Map<String, String> fields);
+
+  @FactoryConverter(request: convertForm)
+  @Post(path: 'form/body/fields')
+  Future<Response> postFormFields(@Field() String foo, @Field() int bar);
+
+  @Post(path: 'map/json')
+  @FactoryConverter(
+    request: customConvertRequest,
+    response: customConvertResponse,
+  )
+  Future<Response> forceJsonTest(@Body() Map map);
+
+  @Post(path: 'multi')
+  @multipart
+  Future<Response> postResources(
+    @Part('1') Map a,
+    @Part('2') Map b,
+  );
+
+  @Post(path: 'file')
+  @multipart
+  Future<Response> postFile(
+    @PartFile('file') List<int> bytes,
+  );
+
+  @Post(path: 'image')
+  @multipart
+  Future<Response> postImage(
+    @PartFile('image') List<int> imageData,
+  );
+
+  @Post(path: 'file')
+  @multipart
+  Future<Response> postMultipartFile(
+    @PartFile() MultipartFile file, {
+    @Part() String? id,
+  });
+
+  @Post(path: 'files')
+  @multipart
+  Future<Response> postListFiles(@PartFile() List<MultipartFile> files);
+
+  @Post(path: 'multipart_list')
+  @multipart
+  Future<Response> postMultipartList({
+    @Part('ints') required List<int> ints,
+    @Part('doubles') required List<double> doubles,
+    @Part('nums') required List<num> nums,
+    @Part('strings') required List<String> strings,
+  });
+
+  @Get(path: 'https://test.com')
+  Future fullUrl();
+
+  @Get(path: '/list/string')
+  Future<Response<List<String>>> listString();
+
+  @Post(path: 'no-body')
+  Future<Response> noBody();
+
+  @Get(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
+  Future<Response<String>> getUsingQueryParamIncludeNullQueryVars({
+    @Query('foo') String? foo,
+    @Query('bar') String? bar,
+    @Query('baz') String? baz,
+  });
+
+  @Get(path: '/list_query_param')
+  Future<Response<String>> getUsingListQueryParam(
+    @Query('value') List<String> value,
+  );
+
+  @Get(path: '/list_query_param_with_brackets', useBrackets: true)
+  Future<Response<String>> getUsingListQueryParamWithBrackets(
+    @Query('value') List<String> value,
+  );
+
+  @Get(path: '/map_query_param')
+  Future<Response<String>> getUsingMapQueryParam(
+    @Query('value') Map<String, dynamic> value,
+  );
+
+  @Get(
+    path: '/map_query_param_include_null_query_vars',
+    includeNullQueryVars: true,
+  )
+  Future<Response<String>> getUsingMapQueryParamIncludeNullQueryVars(
+    @Query('value') Map<String, dynamic> value,
+  );
+
+  @Get(path: '/map_query_param_with_brackets', useBrackets: true)
+  Future<Response<String>> getUsingMapQueryParamWithBrackets(
+    @Query('value') Map<String, dynamic> value,
+  );
+}
+
+Request customConvertRequest(Request req) {
+  final r = JsonConverter().convertRequest(req);
+
+  return applyHeader(r, 'customConverter', 'true');
+}
+
+Response<T> customConvertResponse<T>(Response res) =>
+    res.copyWith(body: json.decode(res.body));
+
+Request convertForm(Request req) {
+  req = applyHeader(req, contentTypeKey, formEncodedHeaders);
+
+  if (req.body is Map) {
+    final body = <String, String>{};
+
+    req.body.forEach((key, val) {
+      if (val != null) {
+        body[key.toString()] = val.toString();
+      }
+    });
+
+    req = req.copyWith(body: body);
+  }
+
+  return req;
+}


### PR DESCRIPTION
I created this pr to give support to top level variables for the scenarios where we have multiple urls and that urls depend on ambient. for example we have our service A to make the main requests but we have service B to specific funcionality with diferent base url and maybe we want to change the service B to a dev version, so to change the url we have tu rebuild the chopper files because base url points to the literal value of the variable, with this change we don't need to rebuild in that scenerio because we can point the base url to a top level variable and that variable is going to be present in the generated file instead of the literal value

Imaging this case

```dart
const String enviromentUrl = Enviroments.temporal;

class Enviroments {
  static const String temporal = 'https://api.example.app';
}
```

```dart
@ChopperApi(baseUrl: enviromentUrl)
abstract class TeacherDatasource extends ChopperService {
  @Get(path: '/get_teachers/start/open')
  Future<Response<List<TeacherModel>>> getTeachers();

  static TeacherDatasource create([ChopperClient? client]) =>
      _$TeacherDatasource(client);
}
```

Before the change:

```dart
final class _$TeacherDatasource extends TeacherDatasource {
  _$TeacherDatasource([ChopperClient? client]) {
    if (client == null) return;
    this.client = client;
  }

  @override
  final definitionType = TeacherDatasource;

  @override
  Future<Response<List<TeacherModel>>> getTeachers() {
    final Uri $url =
        Uri.parse('https://api.example.app/get_teachers/start/open');
    final Request $request = Request(
      'GET',
      $url,
      client.baseUrl,
    );
    return client.send<List<TeacherModel>, TeacherModel>($request);
  }
}
```

After the change:

```dart
final class _$TeacherDatasource extends TeacherDatasource {
  _$TeacherDatasource([ChopperClient? client]) {
    if (client == null) return;
    this.client = client;
  }

  @override
  final definitionType = TeacherDatasource;

  @override
  Future<Response<List<TeacherModel>>> getTeachers() {
    final Uri $url = Uri.parse('${enviromentUrl}/get_teachers/start/open');
    final Request $request = Request(
      'GET',
      $url,
      client.baseUrl,
    );
    return client.send<List<TeacherModel>, TeacherModel>($request);
  }
}
```
