### PR TITLE
:bug: fix chopper base.dart send() authenticate sending wrong request

### DIFF
--- a/chopper/lib/src/base.dart
+++ b/chopper/lib/src/base.dart
@@ -309,11 +309,8 @@ base class ChopperClient {
     dynamic res = Response(response, response.body);
 
     if (authenticator != null) {
-      final Request? updatedRequest = await authenticator!.authenticate(
-        request,
-        res,
-        request,
-      );
+      final Request? updatedRequest =
+          await authenticator!.authenticate(req, res, request);
 
       if (updatedRequest != null) {
         res = await send<BodyType, InnerType>(

--- a/chopper/lib/src/interceptor.dart
+++ b/chopper/lib/src/interceptor.dart
@@ -193,9 +193,12 @@ class JsonConverter implements Converter, ErrorConverter {
   Request encodeJson(Request request) {
     final String? contentType = request.headers[contentTypeKey];
 
-    return (contentType?.contains(jsonHeaders) ?? false)
-        ? request.copyWith(body: json.encode(request.body))
-        : request;
+    if ((contentType?.contains(jsonHeaders) ?? false) &&
+        (request.body.runtimeType != String || !_isJson(request.body))) {
+      return request.copyWith(body: json.encode(request.body));
+    }
+
+    return request;
   }
 
   FutureOr<Response> decodeJson<BodyType, InnerType>(Response response) async {
@@ -255,6 +258,15 @@ class JsonConverter implements Converter, ErrorConverter {
 
   static Request requestFactory(Request request) =>
       const JsonConverter().convertRequest(request);
+
+  static bool _isJson(dynamic data) {
+    try {
+      json.decode(data);
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
 }
 
 /// A [Converter] implementation that converts only [Request]s having a [Map] as their body.

--- a/chopper/lib/src/interceptor.dart
+++ b/chopper/lib/src/interceptor.dart
@@ -194,7 +194,7 @@ class JsonConverter implements Converter, ErrorConverter {
     final String? contentType = request.headers[contentTypeKey];
 
     if ((contentType?.contains(jsonHeaders) ?? false) &&
-        (request.body.runtimeType != String || !_isJson(request.body))) {
+        (request.body.runtimeType != String || !isJson(request.body))) {
       return request.copyWith(body: json.encode(request.body));
     }
 
@@ -259,7 +259,8 @@ class JsonConverter implements Converter, ErrorConverter {
   static Request requestFactory(Request request) =>
       const JsonConverter().convertRequest(request);
 
-  static bool _isJson(dynamic data) {
+  @visibleForTesting
+  static bool isJson(dynamic data) {
     try {
       json.decode(data);
       return true;

--- a/chopper/test/converter_test.dart
+++ b/chopper/test/converter_test.dart
@@ -119,13 +119,16 @@ void main() {
       expect(JsonConverter.isJson(null), isFalse);
       expect(JsonConverter.isJson(42), isFalse);
       expect(JsonConverter.isJson([]), isFalse);
-      expect(JsonConverter.isJson([1,2,3]), isFalse);
+      expect(JsonConverter.isJson([1, 2, 3]), isFalse);
       expect(JsonConverter.isJson(['a', 'b', 'c']), isFalse);
       expect(JsonConverter.isJson({}), isFalse);
-      expect(JsonConverter.isJson({
-        'foo': 'bar',
-        'list': [1, 2, 3],
-      }), isFalse);
+      expect(
+        JsonConverter.isJson({
+          'foo': 'bar',
+          'list': [1, 2, 3],
+        }),
+        isFalse,
+      );
     });
   });
 

--- a/chopper/test/converter_test.dart
+++ b/chopper/test/converter_test.dart
@@ -111,6 +111,22 @@ void main() {
 
       expect(converted.body, equals({'foo': 'bar'}));
     });
+
+    test('JsonConverter.isJson', () {
+      expect(JsonConverter.isJson('{"foo":"bar"}'), isTrue);
+      expect(JsonConverter.isJson('foo'), isFalse);
+      expect(JsonConverter.isJson(''), isFalse);
+      expect(JsonConverter.isJson(null), isFalse);
+      expect(JsonConverter.isJson(42), isFalse);
+      expect(JsonConverter.isJson([]), isFalse);
+      expect(JsonConverter.isJson([1,2,3]), isFalse);
+      expect(JsonConverter.isJson(['a', 'b', 'c']), isFalse);
+      expect(JsonConverter.isJson({}), isFalse);
+      expect(JsonConverter.isJson({
+        'foo': 'bar',
+        'list': [1, 2, 3],
+      }), isFalse);
+    });
   });
 
   test('respects content-type headers', () {


### PR DESCRIPTION
Fixes #492

Also fixes #388 and properly implements #390 by checking if the `request.body` is already a JSON before encoding it to JSON thereby preventing duplicate JSON encoding when using the `authenticator`.