### PR TITLE
Fix incorrect url generation when using new baseurl

### DIFF
--- a/chopper/CHANGELOG.md
+++ b/chopper/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 7.0.9
 
-- Fix ChopperGenerator building ```https://...``` with one slash ([#519](https://github.com/lejard-h/chopper/pull/519))
+- Fix ChopperGenerator building ```https://...``` with one slash ([#520](https://github.com/lejard-h/chopper/pull/520))
 
 ## 7.0.8
 

--- a/chopper/CHANGELOG.md
+++ b/chopper/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.0.9
+
+- Fix ChopperGenerator building ```https://...``` with one slash ([#519](https://github.com/lejard-h/chopper/pull/519))
+
 ## 7.0.8
 
 - Encode DateTime query parameters in ISO8601 format ([#516](https://github.com/lejard-h/chopper/pull/516))

--- a/chopper/CHANGELOG.md
+++ b/chopper/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## 7.0.9
-
-- Fix ChopperGenerator building ```https://...``` with one slash ([#520](https://github.com/lejard-h/chopper/pull/520))
-
 ## 7.0.8
 
 - Encode DateTime query parameters in ISO8601 format ([#516](https://github.com/lejard-h/chopper/pull/516))

--- a/chopper/test/base_test.dart
+++ b/chopper/test/base_test.dart
@@ -10,6 +10,7 @@ import 'package:test/test.dart';
 import 'package:transparent_image/transparent_image.dart';
 
 import 'test_service.dart';
+import 'test_service_base_url.dart';
 import 'test_service_variable.dart';
 
 final baseUrl = Uri.parse('http://localhost:8000');
@@ -26,6 +27,7 @@ void main() {
           // the generated service
           HttpTestService.create(),
           HttpTestServiceVariable.create(),
+          HttpTestServiceBaseUrl.create(),
         ],
         client: httpClient,
         errorConverter: errorConverter,
@@ -1164,6 +1166,23 @@ void main() {
     await service.getAll();
   });
 
+  test('Empty path gives no trailing slash new base url', () async {
+    final httpClient = MockClient((request) async {
+      expect(
+        request.url.toString(),
+        equals('$testEnv/test'),
+      );
+      expect(request.method, equals('GET'));
+
+      return http.Response('get response', 200);
+    });
+
+    final chopper = buildClient(httpClient);
+    final service = chopper.getService<HttpTestServiceBaseUrl>();
+
+    await service.getAll();
+  });
+
   test('Slash in path gives a trailing slash', () async {
     final httpClient = MockClient((request) async {
       expect(
@@ -1177,6 +1196,23 @@ void main() {
 
     final chopper = buildClient(httpClient);
     final service = chopper.getService<HttpTestService>();
+
+    await service.getAllWithTrailingSlash();
+  });
+
+  test('Slash in path gives a trailing slash new base url', () async {
+    final httpClient = MockClient((request) async {
+      expect(
+        request.url.toString(),
+        equals('$testEnv/test/'),
+      );
+      expect(request.method, equals('GET'));
+
+      return http.Response('get response', 200);
+    });
+
+    final chopper = buildClient(httpClient);
+    final service = chopper.getService<HttpTestServiceBaseUrl>();
 
     await service.getAllWithTrailingSlash();
   });

--- a/chopper/test/ensure_build_test.dart
+++ b/chopper/test/ensure_build_test.dart
@@ -6,17 +6,13 @@ import 'package:test/test.dart';
 void main() {
   test(
     'ensure_build',
-    () {
-      expectBuildClean(
+    () async {
+      await expectBuildClean(
         packageRelativeDirectory: 'chopper',
         gitDiffPathArguments: [
           'test/test_service.chopper.dart',
-        ],
-      );
-      expectBuildClean(
-        packageRelativeDirectory: 'chopper',
-        gitDiffPathArguments: [
           'test/test_service_variable.chopper.dart',
+          'test/test_service_base_url.chopper.dart',
         ],
       );
     },

--- a/chopper/test/test_service_base_url.chopper.dart
+++ b/chopper/test/test_service_base_url.chopper.dart
@@ -1,0 +1,148 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'test_service_base_url.dart';
+
+// **************************************************************************
+// ChopperGenerator
+// **************************************************************************
+
+// ignore_for_file: type=lint
+final class _$HttpTestServiceBaseUrl extends HttpTestServiceBaseUrl {
+  _$HttpTestServiceBaseUrl([ChopperClient? client]) {
+    if (client == null) return;
+    this.client = client;
+  }
+
+  @override
+  final definitionType = HttpTestServiceBaseUrl;
+
+  @override
+  Future<Response<dynamic>> getAll() {
+    final Uri $url = Uri.parse('https://localhost:4000/test');
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> getAllWithTrailingSlash() {
+    final Uri $url = Uri.parse('https://localhost:4000/test/');
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<List<String>>> listString() {
+    final Uri $url = Uri.parse('https://localhost:4000/test/list/string');
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<List<String>, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getUsingQueryParamIncludeNullQueryVars({
+    String? foo,
+    String? bar,
+    String? baz,
+  }) {
+    final Uri $url = Uri.parse(
+        'https://localhost:4000/test/query_param_include_null_query_vars');
+    final Map<String, dynamic> $params = <String, dynamic>{
+      'foo': foo,
+      'bar': bar,
+      'baz': baz,
+    };
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      includeNullQueryVars: true,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getUsingListQueryParam(List<String> value) {
+    final Uri $url = Uri.parse('https://localhost:4000/test/list_query_param');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getUsingListQueryParamWithBrackets(
+      List<String> value) {
+    final Uri $url =
+        Uri.parse('https://localhost:4000/test/list_query_param_with_brackets');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      useBrackets: true,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getUsingMapQueryParam(Map<String, dynamic> value) {
+    final Uri $url = Uri.parse('https://localhost:4000/test/map_query_param');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getUsingMapQueryParamIncludeNullQueryVars(
+      Map<String, dynamic> value) {
+    final Uri $url = Uri.parse(
+        'https://localhost:4000/test/map_query_param_include_null_query_vars');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      includeNullQueryVars: true,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getUsingMapQueryParamWithBrackets(
+      Map<String, dynamic> value) {
+    final Uri $url =
+        Uri.parse('https://localhost:4000/test/map_query_param_with_brackets');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      useBrackets: true,
+    );
+    return client.send<String, String>($request);
+  }
+}

--- a/chopper/test/test_service_base_url.dart
+++ b/chopper/test/test_service_base_url.dart
@@ -1,0 +1,83 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:chopper/chopper.dart';
+
+part 'test_service_base_url.chopper.dart';
+
+@ChopperApi(baseUrl: 'https://localhost:4000/test')
+abstract class HttpTestServiceBaseUrl extends ChopperService {
+  static HttpTestServiceBaseUrl create([ChopperClient? client]) =>
+      _$HttpTestServiceBaseUrl(client);
+
+  @Get(path: '')
+  Future<Response> getAll();
+
+  @Get(path: '/')
+  Future<Response> getAllWithTrailingSlash();
+
+  @Get(path: '/list/string')
+  Future<Response<List<String>>> listString();
+
+  @Get(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
+  Future<Response<String>> getUsingQueryParamIncludeNullQueryVars({
+    @Query('foo') String? foo,
+    @Query('bar') String? bar,
+    @Query('baz') String? baz,
+  });
+
+  @Get(path: '/list_query_param')
+  Future<Response<String>> getUsingListQueryParam(
+    @Query('value') List<String> value,
+  );
+
+  @Get(path: '/list_query_param_with_brackets', useBrackets: true)
+  Future<Response<String>> getUsingListQueryParamWithBrackets(
+    @Query('value') List<String> value,
+  );
+
+  @Get(path: '/map_query_param')
+  Future<Response<String>> getUsingMapQueryParam(
+    @Query('value') Map<String, dynamic> value,
+  );
+
+  @Get(
+    path: '/map_query_param_include_null_query_vars',
+    includeNullQueryVars: true,
+  )
+  Future<Response<String>> getUsingMapQueryParamIncludeNullQueryVars(
+    @Query('value') Map<String, dynamic> value,
+  );
+
+  @Get(path: '/map_query_param_with_brackets', useBrackets: true)
+  Future<Response<String>> getUsingMapQueryParamWithBrackets(
+    @Query('value') Map<String, dynamic> value,
+  );
+}
+
+Request customConvertRequest(Request req) {
+  final r = JsonConverter().convertRequest(req);
+
+  return applyHeader(r, 'customConverter', 'true');
+}
+
+Response<T> customConvertResponse<T>(Response res) =>
+    res.copyWith(body: json.decode(res.body));
+
+Request convertForm(Request req) {
+  req = applyHeader(req, contentTypeKey, formEncodedHeaders);
+
+  if (req.body is Map) {
+    final body = <String, String>{};
+
+    req.body.forEach((key, val) {
+      if (val != null) {
+        body[key.toString()] = val.toString();
+      }
+    });
+
+    req = req.copyWith(body: body);
+  }
+
+  return req;
+}

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -550,11 +550,21 @@ final class ChopperGenerator
       }
     }
 
+    if (finalBaseUrl.startsWith('http://') ||
+        finalBaseUrl.startsWith('https://')) {
+      final tempUri = Uri.tryParse(finalBaseUrl);
+
+      if (tempUri != null) {
+        final urlNoScheme =
+            '${tempUri.authority}${tempUri.path}$path'.replaceAll('//', '/');
+        return _generateUri(
+          '${tempUri.scheme}://$urlNoScheme',
+        );
+      }
+    }
+
     return _generateUri(
-      '$finalBaseUrl$path'.replaceAll(
-        RegExp(r'(?<!http:|https:)\/\/'),
-        '/',
-      ),
+      '$finalBaseUrl$path'.replaceAll('//', '/'),
     );
   }
 

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -550,7 +550,12 @@ final class ChopperGenerator
       }
     }
 
-    return _generateUri('$finalBaseUrl$path'.replaceAll('//', '/'));
+    return _generateUri(
+      '$finalBaseUrl$path'.replaceAll(
+        RegExp(r'(?<!http:|https:)\/\/'),
+        '/',
+      ),
+    );
   }
 
   static Expression _generateUri(String url) =>


### PR DESCRIPTION
I rewrite the replaceallMethod that removes double ```//``` making it follow a regular expresion that ignores ```http://``` and ```https://``` on the replacement

---

Addresses #519