### PR TITLE
Helper function for fetching errors of specific type

### DIFF
--- a/chopper/lib/src/response.dart
+++ b/chopper/lib/src/response.dart
@@ -67,6 +67,15 @@ base class Response<BodyType> with EquatableMixin {
   String get bodyString =>
       base is http.Response ? (base as http.Response).body : '';
 
+  /// Check if the response is an error and if the error is of type [ErrorType] and casts the error to [ErrorType]. Otherwise it returns null.
+  ErrorType? errorWhereType<ErrorType>() {
+    if (error != null && error is ErrorType) {
+      return error as ErrorType;
+    } else {
+      return null;
+    }
+  }
+
   @override
   List<Object?> get props => [
         base,

--- a/chopper/test/base_test.dart
+++ b/chopper/test/base_test.dart
@@ -9,6 +9,7 @@ import 'package:http/testing.dart';
 import 'package:test/test.dart';
 import 'package:transparent_image/transparent_image.dart';
 
+import 'fixtures/error_fixtures.dart';
 import 'fixtures/example_enum.dart';
 import 'test_service.dart';
 import 'test_service_base_url.dart';
@@ -1651,44 +1652,50 @@ void main() {
   });
 
   group('Response error casting test', () {
-    test('successful response returns null', () {
+    test('Response is succesfull, [returns null]', () {
       final base = http.Response('Foobar', 200);
 
       final response = Response(base, 'Foobar');
 
-      final result = response.errorWhereType<int>();
+      final result = response.errorWhereType<FooErrorType>();
 
       expect(result, isNull);
     });
 
-    test('error response returns null if no error is set', () {
+    test('Response is unsuccessful and has no error object, [returns null]',
+        () {
       final base = http.Response('Foobar', 400);
 
       final response = Response(base, '');
 
-      final result = response.errorWhereType<int>();
+      final result = response.errorWhereType<FooErrorType>();
 
       expect(result, isNull);
     });
 
-    test('error response returns null if error is not of type', () {
+    test(
+        'Response is unsuccessful and has error object of different type, [returns null]',
+        () {
       final base = http.Response('Foobar', 400);
 
       final response = Response(base, '', error: 'Foobar');
 
-      final result = response.errorWhereType<int>();
+      final result = response.errorWhereType<FooErrorType>();
 
       expect(result, isNull);
     });
 
-    test('error response returns type if error matches type', () {
+    test(
+        'Response is unsuccessful and has error object of specified type, [returns error as ErrorType]',
+        () {
       final base = http.Response('Foobar', 400);
 
-      final response = Response(base, 'Foobar', error: 1);
+      final response = Response(base, 'Foobar', error: FooErrorType());
 
-      final result = response.errorWhereType<int>();
+      final result = response.errorWhereType<FooErrorType>();
 
-      expect(result, 1);
+      expect(result, isNotNull);
+      expect(result, isA<FooErrorType>());
     });
   });
 }

--- a/chopper/test/base_test.dart
+++ b/chopper/test/base_test.dart
@@ -1649,4 +1649,46 @@ void main() {
 
     httpClient.close();
   });
+
+  group('Response error casting test', () {
+    test('successful response returns null', () {
+      final base = http.Response('Foobar', 200);
+
+      final response = Response(base, 'Foobar');
+
+      final result = response.errorWhereType<int>();
+
+      expect(result, isNull);
+    });
+
+    test('error response returns null if no error is set', () {
+      final base = http.Response('Foobar', 400);
+
+      final response = Response(base, '');
+
+      final result = response.errorWhereType<int>();
+
+      expect(result, isNull);
+    });
+
+    test('error response returns null if error is not of type', () {
+      final base = http.Response('Foobar', 400);
+
+      final response = Response(base, '', error: 'Foobar');
+
+      final result = response.errorWhereType<int>();
+
+      expect(result, isNull);
+    });
+
+    test('error response returns type if error matches type', () {
+      final base = http.Response('Foobar', 400);
+
+      final response = Response(base, 'Foobar', error: 1);
+
+      final result = response.errorWhereType<int>();
+
+      expect(result, 1);
+    });
+  });
 }

--- a/chopper/test/fixtures/error_fixtures.dart
+++ b/chopper/test/fixtures/error_fixtures.dart
@@ -1,0 +1,3 @@
+class FooErrorType {
+  const FooErrorType();
+}


### PR DESCRIPTION
Added simple helper function for fetching error of a specific type. This could be helpful when a error converter is added to convert error into a custom error object. This reduces the boilerplate needed to get the custom error from the response.

See #429 