### PR TITLE
:bug: Fix chopper_built_value pub.dev topics

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,6 +68,19 @@ jobs:
           dart pub get
           echo "IS_VERSION_GREATER=$(dart run compare_versions.dart $THIS_VERSION $BASE_VERSION_${{ matrix.package }})" >> $GITHUB_ENV
           popd || exit
+      - name: Validate pub.dev topics
+        id: validate_pub_dev_topics
+        run: |
+          set -e
+          pushd ${{ matrix.package }} || exit
+          pattern="^[a-z][a-z0-9-]*[a-z0-9]$"
+          for topic in $(yq -r '.topics[]' pubspec.yaml); do
+            if [[ ! $topic =~ $pattern ]]; then
+              echo "Invalid topic: $topic"
+              exit 1
+            fi
+          done
+          popd || exit
       - name: Set up pub credentials
         id: credentials
         if: ${{ env.IS_VERSION_GREATER == 1 }}

--- a/.github/workflows/publish_dry_run.yml
+++ b/.github/workflows/publish_dry_run.yml
@@ -67,6 +67,19 @@ jobs:
           dart pub get
           echo "IS_VERSION_GREATER=$(dart run compare_versions.dart $THIS_VERSION $BASE_VERSION_${{ matrix.package }})" >> $GITHUB_ENV
           popd || exit
+      - name: Validate pub.dev topics
+        id: validate_pub_dev_topics
+        run: |
+          set -e
+          pushd ${{ matrix.package }} || exit
+          pattern="^[a-z][a-z0-9-]*[a-z0-9]$"
+          for topic in $(yq -r '.topics[]' pubspec.yaml); do
+            if [[ ! $topic =~ $pattern ]]; then
+              echo "Invalid topic: $topic"
+              exit 1
+            fi
+          done
+          popd || exit
       - name: Publish (dry run)
         id: publish_dry_run
         if: ${{ env.IS_VERSION_GREATER == 1 }}

--- a/chopper_built_value/CHANGELOG.md
+++ b/chopper_built_value/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.1+1
+
+- Fix pub.dev topics
+
 ## 2.0.1
 
 - Add pub.dev topics to package metadata ([#495](https://github.com/lejard-h/chopper/pull/495))

--- a/chopper_built_value/CHANGELOG.md
+++ b/chopper_built_value/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.0.1+1
 
-- Fix pub.dev topics
+- Fix pub.dev topic in package metadata ([#498](https://github.com/lejard-h/chopper/pull/498))
 
 ## 2.0.1
 

--- a/chopper_built_value/pubspec.yaml
+++ b/chopper_built_value/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chopper_built_value
 description: A built_value based Converter for Chopper.
-version: 2.0.1
+version: 2.0.1+1
 documentation: https://hadrien-lejard.gitbook.io/chopper/converters/built-value-converter
 repository: https://github.com/lejard-h/chopper
 
@@ -27,4 +27,4 @@ dependency_overrides:
 topics:
   - codegen
   - converter
-  - built_value
+  - built-value


### PR DESCRIPTION
Fixes

```
Invalid `topics` value (`built_value`): must consist of lowercase alphanumerical characters or dash (but no double dash), starting with a-z and ending with a-z or 0-9.
```

Looks like the topic `built_value` has to be renamed to `built-value` 😒 Odd that `dart pub publish --dry-run` didn't catch it.

To prevent this in the future, I've added a step into both the `publish.yml` and `publish_dry_run.yml` workflows:

```yaml
- name: Validate pub.dev topics
  id: validate_pub_dev_topics
  run: |
    set -e
    pushd ${{ matrix.package }} || exit
    pattern="^[a-z][a-z0-9-]*[a-z0-9]$"
    for topic in $(yq -r '.topics[]' pubspec.yaml); do
      if [[ ! $topic =~ $pattern ]]; then
        echo "Invalid topic: $topic"
        exit 1
      fi
    done
    popd || exit
```