### PR TITLE
:bookmark: release chopper v7.0.10, chopper_generator v7.0.7

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v6.6.0
+# Created with package:mono_repo v6.6.1
 name: Dart CI
 on:
   push:
@@ -37,7 +37,7 @@ jobs:
         name: Checkout repository
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
       - name: mono_repo self validate
-        run: dart pub global activate mono_repo 6.6.0
+        run: dart pub global activate mono_repo 6.6.1
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           sdk: stable
       - id: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - run: git checkout HEAD^
@@ -53,7 +53,7 @@ jobs:
         with:
           sdk: stable
       - id: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Load this version
         id: load_this_version
         working-directory: ${{ matrix.package }}

--- a/.github/workflows/publish_dry_run.yml
+++ b/.github/workflows/publish_dry_run.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           sdk: stable
       - id: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.ref }}
       - name: Load base version
@@ -50,7 +50,7 @@ jobs:
         with:
           sdk: stable
       - id: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Load this version
         id: load_this_version
         working-directory: ${{ matrix.package }}

--- a/chopper/CHANGELOG.md
+++ b/chopper/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.0.10
+
+- Enable the user to specify non-String type header values by calling `.toString()` on any non-String Dart type. ([#538](https://github.com/lejard-h/chopper/pull/538))
+
 ## 7.0.9
 
 - Add success/failure callback hooks to Authenticator ([#527](https://github.com/lejard-h/chopper/pull/527))

--- a/chopper/example/definition.chopper.dart
+++ b/chopper/example/definition.chopper.dart
@@ -6,6 +6,7 @@ part of 'definition.dart';
 // ChopperGenerator
 // **************************************************************************
 
+// coverage:ignore-file
 // ignore_for_file: type=lint
 final class _$MyService extends MyService {
   _$MyService([ChopperClient? client]) {
@@ -14,7 +15,7 @@ final class _$MyService extends MyService {
   }
 
   @override
-  final definitionType = MyService;
+  final Type definitionType = MyService;
 
   @override
   Future<Response<dynamic>> getResource(String id) {

--- a/chopper/pubspec.yaml
+++ b/chopper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chopper
 description: Chopper is an http client generator using source_gen, inspired by Retrofit
-version: 7.0.9
+version: 7.0.10
 documentation: https://hadrien-lejard.gitbook.io/chopper
 repository: https://github.com/lejard-h/chopper
 

--- a/chopper/test/base_test.dart
+++ b/chopper/test/base_test.dart
@@ -9,6 +9,7 @@ import 'package:http/testing.dart';
 import 'package:test/test.dart';
 import 'package:transparent_image/transparent_image.dart';
 
+import 'fixtures/example_enum.dart';
 import 'test_service.dart';
 import 'test_service_base_url.dart';
 import 'test_service_variable.dart';
@@ -1612,6 +1613,38 @@ void main() {
     final response = await service.getDateTime(dateTime);
 
     expect(response.body, equals('get response'));
+    expect(response.statusCode, equals(200));
+
+    httpClient.close();
+  });
+
+  test('headers are always stringified', () async {
+    final httpClient = MockClient((request) async {
+      expect(
+        request.url.toString(),
+        equals('$baseUrl/test/headers'),
+      );
+      expect(request.method, equals('GET'));
+      expect(request.headers['x-string'], equals('lorem'));
+      expect(request.headers['x-boolean'], equals('true'));
+      expect(request.headers['x-int'], equals('42'));
+      expect(request.headers['x-double'], equals('42.42'));
+      expect(request.headers['x-enum'], equals('baz'));
+
+      return http.Response('get response', 200);
+    });
+
+    final chopper = buildClient(httpClient, JsonConverter());
+    final service = chopper.getService<HttpTestService>();
+
+    final response = await service.getHeaders(
+      stringHeader: 'lorem',
+      boolHeader: true,
+      intHeader: 42,
+      doubleHeader: 42.42,
+      enumHeader: ExampleEnum.baz,
+    );
+
     expect(response.statusCode, equals(200));
 
     httpClient.close();

--- a/chopper/test/fixtures/example_enum.dart
+++ b/chopper/test/fixtures/example_enum.dart
@@ -1,0 +1,8 @@
+enum ExampleEnum {
+  foo,
+  bar,
+  baz;
+
+  @override
+  String toString() => name;
+}

--- a/chopper/test/test_service.chopper.dart
+++ b/chopper/test/test_service.chopper.dart
@@ -6,6 +6,7 @@ part of 'test_service.dart';
 // ChopperGenerator
 // **************************************************************************
 
+// coverage:ignore-file
 // ignore_for_file: type=lint
 final class _$HttpTestService extends HttpTestService {
   _$HttpTestService([ChopperClient? client]) {
@@ -14,7 +15,7 @@ final class _$HttpTestService extends HttpTestService {
   }
 
   @override
-  final definitionType = HttpTestService;
+  final Type definitionType = HttpTestService;
 
   @override
   Future<Response<String>> getTest(
@@ -646,6 +647,31 @@ final class _$HttpTestService extends HttpTestService {
       $url,
       client.baseUrl,
       parameters: $params,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getHeaders({
+    required String stringHeader,
+    bool? boolHeader,
+    int? intHeader,
+    double? doubleHeader,
+    ExampleEnum? enumHeader,
+  }) {
+    final Uri $url = Uri.parse('/test/headers');
+    final Map<String, String> $headers = {
+      'x-string': stringHeader,
+      if (boolHeader != null) 'x-boolean': boolHeader.toString(),
+      if (intHeader != null) 'x-int': intHeader.toString(),
+      if (doubleHeader != null) 'x-double': doubleHeader.toString(),
+      if (enumHeader != null) 'x-enum': enumHeader.toString(),
+    };
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      headers: $headers,
     );
     return client.send<String, String>($request);
   }

--- a/chopper/test/test_service.dart
+++ b/chopper/test/test_service.dart
@@ -4,6 +4,8 @@ import 'dart:convert';
 import 'package:chopper/chopper.dart';
 import 'package:http/http.dart' show MultipartFile;
 
+import 'fixtures/example_enum.dart';
+
 part 'test_service.chopper.dart';
 
 @ChopperApi(baseUrl: '/test')
@@ -193,6 +195,15 @@ abstract class HttpTestService extends ChopperService {
   Future<Response<String>> getDateTime(
     @Query('value') DateTime value,
   );
+
+  @Get(path: 'headers')
+  Future<Response<String>> getHeaders({
+    @Header('x-string') required String stringHeader,
+    @Header('x-boolean') bool? boolHeader,
+    @Header('x-int') int? intHeader,
+    @Header('x-double') double? doubleHeader,
+    @Header('x-enum') ExampleEnum? enumHeader,
+  });
 }
 
 Request customConvertRequest(Request req) {

--- a/chopper/test/test_service_base_url.chopper.dart
+++ b/chopper/test/test_service_base_url.chopper.dart
@@ -6,6 +6,7 @@ part of 'test_service_base_url.dart';
 // ChopperGenerator
 // **************************************************************************
 
+// coverage:ignore-file
 // ignore_for_file: type=lint
 final class _$HttpTestServiceBaseUrl extends HttpTestServiceBaseUrl {
   _$HttpTestServiceBaseUrl([ChopperClient? client]) {
@@ -14,7 +15,7 @@ final class _$HttpTestServiceBaseUrl extends HttpTestServiceBaseUrl {
   }
 
   @override
-  final definitionType = HttpTestServiceBaseUrl;
+  final Type definitionType = HttpTestServiceBaseUrl;
 
   @override
   Future<Response<dynamic>> getAll() {

--- a/chopper/test/test_service_variable.chopper.dart
+++ b/chopper/test/test_service_variable.chopper.dart
@@ -6,6 +6,7 @@ part of 'test_service_variable.dart';
 // ChopperGenerator
 // **************************************************************************
 
+// coverage:ignore-file
 // ignore_for_file: type=lint
 final class _$HttpTestServiceVariable extends HttpTestServiceVariable {
   _$HttpTestServiceVariable([ChopperClient? client]) {
@@ -14,7 +15,7 @@ final class _$HttpTestServiceVariable extends HttpTestServiceVariable {
   }
 
   @override
-  final definitionType = HttpTestServiceVariable;
+  final Type definitionType = HttpTestServiceVariable;
 
   @override
   Future<Response<String>> getTest(

--- a/chopper_generator/CHANGELOG.md
+++ b/chopper_generator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.0.7
+
+- Enable the user to specify non-String type header values by calling `.toString()` on any non-String Dart type. ([#538](https://github.com/lejard-h/chopper/pull/538))
+
 ## 7.0.6
 
 - Fix incorrect url generation when using new baseUrl ([#520](https://github.com/lejard-h/chopper/pull/520))

--- a/chopper_generator/pubspec.yaml
+++ b/chopper_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chopper_generator
 description: Chopper is an http client generator using source_gen, inspired by Retrofit
-version: 7.0.6
+version: 7.0.7
 documentation: https://hadrien-lejard.gitbook.io/chopper
 repository: https://github.com/lejard-h/chopper
 

--- a/chopper_generator/test/test_service.chopper.dart
+++ b/chopper_generator/test/test_service.chopper.dart
@@ -6,6 +6,7 @@ part of 'test_service.dart';
 // ChopperGenerator
 // **************************************************************************
 
+// coverage:ignore-file
 // ignore_for_file: type=lint
 final class _$HttpTestService extends HttpTestService {
   _$HttpTestService([ChopperClient? client]) {
@@ -14,7 +15,7 @@ final class _$HttpTestService extends HttpTestService {
   }
 
   @override
-  final definitionType = HttpTestService;
+  final Type definitionType = HttpTestService;
 
   @override
   Future<Response<String>> getTest(
@@ -633,6 +634,31 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       parameters: $params,
       useBrackets: true,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getHeaders({
+    required String stringHeader,
+    bool? boolHeader,
+    int? intHeader,
+    double? doubleHeader,
+    ExampleEnum? enumHeader,
+  }) {
+    final Uri $url = Uri.parse('/test/headers');
+    final Map<String, String> $headers = {
+      'x-string': stringHeader,
+      if (boolHeader != null) 'x-boolean': boolHeader.toString(),
+      if (intHeader != null) 'x-int': intHeader.toString(),
+      if (doubleHeader != null) 'x-double': doubleHeader.toString(),
+      if (enumHeader != null) 'x-enum': enumHeader.toString(),
+    };
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      headers: $headers,
     );
     return client.send<String, String>($request);
   }

--- a/chopper_generator/test/test_service.dart
+++ b/chopper_generator/test/test_service.dart
@@ -188,6 +188,15 @@ abstract class HttpTestService extends ChopperService {
   Future<Response<String>> getUsingMapQueryParamWithBrackets(
     @Query('value') Map<String, dynamic> value,
   );
+
+  @Get(path: 'headers')
+  Future<Response<String>> getHeaders({
+    @Header('x-string') required String stringHeader,
+    @Header('x-boolean') bool? boolHeader,
+    @Header('x-int') int? intHeader,
+    @Header('x-double') double? doubleHeader,
+    @Header('x-enum') ExampleEnum? enumHeader,
+  });
 }
 
 Request customConvertRequest(Request req) {
@@ -215,4 +224,13 @@ Request convertForm(Request req) {
   }
 
   return req;
+}
+
+enum ExampleEnum {
+  foo,
+  bar,
+  baz;
+
+  @override
+  String toString() => name;
 }

--- a/chopper_generator/test/test_service_variable.chopper.dart
+++ b/chopper_generator/test/test_service_variable.chopper.dart
@@ -6,6 +6,7 @@ part of 'test_service_variable.dart';
 // ChopperGenerator
 // **************************************************************************
 
+// coverage:ignore-file
 // ignore_for_file: type=lint
 final class _$HttpTestServiceVariable extends HttpTestServiceVariable {
   _$HttpTestServiceVariable([ChopperClient? client]) {
@@ -14,7 +15,7 @@ final class _$HttpTestServiceVariable extends HttpTestServiceVariable {
   }
 
   @override
-  final definitionType = HttpTestServiceVariable;
+  final Type definitionType = HttpTestServiceVariable;
 
   @override
   Future<Response<String>> getTest(

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
-# Created with package:mono_repo v6.6.0
+# Created with package:mono_repo v6.6.1
 
 # Support built in commands on windows out of the box.
+
 # When it is a flutter repo (check the pubspec.yaml for "sdk: flutter")
-# then "flutter" is called instead of "pub".
+# then "flutter pub" is called instead of "dart pub".
 # This assumes that the Flutter SDK has been installed in a previous step.
 function pub() {
   if grep -Fq "sdk: flutter" "${PWD}/pubspec.yaml"; then
@@ -12,18 +13,13 @@ function pub() {
     command dart pub "$@"
   fi
 }
-# When it is a flutter repo (check the pubspec.yaml for "sdk: flutter")
-# then "flutter" is called instead of "pub".
-# This assumes that the Flutter SDK has been installed in a previous step.
+
 function format() {
-  if grep -Fq "sdk: flutter" "${PWD}/pubspec.yaml"; then
-    command flutter format "$@"
-  else
-    command dart format "$@"
-  fi
+  command dart format "$@"
 }
+
 # When it is a flutter repo (check the pubspec.yaml for "sdk: flutter")
-# then "flutter" is called instead of "pub".
+# then "flutter analyze" is called instead of "dart analyze".
 # This assumes that the Flutter SDK has been installed in a previous step.
 function analyze() {
   if grep -Fq "sdk: flutter" "${PWD}/pubspec.yaml"; then


### PR DESCRIPTION
# chopper

## 7.0.10

- Enable the user to specify non-String type header values by calling `.toString()` on any non-String Dart type. ([#538](https://github.com/lejard-h/chopper/pull/538))

# chopper_generator

## 7.0.7

- Enable the user to specify non-String type header values by calling `.toString()` on any non-String Dart type. ([#538](https://github.com/lejard-h/chopper/pull/538))