### PR TITLE
:sparkles: Feature: Omit Response in service

### DIFF
--- a/chopper/lib/src/chopper_http_exception.dart
+++ b/chopper/lib/src/chopper_http_exception.dart
@@ -1,0 +1,13 @@
+import 'package:chopper/src/response.dart';
+
+/// An exception thrown when a [Response] is unsuccessful < 200 or > 300.
+class ChopperHttpException implements Exception {
+  ChopperHttpException(this.response);
+
+  final Response response;
+
+  @override
+  String toString() {
+    return 'Could not fetch the response for ${response.base.request}. Status code: ${response.statusCode}, error: ${response.error}';
+  }
+}

--- a/chopper/lib/src/response.dart
+++ b/chopper/lib/src/response.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:equatable/equatable.dart' show EquatableMixin;
@@ -73,6 +74,20 @@ base class Response<BodyType> with EquatableMixin {
       return error as ErrorType;
     } else {
       return null;
+    }
+  }
+
+  /// Returns the response body if [Response] [isSuccessful] and [body] is not null.
+  /// Otherwise it throws an [HttpException] with the response status code and error object.
+  /// If the error object is an [Exception], it will be thrown instead.
+  BodyType get bodyOrThrow {
+    if (isSuccessful && body != null) {
+      return body!;
+    } else {
+      if (error is Exception) {
+        throw error!;
+      }
+      throw HttpException('Could not fetch response $statusCode: $error');
     }
   }
 

--- a/chopper/lib/src/response.dart
+++ b/chopper/lib/src/response.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:chopper/src/chopper_http_exception.dart';
 import 'package:equatable/equatable.dart' show EquatableMixin;
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
@@ -87,7 +88,7 @@ base class Response<BodyType> with EquatableMixin {
       if (error is Exception) {
         throw error!;
       }
-      throw HttpException('Could not fetch response $statusCode: $error');
+      throw ChopperHttpException(this);
     }
   }
 

--- a/chopper/lib/src/response.dart
+++ b/chopper/lib/src/response.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:chopper/src/chopper_http_exception.dart';

--- a/chopper/test/base_test.dart
+++ b/chopper/test/base_test.dart
@@ -9,7 +9,6 @@ import 'package:http/testing.dart';
 import 'package:test/test.dart';
 import 'package:transparent_image/transparent_image.dart';
 
-import 'fixtures/error_fixtures.dart';
 import 'fixtures/example_enum.dart';
 import 'test_service.dart';
 import 'test_service_base_url.dart';
@@ -1649,53 +1648,5 @@ void main() {
     expect(response.statusCode, equals(200));
 
     httpClient.close();
-  });
-
-  group('Response error casting test', () {
-    test('Response is succesfull, [returns null]', () {
-      final base = http.Response('Foobar', 200);
-
-      final response = Response(base, 'Foobar');
-
-      final result = response.errorWhereType<FooErrorType>();
-
-      expect(result, isNull);
-    });
-
-    test('Response is unsuccessful and has no error object, [returns null]',
-        () {
-      final base = http.Response('Foobar', 400);
-
-      final response = Response(base, '');
-
-      final result = response.errorWhereType<FooErrorType>();
-
-      expect(result, isNull);
-    });
-
-    test(
-        'Response is unsuccessful and has error object of different type, [returns null]',
-        () {
-      final base = http.Response('Foobar', 400);
-
-      final response = Response(base, '', error: 'Foobar');
-
-      final result = response.errorWhereType<FooErrorType>();
-
-      expect(result, isNull);
-    });
-
-    test(
-        'Response is unsuccessful and has error object of specified type, [returns error as ErrorType]',
-        () {
-      final base = http.Response('Foobar', 400);
-
-      final response = Response(base, 'Foobar', error: FooErrorType());
-
-      final result = response.errorWhereType<FooErrorType>();
-
-      expect(result, isNotNull);
-      expect(result, isA<FooErrorType>());
-    });
   });
 }

--- a/chopper/test/chopper_http_exception_test.dart
+++ b/chopper/test/chopper_http_exception_test.dart
@@ -1,0 +1,21 @@
+import 'package:chopper/src/chopper_http_exception.dart';
+import 'package:chopper/src/response.dart';
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+
+void main() {
+  test('ChopperHttpException toString prints available information', () {
+    final request = http.Request('GET', Uri.parse('http://localhost:8000'));
+    final base = http.Response('Foobar', 400, request: request);
+    final response = Response(base, 'Foobar', error: 'FooError');
+
+    final exception = ChopperHttpException(response);
+
+    final result = exception.toString();
+
+    expect(
+      result,
+      'Could not fetch the response for GET http://localhost:8000. Status code: 400, error: FooError',
+    );
+  });
+}

--- a/chopper/test/ensure_build_test.dart
+++ b/chopper/test/ensure_build_test.dart
@@ -12,6 +12,7 @@ void main() {
         gitDiffPathArguments: [
           'test/test_service.chopper.dart',
           'test/test_service_variable.chopper.dart',
+          'test/test_without_response_service.chopper.dart',
           'test/test_service_base_url.chopper.dart',
         ],
       );

--- a/chopper/test/response_test.dart
+++ b/chopper/test/response_test.dart
@@ -106,7 +106,7 @@ void main() {
       final base = http.Response('Foobar', 200);
       // Ignoring void checks for testing purposes
       //ignore: void_checks
-      final Response<void> response = Response(base, Null);
+      final Response<void> response = Response(base, '');
 
       expect(() => response.bodyOrThrow, returnsNormally);
     });

--- a/chopper/test/response_test.dart
+++ b/chopper/test/response_test.dart
@@ -1,8 +1,7 @@
-import 'dart:io';
-
+import 'package:chopper/src/chopper_http_exception.dart';
 import 'package:chopper/src/response.dart';
-import 'package:test/test.dart';
 import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
 
 import 'fixtures/error_fixtures.dart';
 
@@ -81,25 +80,35 @@ void main() {
       final base = http.Response('Foobar', 400);
       final response = Response(base, '', error: 'Error occurred');
 
-      expect(() => response.bodyOrThrow, throwsA(isA<HttpException>()));
+      expect(() => response.bodyOrThrow, throwsA(isA<ChopperHttpException>()));
     });
 
     test(
-        'Response is unsuccessful and has no error, [bodyOrThrow throws HttpException]',
+        'Response is unsuccessful and has no error, [bodyOrThrow throws ChopperHttpException]',
         () {
       final base = http.Response('Foobar', 400);
       final response = Response(base, '');
 
-      expect(() => response.bodyOrThrow, throwsA(isA<HttpException>()));
+      expect(() => response.bodyOrThrow, throwsA(isA<ChopperHttpException>()));
     });
 
     test(
-        'Response is successful and has no body, [bodyOrThrow throws HttpException]',
+        'Response is successful and has no body, [bodyOrThrow throws ChopperHttpException]',
         () {
       final base = http.Response('Foobar', 200);
-      final response = Response(base, null);
+      final Response<String> response = Response(base, null);
 
-      expect(() => response.bodyOrThrow, throwsA(isA<HttpException>()));
+      expect(() => response.bodyOrThrow, throwsA(isA<ChopperHttpException>()));
+    });
+
+    test('Response is successful and has void body, [bodyOrThrow returns void]',
+        () {
+      final base = http.Response('Foobar', 200);
+      // Ignoring void checks for testing purposes
+      //ignore: void_checks
+      final Response<void> response = Response(base, Null);
+
+      expect(() => response.bodyOrThrow, returnsNormally);
     });
   });
 }

--- a/chopper/test/response_test.dart
+++ b/chopper/test/response_test.dart
@@ -1,0 +1,105 @@
+import 'dart:io';
+
+import 'package:chopper/src/response.dart';
+import 'package:test/test.dart';
+import 'package:http/http.dart' as http;
+
+import 'fixtures/error_fixtures.dart';
+
+void main() {
+  group('Response error casting test', () {
+    test('Response is succesfull, [returns null]', () {
+      final base = http.Response('Foobar', 200);
+
+      final response = Response(base, 'Foobar');
+
+      final result = response.errorWhereType<FooErrorType>();
+
+      expect(result, isNull);
+    });
+
+    test('Response is unsuccessful and has no error object, [returns null]',
+        () {
+      final base = http.Response('Foobar', 400);
+
+      final response = Response(base, '');
+
+      final result = response.errorWhereType<FooErrorType>();
+
+      expect(result, isNull);
+    });
+
+    test(
+        'Response is unsuccessful and has error object of different type, [returns null]',
+        () {
+      final base = http.Response('Foobar', 400);
+
+      final response = Response(base, '', error: 'Foobar');
+
+      final result = response.errorWhereType<FooErrorType>();
+
+      expect(result, isNull);
+    });
+
+    test(
+        'Response is unsuccessful and has error object of specified type, [returns error as ErrorType]',
+        () {
+      final base = http.Response('Foobar', 400);
+
+      final response = Response(base, 'Foobar', error: FooErrorType());
+
+      final result = response.errorWhereType<FooErrorType>();
+
+      expect(result, isNotNull);
+      expect(result, isA<FooErrorType>());
+    });
+  });
+
+  group('bodyOrThrow tests', () {
+    test('Response is successful and has body, [bodyOrThrow returns body]', () {
+      final base = http.Response('Foobar', 200);
+      final response = Response(base, {'Foo': 'Bar'});
+
+      final result = response.bodyOrThrow;
+
+      expect(result, isNotNull);
+      expect(result, {'Foo': 'Bar'});
+    });
+
+    test(
+        'Response is unsuccessful and has Exception as error, [bodyOrThrow throws error]',
+        () {
+      final base = http.Response('Foobar', 400);
+      final response = Response(base, '', error: Exception('Error occurred'));
+
+      expect(() => response.bodyOrThrow, throwsA(isA<Exception>()));
+    });
+
+    test(
+        'Response is unsuccessful and has non-exception object as error, [bodyOrThrow throws error]',
+        () {
+      final base = http.Response('Foobar', 400);
+      final response = Response(base, '', error: 'Error occurred');
+
+      expect(() => response.bodyOrThrow, throwsA(isA<HttpException>()));
+    });
+
+    test(
+        'Response is unsuccessful and has no error, [bodyOrThrow throws HttpException]',
+        () {
+      final base = http.Response('Foobar', 400);
+      final response = Response(base, '');
+
+      expect(() => response.bodyOrThrow, throwsA(isA<HttpException>()));
+    });
+
+    test(
+        'Response is successful and has no body, [bodyOrThrow throws HttpException]',
+        () {
+      final base = http.Response('Foobar', 200);
+      final response = Response(base, null);
+
+      expect(() => response.bodyOrThrow, throwsA(isA<HttpException>()));
+    });
+  });
+}

--- a/chopper/test/test_service.chopper.dart
+++ b/chopper/test/test_service.chopper.dart
@@ -513,14 +513,14 @@ final class _$HttpTestService extends HttpTestService {
   }
 
   @override
-  Future<dynamic> fullUrl() {
+  Future<Response<dynamic>> fullUrl() {
     final Uri $url = Uri.parse('https://test.com');
     final Request $request = Request(
       'GET',
       $url,
       client.baseUrl,
     );
-    return client.send($request);
+    return client.send<dynamic, dynamic>($request);
   }
 
   @override

--- a/chopper/test/test_service.dart
+++ b/chopper/test/test_service.dart
@@ -148,7 +148,7 @@ abstract class HttpTestService extends ChopperService {
   });
 
   @Get(path: 'https://test.com')
-  Future fullUrl();
+  Future<Response> fullUrl();
 
   @Get(path: '/list/string')
   Future<Response<List<String>>> listString();

--- a/chopper/test/test_service_variable.chopper.dart
+++ b/chopper/test/test_service_variable.chopper.dart
@@ -513,14 +513,14 @@ final class _$HttpTestServiceVariable extends HttpTestServiceVariable {
   }
 
   @override
-  Future<dynamic> fullUrl() {
+  Future<Response<dynamic>> fullUrl() {
     final Uri $url = Uri.parse('https://test.com');
     final Request $request = Request(
       'GET',
       $url,
       client.baseUrl,
     );
-    return client.send($request);
+    return client.send<dynamic, dynamic>($request);
   }
 
   @override

--- a/chopper/test/test_without_response_service.chopper.dart
+++ b/chopper/test/test_without_response_service.chopper.dart
@@ -269,7 +269,7 @@ final class _$HttpTestService extends HttpTestService {
   }
 
   @override
-  Future<dynamic> deleteTest(String id) async {
+  Future<void> deleteTest(String id) async {
     final Uri $url = Uri.parse('/test/delete/${id}');
     final Map<String, String> $headers = {
       'foo': 'bar',
@@ -280,7 +280,7 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       headers: $headers,
     );
-    final Response $response = await client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<void, void>($request);
     return $response.bodyOrThrow;
   }
 

--- a/chopper/test/test_without_response_service.chopper.dart
+++ b/chopper/test/test_without_response_service.chopper.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'test_service.dart';
+part of 'test_without_response_service.dart';
 
 // **************************************************************************
 // ChopperGenerator
@@ -18,10 +18,10 @@ final class _$HttpTestService extends HttpTestService {
   final Type definitionType = HttpTestService;
 
   @override
-  Future<Response<String>> getTest(
+  Future<String> getTest(
     String id, {
     required String dynamicHeader,
-  }) {
+  }) async {
     final Uri $url = Uri.parse('/test/get/${id}');
     final Map<String, String> $headers = {
       'test': dynamicHeader,
@@ -32,70 +32,77 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       headers: $headers,
     );
-    return client.send<String, String>($request);
+    final Response $response = await client.send<String, String>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> headTest() {
+  Future<dynamic> headTest() async {
     final Uri $url = Uri.parse('/test/head');
     final Request $request = Request(
       'HEAD',
       $url,
       client.baseUrl,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> optionsTest() {
+  Future<dynamic> optionsTest() async {
     final Uri $url = Uri.parse('/test/options');
     final Request $request = Request(
       'OPTIONS',
       $url,
       client.baseUrl,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<Stream<List<int>>>> getStreamTest() {
+  Future<Stream<List<int>>> getStreamTest() async {
     final Uri $url = Uri.parse('/test/get');
     final Request $request = Request(
       'GET',
       $url,
       client.baseUrl,
     );
-    return client.send<Stream<List<int>>, int>($request);
+    final Response $response =
+        await client.send<Stream<List<int>>, int>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> getAll() {
+  Future<dynamic> getAll() async {
     final Uri $url = Uri.parse('/test');
     final Request $request = Request(
       'GET',
       $url,
       client.baseUrl,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> getAllWithTrailingSlash() {
+  Future<dynamic> getAllWithTrailingSlash() async {
     final Uri $url = Uri.parse('/test/');
     final Request $request = Request(
       'GET',
       $url,
       client.baseUrl,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> getQueryTest({
+  Future<dynamic> getQueryTest({
     String name = '',
     int? number,
     int? def = 42,
-  }) {
+  }) async {
     final Uri $url = Uri.parse('/test/query');
     final Map<String, dynamic> $params = <String, dynamic>{
       'name': name,
@@ -108,11 +115,12 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       parameters: $params,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> getQueryMapTest(Map<String, dynamic> query) {
+  Future<dynamic> getQueryMapTest(Map<String, dynamic> query) async {
     final Uri $url = Uri.parse('/test/query_map');
     final Map<String, dynamic> $params = query;
     final Request $request = Request(
@@ -121,14 +129,15 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       parameters: $params,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> getQueryMapTest2(
+  Future<dynamic> getQueryMapTest2(
     Map<String, dynamic> query, {
     bool? test,
-  }) {
+  }) async {
     final Uri $url = Uri.parse('/test/query_map');
     final Map<String, dynamic> $params = <String, dynamic>{'test': test};
     $params.addAll(query);
@@ -138,15 +147,16 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       parameters: $params,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> getQueryMapTest3({
+  Future<dynamic> getQueryMapTest3({
     String name = '',
     int? number,
     Map<String, dynamic> filters = const {},
-  }) {
+  }) async {
     final Uri $url = Uri.parse('/test/query_map');
     final Map<String, dynamic> $params = <String, dynamic>{
       'name': name,
@@ -159,15 +169,16 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       parameters: $params,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> getQueryMapTest4({
+  Future<dynamic> getQueryMapTest4({
     String name = '',
     int? number,
     Map<String, dynamic>? filters,
-  }) {
+  }) async {
     final Uri $url = Uri.parse('/test/query_map');
     final Map<String, dynamic> $params = <String, dynamic>{
       'name': name,
@@ -180,11 +191,12 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       parameters: $params,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> getQueryMapTest5({Map<String, dynamic>? filters}) {
+  Future<dynamic> getQueryMapTest5({Map<String, dynamic>? filters}) async {
     final Uri $url = Uri.parse('/test/query_map');
     final Map<String, dynamic> $params = filters ?? const {};
     final Request $request = Request(
@@ -193,11 +205,12 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       parameters: $params,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> getBody(dynamic body) {
+  Future<dynamic> getBody(dynamic body) async {
     final Uri $url = Uri.parse('/test/get_body');
     final $body = body;
     final Request $request = Request(
@@ -206,11 +219,12 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       body: $body,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> postTest(String data) {
+  Future<dynamic> postTest(String data) async {
     final Uri $url = Uri.parse('/test/post');
     final $body = data;
     final Request $request = Request(
@@ -219,11 +233,12 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       body: $body,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> postStreamTest(Stream<List<int>> byteStream) {
+  Future<dynamic> postStreamTest(Stream<List<int>> byteStream) async {
     final Uri $url = Uri.parse('/test/post');
     final $body = byteStream;
     final Request $request = Request(
@@ -232,14 +247,15 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       body: $body,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> putTest(
+  Future<dynamic> putTest(
     String test,
     String data,
-  ) {
+  ) async {
     final Uri $url = Uri.parse('/test/put/${test}');
     final $body = data;
     final Request $request = Request(
@@ -248,11 +264,12 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       body: $body,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> deleteTest(String id) {
+  Future<dynamic> deleteTest(String id) async {
     final Uri $url = Uri.parse('/test/delete/${id}');
     final Map<String, String> $headers = {
       'foo': 'bar',
@@ -263,14 +280,15 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       headers: $headers,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> patchTest(
+  Future<dynamic> patchTest(
     String id,
     String data,
-  ) {
+  ) async {
     final Uri $url = Uri.parse('/test/patch/${id}');
     final $body = data;
     final Request $request = Request(
@@ -279,11 +297,12 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       body: $body,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> mapTest(Map<String, String> map) {
+  Future<dynamic> mapTest(Map<String, String> map) async {
     final Uri $url = Uri.parse('/test/map');
     final $body = map;
     final Request $request = Request(
@@ -292,11 +311,12 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       body: $body,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> postForm(Map<String, String> fields) {
+  Future<dynamic> postForm(Map<String, String> fields) async {
     final Uri $url = Uri.parse('/test/form/body');
     final $body = fields;
     final Request $request = Request(
@@ -305,14 +325,15 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       body: $body,
     );
-    return client.send<dynamic, dynamic>(
+    final Response $response = await client.send<dynamic, dynamic>(
       $request,
       requestConverter: convertForm,
     );
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> postFormUsingHeaders(Map<String, String> fields) {
+  Future<dynamic> postFormUsingHeaders(Map<String, String> fields) async {
     final Uri $url = Uri.parse('/test/form/body');
     final Map<String, String> $headers = {
       'content-type': 'application/x-www-form-urlencoded',
@@ -325,14 +346,15 @@ final class _$HttpTestService extends HttpTestService {
       body: $body,
       headers: $headers,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> postFormFields(
+  Future<dynamic> postFormFields(
     String foo,
     int bar,
-  ) {
+  ) async {
     final Uri $url = Uri.parse('/test/form/body/fields');
     final $body = <String, dynamic>{
       'foo': foo,
@@ -344,14 +366,15 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       body: $body,
     );
-    return client.send<dynamic, dynamic>(
+    final Response $response = await client.send<dynamic, dynamic>(
       $request,
       requestConverter: convertForm,
     );
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> forceJsonTest(Map<dynamic, dynamic> map) {
+  Future<dynamic> forceJsonTest(Map<dynamic, dynamic> map) async {
     final Uri $url = Uri.parse('/test/map/json');
     final $body = map;
     final Request $request = Request(
@@ -360,18 +383,19 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       body: $body,
     );
-    return client.send<dynamic, dynamic>(
+    final Response $response = await client.send<dynamic, dynamic>(
       $request,
       requestConverter: customConvertRequest,
       responseConverter: customConvertResponse,
     );
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> postResources(
+  Future<dynamic> postResources(
     Map<dynamic, dynamic> a,
     Map<dynamic, dynamic> b,
-  ) {
+  ) async {
     final Uri $url = Uri.parse('/test/multi');
     final List<PartValue> $parts = <PartValue>[
       PartValue<Map<dynamic, dynamic>>(
@@ -390,11 +414,12 @@ final class _$HttpTestService extends HttpTestService {
       parts: $parts,
       multipart: true,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> postFile(List<int> bytes) {
+  Future<dynamic> postFile(List<int> bytes) async {
     final Uri $url = Uri.parse('/test/file');
     final List<PartValue> $parts = <PartValue>[
       PartValueFile<List<int>>(
@@ -409,11 +434,12 @@ final class _$HttpTestService extends HttpTestService {
       parts: $parts,
       multipart: true,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> postImage(List<int> imageData) {
+  Future<dynamic> postImage(List<int> imageData) async {
     final Uri $url = Uri.parse('/test/image');
     final List<PartValue> $parts = <PartValue>[
       PartValueFile<List<int>>(
@@ -428,14 +454,15 @@ final class _$HttpTestService extends HttpTestService {
       parts: $parts,
       multipart: true,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> postMultipartFile(
+  Future<dynamic> postMultipartFile(
     MultipartFile file, {
     String? id,
-  }) {
+  }) async {
     final Uri $url = Uri.parse('/test/file');
     final List<PartValue> $parts = <PartValue>[
       PartValue<String?>(
@@ -454,11 +481,12 @@ final class _$HttpTestService extends HttpTestService {
       parts: $parts,
       multipart: true,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> postListFiles(List<MultipartFile> files) {
+  Future<dynamic> postListFiles(List<MultipartFile> files) async {
     final Uri $url = Uri.parse('/test/files');
     final List<PartValue> $parts = <PartValue>[
       PartValueFile<List<MultipartFile>>(
@@ -473,16 +501,17 @@ final class _$HttpTestService extends HttpTestService {
       parts: $parts,
       multipart: true,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> postMultipartList({
+  Future<dynamic> postMultipartList({
     required List<int> ints,
     required List<double> doubles,
     required List<num> nums,
     required List<String> strings,
-  }) {
+  }) async {
     final Uri $url = Uri.parse('/test/multipart_list');
     final List<PartValue> $parts = <PartValue>[
       PartValue<List<int>>(
@@ -509,48 +538,53 @@ final class _$HttpTestService extends HttpTestService {
       parts: $parts,
       multipart: true,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> fullUrl() {
+  Future<dynamic> fullUrl() async {
     final Uri $url = Uri.parse('https://test.com');
     final Request $request = Request(
       'GET',
       $url,
       client.baseUrl,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<List<String>>> listString() {
+  Future<List<String>> listString() async {
     final Uri $url = Uri.parse('/test/list/string');
     final Request $request = Request(
       'GET',
       $url,
       client.baseUrl,
     );
-    return client.send<List<String>, String>($request);
+    final Response $response =
+        await client.send<List<String>, String>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> noBody() {
+  Future<dynamic> noBody() async {
     final Uri $url = Uri.parse('/test/no-body');
     final Request $request = Request(
       'POST',
       $url,
       client.baseUrl,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<String>> getUsingQueryParamIncludeNullQueryVars({
+  Future<String> getUsingQueryParamIncludeNullQueryVars({
     String? foo,
     String? bar,
     String? baz,
-  }) {
+  }) async {
     final Uri $url = Uri.parse('/test/query_param_include_null_query_vars');
     final Map<String, dynamic> $params = <String, dynamic>{
       'foo': foo,
@@ -564,11 +598,12 @@ final class _$HttpTestService extends HttpTestService {
       parameters: $params,
       includeNullQueryVars: true,
     );
-    return client.send<String, String>($request);
+    final Response $response = await client.send<String, String>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<String>> getUsingListQueryParam(List<String> value) {
+  Future<String> getUsingListQueryParam(List<String> value) async {
     final Uri $url = Uri.parse('/test/list_query_param');
     final Map<String, dynamic> $params = <String, dynamic>{'value': value};
     final Request $request = Request(
@@ -577,12 +612,12 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       parameters: $params,
     );
-    return client.send<String, String>($request);
+    final Response $response = await client.send<String, String>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<String>> getUsingListQueryParamWithBrackets(
-      List<String> value) {
+  Future<String> getUsingListQueryParamWithBrackets(List<String> value) async {
     final Uri $url = Uri.parse('/test/list_query_param_with_brackets');
     final Map<String, dynamic> $params = <String, dynamic>{'value': value};
     final Request $request = Request(
@@ -592,11 +627,12 @@ final class _$HttpTestService extends HttpTestService {
       parameters: $params,
       useBrackets: true,
     );
-    return client.send<String, String>($request);
+    final Response $response = await client.send<String, String>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<String>> getUsingMapQueryParam(Map<String, dynamic> value) {
+  Future<String> getUsingMapQueryParam(Map<String, dynamic> value) async {
     final Uri $url = Uri.parse('/test/map_query_param');
     final Map<String, dynamic> $params = <String, dynamic>{'value': value};
     final Request $request = Request(
@@ -605,12 +641,13 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       parameters: $params,
     );
-    return client.send<String, String>($request);
+    final Response $response = await client.send<String, String>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<String>> getUsingMapQueryParamIncludeNullQueryVars(
-      Map<String, dynamic> value) {
+  Future<String> getUsingMapQueryParamIncludeNullQueryVars(
+      Map<String, dynamic> value) async {
     final Uri $url = Uri.parse('/test/map_query_param_include_null_query_vars');
     final Map<String, dynamic> $params = <String, dynamic>{'value': value};
     final Request $request = Request(
@@ -620,12 +657,13 @@ final class _$HttpTestService extends HttpTestService {
       parameters: $params,
       includeNullQueryVars: true,
     );
-    return client.send<String, String>($request);
+    final Response $response = await client.send<String, String>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<String>> getUsingMapQueryParamWithBrackets(
-      Map<String, dynamic> value) {
+  Future<String> getUsingMapQueryParamWithBrackets(
+      Map<String, dynamic> value) async {
     final Uri $url = Uri.parse('/test/map_query_param_with_brackets');
     final Map<String, dynamic> $params = <String, dynamic>{'value': value};
     final Request $request = Request(
@@ -635,17 +673,18 @@ final class _$HttpTestService extends HttpTestService {
       parameters: $params,
       useBrackets: true,
     );
-    return client.send<String, String>($request);
+    final Response $response = await client.send<String, String>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<String>> getHeaders({
+  Future<String> getHeaders({
     required String stringHeader,
     bool? boolHeader,
     int? intHeader,
     double? doubleHeader,
     ExampleEnum? enumHeader,
-  }) {
+  }) async {
     final Uri $url = Uri.parse('/test/headers');
     final Map<String, String> $headers = {
       'x-string': stringHeader,
@@ -660,6 +699,7 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       headers: $headers,
     );
-    return client.send<String, String>($request);
+    final Response $response = await client.send<String, String>($request);
+    return $response.bodyOrThrow;
   }
 }

--- a/chopper/test/test_without_response_service.dart
+++ b/chopper/test/test_without_response_service.dart
@@ -80,7 +80,7 @@ abstract class HttpTestService extends ChopperService {
   Future putTest(@Path('id') String test, @Body() String data);
 
   @Delete(path: 'delete/{id}', headers: {'foo': 'bar'})
-  Future deleteTest(@Path() String id);
+  Future<void> deleteTest(@Path() String id);
 
   @Patch(path: 'patch/{id}')
   Future patchTest(@Path() String id, @Body() String data);

--- a/chopper/test/test_without_response_service.dart
+++ b/chopper/test/test_without_response_service.dart
@@ -4,143 +4,141 @@ import 'dart:convert';
 import 'package:chopper/chopper.dart';
 import 'package:http/http.dart' show MultipartFile;
 
-part 'test_service_variable.chopper.dart';
+part 'test_without_response_service.chopper.dart';
 
-const String service = 'https://localhost:4000';
-
-@ChopperApi(baseUrl: service)
-abstract class HttpTestServiceVariable extends ChopperService {
-  static HttpTestServiceVariable create([ChopperClient? client]) =>
-      _$HttpTestServiceVariable(client);
+@ChopperApi(baseUrl: '/test')
+abstract class HttpTestService extends ChopperService {
+  static HttpTestService create([ChopperClient? client]) =>
+      _$HttpTestService(client);
 
   @Get(path: 'get/{id}')
-  Future<Response<String>> getTest(
+  Future<String> getTest(
     @Path() String id, {
     @Header('test') required String dynamicHeader,
   });
 
   @Head(path: 'head')
-  Future<Response> headTest();
+  Future headTest();
 
   @Options(path: 'options')
-  Future<Response> optionsTest();
+  Future optionsTest();
 
   @Get(path: 'get')
-  Future<Response<Stream<List<int>>>> getStreamTest();
+  Future<Stream<List<int>>> getStreamTest();
 
   @Get(path: '')
-  Future<Response> getAll();
+  Future getAll();
 
   @Get(path: '/')
-  Future<Response> getAllWithTrailingSlash();
+  Future getAllWithTrailingSlash();
 
   @Get(path: 'query')
-  Future<Response> getQueryTest({
+  Future getQueryTest({
     @Query('name') String name = '',
     @Query('int') int? number,
     @Query('default_value') int? def = 42,
   });
 
   @Get(path: 'query_map')
-  Future<Response> getQueryMapTest(@QueryMap() Map<String, dynamic> query);
+  Future getQueryMapTest(@QueryMap() Map<String, dynamic> query);
 
   @Get(path: 'query_map')
-  Future<Response> getQueryMapTest2(
+  Future getQueryMapTest2(
     @QueryMap() Map<String, dynamic> query, {
     @Query('test') bool? test,
   });
 
   @Get(path: 'query_map')
-  Future<Response> getQueryMapTest3({
+  Future getQueryMapTest3({
     @Query('name') String name = '',
     @Query('number') int? number,
     @QueryMap() Map<String, dynamic> filters = const {},
   });
 
   @Get(path: 'query_map')
-  Future<Response> getQueryMapTest4({
+  Future getQueryMapTest4({
     @Query('name') String name = '',
     @Query('number') int? number,
     @QueryMap() Map<String, dynamic>? filters,
   });
 
   @Get(path: 'query_map')
-  Future<Response> getQueryMapTest5({
+  Future getQueryMapTest5({
     @QueryMap() Map<String, dynamic>? filters,
   });
 
   @Get(path: 'get_body')
-  Future<Response> getBody(@Body() dynamic body);
+  Future getBody(@Body() dynamic body);
 
   @Post(path: 'post')
-  Future<Response> postTest(@Body() String data);
+  Future postTest(@Body() String data);
 
   @Post(path: 'post')
-  Future<Response> postStreamTest(@Body() Stream<List<int>> byteStream);
+  Future postStreamTest(@Body() Stream<List<int>> byteStream);
 
   @Put(path: 'put/{id}')
-  Future<Response> putTest(@Path('id') String test, @Body() String data);
+  Future putTest(@Path('id') String test, @Body() String data);
 
   @Delete(path: 'delete/{id}', headers: {'foo': 'bar'})
-  Future<Response> deleteTest(@Path() String id);
+  Future deleteTest(@Path() String id);
 
   @Patch(path: 'patch/{id}')
-  Future<Response> patchTest(@Path() String id, @Body() String data);
+  Future patchTest(@Path() String id, @Body() String data);
 
   @Post(path: 'map')
-  Future<Response> mapTest(@Body() Map<String, String> map);
+  Future mapTest(@Body() Map<String, String> map);
 
   @FactoryConverter(request: convertForm)
   @Post(path: 'form/body')
-  Future<Response> postForm(@Body() Map<String, String> fields);
+  Future postForm(@Body() Map<String, String> fields);
 
   @Post(path: 'form/body', headers: {contentTypeKey: formEncodedHeaders})
-  Future<Response> postFormUsingHeaders(@Body() Map<String, String> fields);
+  Future postFormUsingHeaders(@Body() Map<String, String> fields);
 
   @FactoryConverter(request: convertForm)
   @Post(path: 'form/body/fields')
-  Future<Response> postFormFields(@Field() String foo, @Field() int bar);
+  Future postFormFields(@Field() String foo, @Field() int bar);
 
   @Post(path: 'map/json')
   @FactoryConverter(
     request: customConvertRequest,
     response: customConvertResponse,
   )
-  Future<Response> forceJsonTest(@Body() Map map);
+  Future forceJsonTest(@Body() Map map);
 
   @Post(path: 'multi')
   @multipart
-  Future<Response> postResources(
+  Future postResources(
     @Part('1') Map a,
     @Part('2') Map b,
   );
 
   @Post(path: 'file')
   @multipart
-  Future<Response> postFile(
+  Future postFile(
     @PartFile('file') List<int> bytes,
   );
 
   @Post(path: 'image')
   @multipart
-  Future<Response> postImage(
+  Future postImage(
     @PartFile('image') List<int> imageData,
   );
 
   @Post(path: 'file')
   @multipart
-  Future<Response> postMultipartFile(
+  Future postMultipartFile(
     @PartFile() MultipartFile file, {
     @Part() String? id,
   });
 
   @Post(path: 'files')
   @multipart
-  Future<Response> postListFiles(@PartFile() List<MultipartFile> files);
+  Future postListFiles(@PartFile() List<MultipartFile> files);
 
   @Post(path: 'multipart_list')
   @multipart
-  Future<Response> postMultipartList({
+  Future postMultipartList({
     @Part('ints') required List<int> ints,
     @Part('doubles') required List<double> doubles,
     @Part('nums') required List<num> nums,
@@ -148,33 +146,33 @@ abstract class HttpTestServiceVariable extends ChopperService {
   });
 
   @Get(path: 'https://test.com')
-  Future<Response> fullUrl();
+  Future fullUrl();
 
   @Get(path: '/list/string')
-  Future<Response<List<String>>> listString();
+  Future<List<String>> listString();
 
   @Post(path: 'no-body')
-  Future<Response> noBody();
+  Future noBody();
 
   @Get(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
-  Future<Response<String>> getUsingQueryParamIncludeNullQueryVars({
+  Future<String> getUsingQueryParamIncludeNullQueryVars({
     @Query('foo') String? foo,
     @Query('bar') String? bar,
     @Query('baz') String? baz,
   });
 
   @Get(path: '/list_query_param')
-  Future<Response<String>> getUsingListQueryParam(
+  Future<String> getUsingListQueryParam(
     @Query('value') List<String> value,
   );
 
   @Get(path: '/list_query_param_with_brackets', useBrackets: true)
-  Future<Response<String>> getUsingListQueryParamWithBrackets(
+  Future<String> getUsingListQueryParamWithBrackets(
     @Query('value') List<String> value,
   );
 
   @Get(path: '/map_query_param')
-  Future<Response<String>> getUsingMapQueryParam(
+  Future<String> getUsingMapQueryParam(
     @Query('value') Map<String, dynamic> value,
   );
 
@@ -182,14 +180,23 @@ abstract class HttpTestServiceVariable extends ChopperService {
     path: '/map_query_param_include_null_query_vars',
     includeNullQueryVars: true,
   )
-  Future<Response<String>> getUsingMapQueryParamIncludeNullQueryVars(
+  Future<String> getUsingMapQueryParamIncludeNullQueryVars(
     @Query('value') Map<String, dynamic> value,
   );
 
   @Get(path: '/map_query_param_with_brackets', useBrackets: true)
-  Future<Response<String>> getUsingMapQueryParamWithBrackets(
+  Future<String> getUsingMapQueryParamWithBrackets(
     @Query('value') Map<String, dynamic> value,
   );
+
+  @Get(path: 'headers')
+  Future<String> getHeaders({
+    @Header('x-string') required String stringHeader,
+    @Header('x-boolean') bool? boolHeader,
+    @Header('x-int') int? intHeader,
+    @Header('x-double') double? doubleHeader,
+    @Header('x-enum') ExampleEnum? enumHeader,
+  });
 }
 
 Request customConvertRequest(Request req) {
@@ -217,4 +224,13 @@ Request convertForm(Request req) {
   }
 
   return req;
+}
+
+enum ExampleEnum {
+  foo,
+  bar,
+  baz;
+
+  @override
+  String toString() => name;
 }

--- a/chopper_generator/lib/src/vars.dart
+++ b/chopper_generator/lib/src/vars.dart
@@ -1,5 +1,6 @@
 enum Vars {
   client('client'),
+  response(r'$response'),
   baseUrl('baseUrl'),
   parameters(r'$params'),
   headers(r'$headers'),

--- a/chopper_generator/test/ensure_build_test.dart
+++ b/chopper_generator/test/ensure_build_test.dart
@@ -6,18 +6,13 @@ import 'package:test/test.dart';
 void main() {
   test(
     'ensure_build',
-    () {
-      expectBuildClean(
+    () async {
+      await expectBuildClean(
         packageRelativeDirectory: 'chopper_generator',
         gitDiffPathArguments: [
           'test/test_service.chopper.dart',
-        ],
-      );
-
-      expectBuildClean(
-        packageRelativeDirectory: 'chopper_generator',
-        gitDiffPathArguments: [
           'test/test_service_variable.chopper.dart',
+          'test/test_without_response_service.chopper.dart',
         ],
       );
     },

--- a/chopper_generator/test/test_service.dart
+++ b/chopper_generator/test/test_service.dart
@@ -146,7 +146,7 @@ abstract class HttpTestService extends ChopperService {
   });
 
   @Get(path: 'https://test.com')
-  Future fullUrl();
+  Future<Response> fullUrl();
 
   @Get(path: '/list/string')
   Future<Response<List<String>>> listString();

--- a/chopper_generator/test/test_service_variable.chopper.dart
+++ b/chopper_generator/test/test_service_variable.chopper.dart
@@ -513,14 +513,14 @@ final class _$HttpTestServiceVariable extends HttpTestServiceVariable {
   }
 
   @override
-  Future<dynamic> fullUrl() {
+  Future<Response<dynamic>> fullUrl() {
     final Uri $url = Uri.parse('https://test.com');
     final Request $request = Request(
       'GET',
       $url,
       client.baseUrl,
     );
-    return client.send($request);
+    return client.send<dynamic, dynamic>($request);
   }
 
   @override

--- a/chopper_generator/test/test_service_variable.dart
+++ b/chopper_generator/test/test_service_variable.dart
@@ -148,7 +148,7 @@ abstract class HttpTestServiceVariable extends ChopperService {
   });
 
   @Get(path: 'https://test.com')
-  Future fullUrl();
+  Future<Response> fullUrl();
 
   @Get(path: '/list/string')
   Future<Response<List<String>>> listString();

--- a/chopper_generator/test/test_without_response_service.chopper.dart
+++ b/chopper_generator/test/test_without_response_service.chopper.dart
@@ -269,7 +269,7 @@ final class _$HttpTestService extends HttpTestService {
   }
 
   @override
-  Future<dynamic> deleteTest(String id) async {
+  Future<void> deleteTest(String id) async {
     final Uri $url = Uri.parse('/test/delete/${id}');
     final Map<String, String> $headers = {
       'foo': 'bar',
@@ -280,7 +280,7 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       headers: $headers,
     );
-    final Response $response = await client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<void, void>($request);
     return $response.bodyOrThrow;
   }
 

--- a/chopper_generator/test/test_without_response_service.chopper.dart
+++ b/chopper_generator/test/test_without_response_service.chopper.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'test_service.dart';
+part of 'test_without_response_service.dart';
 
 // **************************************************************************
 // ChopperGenerator
@@ -18,10 +18,10 @@ final class _$HttpTestService extends HttpTestService {
   final Type definitionType = HttpTestService;
 
   @override
-  Future<Response<String>> getTest(
+  Future<String> getTest(
     String id, {
     required String dynamicHeader,
-  }) {
+  }) async {
     final Uri $url = Uri.parse('/test/get/${id}');
     final Map<String, String> $headers = {
       'test': dynamicHeader,
@@ -32,70 +32,77 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       headers: $headers,
     );
-    return client.send<String, String>($request);
+    final Response $response = await client.send<String, String>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> headTest() {
+  Future<dynamic> headTest() async {
     final Uri $url = Uri.parse('/test/head');
     final Request $request = Request(
       'HEAD',
       $url,
       client.baseUrl,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> optionsTest() {
+  Future<dynamic> optionsTest() async {
     final Uri $url = Uri.parse('/test/options');
     final Request $request = Request(
       'OPTIONS',
       $url,
       client.baseUrl,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<Stream<List<int>>>> getStreamTest() {
+  Future<Stream<List<int>>> getStreamTest() async {
     final Uri $url = Uri.parse('/test/get');
     final Request $request = Request(
       'GET',
       $url,
       client.baseUrl,
     );
-    return client.send<Stream<List<int>>, int>($request);
+    final Response $response =
+        await client.send<Stream<List<int>>, int>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> getAll() {
+  Future<dynamic> getAll() async {
     final Uri $url = Uri.parse('/test');
     final Request $request = Request(
       'GET',
       $url,
       client.baseUrl,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> getAllWithTrailingSlash() {
+  Future<dynamic> getAllWithTrailingSlash() async {
     final Uri $url = Uri.parse('/test/');
     final Request $request = Request(
       'GET',
       $url,
       client.baseUrl,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> getQueryTest({
+  Future<dynamic> getQueryTest({
     String name = '',
     int? number,
     int? def = 42,
-  }) {
+  }) async {
     final Uri $url = Uri.parse('/test/query');
     final Map<String, dynamic> $params = <String, dynamic>{
       'name': name,
@@ -108,11 +115,12 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       parameters: $params,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> getQueryMapTest(Map<String, dynamic> query) {
+  Future<dynamic> getQueryMapTest(Map<String, dynamic> query) async {
     final Uri $url = Uri.parse('/test/query_map');
     final Map<String, dynamic> $params = query;
     final Request $request = Request(
@@ -121,14 +129,15 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       parameters: $params,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> getQueryMapTest2(
+  Future<dynamic> getQueryMapTest2(
     Map<String, dynamic> query, {
     bool? test,
-  }) {
+  }) async {
     final Uri $url = Uri.parse('/test/query_map');
     final Map<String, dynamic> $params = <String, dynamic>{'test': test};
     $params.addAll(query);
@@ -138,15 +147,16 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       parameters: $params,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> getQueryMapTest3({
+  Future<dynamic> getQueryMapTest3({
     String name = '',
     int? number,
     Map<String, dynamic> filters = const {},
-  }) {
+  }) async {
     final Uri $url = Uri.parse('/test/query_map');
     final Map<String, dynamic> $params = <String, dynamic>{
       'name': name,
@@ -159,15 +169,16 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       parameters: $params,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> getQueryMapTest4({
+  Future<dynamic> getQueryMapTest4({
     String name = '',
     int? number,
     Map<String, dynamic>? filters,
-  }) {
+  }) async {
     final Uri $url = Uri.parse('/test/query_map');
     final Map<String, dynamic> $params = <String, dynamic>{
       'name': name,
@@ -180,11 +191,12 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       parameters: $params,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> getQueryMapTest5({Map<String, dynamic>? filters}) {
+  Future<dynamic> getQueryMapTest5({Map<String, dynamic>? filters}) async {
     final Uri $url = Uri.parse('/test/query_map');
     final Map<String, dynamic> $params = filters ?? const {};
     final Request $request = Request(
@@ -193,11 +205,12 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       parameters: $params,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> getBody(dynamic body) {
+  Future<dynamic> getBody(dynamic body) async {
     final Uri $url = Uri.parse('/test/get_body');
     final $body = body;
     final Request $request = Request(
@@ -206,11 +219,12 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       body: $body,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> postTest(String data) {
+  Future<dynamic> postTest(String data) async {
     final Uri $url = Uri.parse('/test/post');
     final $body = data;
     final Request $request = Request(
@@ -219,11 +233,12 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       body: $body,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> postStreamTest(Stream<List<int>> byteStream) {
+  Future<dynamic> postStreamTest(Stream<List<int>> byteStream) async {
     final Uri $url = Uri.parse('/test/post');
     final $body = byteStream;
     final Request $request = Request(
@@ -232,14 +247,15 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       body: $body,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> putTest(
+  Future<dynamic> putTest(
     String test,
     String data,
-  ) {
+  ) async {
     final Uri $url = Uri.parse('/test/put/${test}');
     final $body = data;
     final Request $request = Request(
@@ -248,11 +264,12 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       body: $body,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> deleteTest(String id) {
+  Future<dynamic> deleteTest(String id) async {
     final Uri $url = Uri.parse('/test/delete/${id}');
     final Map<String, String> $headers = {
       'foo': 'bar',
@@ -263,14 +280,15 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       headers: $headers,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> patchTest(
+  Future<dynamic> patchTest(
     String id,
     String data,
-  ) {
+  ) async {
     final Uri $url = Uri.parse('/test/patch/${id}');
     final $body = data;
     final Request $request = Request(
@@ -279,11 +297,12 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       body: $body,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> mapTest(Map<String, String> map) {
+  Future<dynamic> mapTest(Map<String, String> map) async {
     final Uri $url = Uri.parse('/test/map');
     final $body = map;
     final Request $request = Request(
@@ -292,11 +311,12 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       body: $body,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> postForm(Map<String, String> fields) {
+  Future<dynamic> postForm(Map<String, String> fields) async {
     final Uri $url = Uri.parse('/test/form/body');
     final $body = fields;
     final Request $request = Request(
@@ -305,14 +325,15 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       body: $body,
     );
-    return client.send<dynamic, dynamic>(
+    final Response $response = await client.send<dynamic, dynamic>(
       $request,
       requestConverter: convertForm,
     );
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> postFormUsingHeaders(Map<String, String> fields) {
+  Future<dynamic> postFormUsingHeaders(Map<String, String> fields) async {
     final Uri $url = Uri.parse('/test/form/body');
     final Map<String, String> $headers = {
       'content-type': 'application/x-www-form-urlencoded',
@@ -325,14 +346,15 @@ final class _$HttpTestService extends HttpTestService {
       body: $body,
       headers: $headers,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> postFormFields(
+  Future<dynamic> postFormFields(
     String foo,
     int bar,
-  ) {
+  ) async {
     final Uri $url = Uri.parse('/test/form/body/fields');
     final $body = <String, dynamic>{
       'foo': foo,
@@ -344,14 +366,15 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       body: $body,
     );
-    return client.send<dynamic, dynamic>(
+    final Response $response = await client.send<dynamic, dynamic>(
       $request,
       requestConverter: convertForm,
     );
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> forceJsonTest(Map<dynamic, dynamic> map) {
+  Future<dynamic> forceJsonTest(Map<dynamic, dynamic> map) async {
     final Uri $url = Uri.parse('/test/map/json');
     final $body = map;
     final Request $request = Request(
@@ -360,18 +383,19 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       body: $body,
     );
-    return client.send<dynamic, dynamic>(
+    final Response $response = await client.send<dynamic, dynamic>(
       $request,
       requestConverter: customConvertRequest,
       responseConverter: customConvertResponse,
     );
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> postResources(
+  Future<dynamic> postResources(
     Map<dynamic, dynamic> a,
     Map<dynamic, dynamic> b,
-  ) {
+  ) async {
     final Uri $url = Uri.parse('/test/multi');
     final List<PartValue> $parts = <PartValue>[
       PartValue<Map<dynamic, dynamic>>(
@@ -390,11 +414,12 @@ final class _$HttpTestService extends HttpTestService {
       parts: $parts,
       multipart: true,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> postFile(List<int> bytes) {
+  Future<dynamic> postFile(List<int> bytes) async {
     final Uri $url = Uri.parse('/test/file');
     final List<PartValue> $parts = <PartValue>[
       PartValueFile<List<int>>(
@@ -409,11 +434,12 @@ final class _$HttpTestService extends HttpTestService {
       parts: $parts,
       multipart: true,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> postImage(List<int> imageData) {
+  Future<dynamic> postImage(List<int> imageData) async {
     final Uri $url = Uri.parse('/test/image');
     final List<PartValue> $parts = <PartValue>[
       PartValueFile<List<int>>(
@@ -428,14 +454,15 @@ final class _$HttpTestService extends HttpTestService {
       parts: $parts,
       multipart: true,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> postMultipartFile(
+  Future<dynamic> postMultipartFile(
     MultipartFile file, {
     String? id,
-  }) {
+  }) async {
     final Uri $url = Uri.parse('/test/file');
     final List<PartValue> $parts = <PartValue>[
       PartValue<String?>(
@@ -454,11 +481,12 @@ final class _$HttpTestService extends HttpTestService {
       parts: $parts,
       multipart: true,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> postListFiles(List<MultipartFile> files) {
+  Future<dynamic> postListFiles(List<MultipartFile> files) async {
     final Uri $url = Uri.parse('/test/files');
     final List<PartValue> $parts = <PartValue>[
       PartValueFile<List<MultipartFile>>(
@@ -473,16 +501,17 @@ final class _$HttpTestService extends HttpTestService {
       parts: $parts,
       multipart: true,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> postMultipartList({
+  Future<dynamic> postMultipartList({
     required List<int> ints,
     required List<double> doubles,
     required List<num> nums,
     required List<String> strings,
-  }) {
+  }) async {
     final Uri $url = Uri.parse('/test/multipart_list');
     final List<PartValue> $parts = <PartValue>[
       PartValue<List<int>>(
@@ -509,48 +538,53 @@ final class _$HttpTestService extends HttpTestService {
       parts: $parts,
       multipart: true,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> fullUrl() {
+  Future<dynamic> fullUrl() async {
     final Uri $url = Uri.parse('https://test.com');
     final Request $request = Request(
       'GET',
       $url,
       client.baseUrl,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<List<String>>> listString() {
+  Future<List<String>> listString() async {
     final Uri $url = Uri.parse('/test/list/string');
     final Request $request = Request(
       'GET',
       $url,
       client.baseUrl,
     );
-    return client.send<List<String>, String>($request);
+    final Response $response =
+        await client.send<List<String>, String>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<dynamic>> noBody() {
+  Future<dynamic> noBody() async {
     final Uri $url = Uri.parse('/test/no-body');
     final Request $request = Request(
       'POST',
       $url,
       client.baseUrl,
     );
-    return client.send<dynamic, dynamic>($request);
+    final Response $response = await client.send<dynamic, dynamic>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<String>> getUsingQueryParamIncludeNullQueryVars({
+  Future<String> getUsingQueryParamIncludeNullQueryVars({
     String? foo,
     String? bar,
     String? baz,
-  }) {
+  }) async {
     final Uri $url = Uri.parse('/test/query_param_include_null_query_vars');
     final Map<String, dynamic> $params = <String, dynamic>{
       'foo': foo,
@@ -564,11 +598,12 @@ final class _$HttpTestService extends HttpTestService {
       parameters: $params,
       includeNullQueryVars: true,
     );
-    return client.send<String, String>($request);
+    final Response $response = await client.send<String, String>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<String>> getUsingListQueryParam(List<String> value) {
+  Future<String> getUsingListQueryParam(List<String> value) async {
     final Uri $url = Uri.parse('/test/list_query_param');
     final Map<String, dynamic> $params = <String, dynamic>{'value': value};
     final Request $request = Request(
@@ -577,12 +612,12 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       parameters: $params,
     );
-    return client.send<String, String>($request);
+    final Response $response = await client.send<String, String>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<String>> getUsingListQueryParamWithBrackets(
-      List<String> value) {
+  Future<String> getUsingListQueryParamWithBrackets(List<String> value) async {
     final Uri $url = Uri.parse('/test/list_query_param_with_brackets');
     final Map<String, dynamic> $params = <String, dynamic>{'value': value};
     final Request $request = Request(
@@ -592,11 +627,12 @@ final class _$HttpTestService extends HttpTestService {
       parameters: $params,
       useBrackets: true,
     );
-    return client.send<String, String>($request);
+    final Response $response = await client.send<String, String>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<String>> getUsingMapQueryParam(Map<String, dynamic> value) {
+  Future<String> getUsingMapQueryParam(Map<String, dynamic> value) async {
     final Uri $url = Uri.parse('/test/map_query_param');
     final Map<String, dynamic> $params = <String, dynamic>{'value': value};
     final Request $request = Request(
@@ -605,12 +641,13 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       parameters: $params,
     );
-    return client.send<String, String>($request);
+    final Response $response = await client.send<String, String>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<String>> getUsingMapQueryParamIncludeNullQueryVars(
-      Map<String, dynamic> value) {
+  Future<String> getUsingMapQueryParamIncludeNullQueryVars(
+      Map<String, dynamic> value) async {
     final Uri $url = Uri.parse('/test/map_query_param_include_null_query_vars');
     final Map<String, dynamic> $params = <String, dynamic>{'value': value};
     final Request $request = Request(
@@ -620,12 +657,13 @@ final class _$HttpTestService extends HttpTestService {
       parameters: $params,
       includeNullQueryVars: true,
     );
-    return client.send<String, String>($request);
+    final Response $response = await client.send<String, String>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<String>> getUsingMapQueryParamWithBrackets(
-      Map<String, dynamic> value) {
+  Future<String> getUsingMapQueryParamWithBrackets(
+      Map<String, dynamic> value) async {
     final Uri $url = Uri.parse('/test/map_query_param_with_brackets');
     final Map<String, dynamic> $params = <String, dynamic>{'value': value};
     final Request $request = Request(
@@ -635,17 +673,18 @@ final class _$HttpTestService extends HttpTestService {
       parameters: $params,
       useBrackets: true,
     );
-    return client.send<String, String>($request);
+    final Response $response = await client.send<String, String>($request);
+    return $response.bodyOrThrow;
   }
 
   @override
-  Future<Response<String>> getHeaders({
+  Future<String> getHeaders({
     required String stringHeader,
     bool? boolHeader,
     int? intHeader,
     double? doubleHeader,
     ExampleEnum? enumHeader,
-  }) {
+  }) async {
     final Uri $url = Uri.parse('/test/headers');
     final Map<String, String> $headers = {
       'x-string': stringHeader,
@@ -660,6 +699,7 @@ final class _$HttpTestService extends HttpTestService {
       client.baseUrl,
       headers: $headers,
     );
-    return client.send<String, String>($request);
+    final Response $response = await client.send<String, String>($request);
+    return $response.bodyOrThrow;
   }
 }

--- a/chopper_generator/test/test_without_response_service.dart
+++ b/chopper_generator/test/test_without_response_service.dart
@@ -80,7 +80,7 @@ abstract class HttpTestService extends ChopperService {
   Future putTest(@Path('id') String test, @Body() String data);
 
   @Delete(path: 'delete/{id}', headers: {'foo': 'bar'})
-  Future deleteTest(@Path() String id);
+  Future<void> deleteTest(@Path() String id);
 
   @Patch(path: 'patch/{id}')
   Future patchTest(@Path() String id, @Body() String data);

--- a/chopper_generator/test/test_without_response_service.dart
+++ b/chopper_generator/test/test_without_response_service.dart
@@ -4,143 +4,141 @@ import 'dart:convert';
 import 'package:chopper/chopper.dart';
 import 'package:http/http.dart' show MultipartFile;
 
-part 'test_service_variable.chopper.dart';
+part 'test_without_response_service.chopper.dart';
 
-const String service = 'https://localhost:4000';
-
-@ChopperApi(baseUrl: service)
-abstract class HttpTestServiceVariable extends ChopperService {
-  static HttpTestServiceVariable create([ChopperClient? client]) =>
-      _$HttpTestServiceVariable(client);
+@ChopperApi(baseUrl: '/test')
+abstract class HttpTestService extends ChopperService {
+  static HttpTestService create([ChopperClient? client]) =>
+      _$HttpTestService(client);
 
   @Get(path: 'get/{id}')
-  Future<Response<String>> getTest(
+  Future<String> getTest(
     @Path() String id, {
     @Header('test') required String dynamicHeader,
   });
 
   @Head(path: 'head')
-  Future<Response> headTest();
+  Future headTest();
 
   @Options(path: 'options')
-  Future<Response> optionsTest();
+  Future optionsTest();
 
   @Get(path: 'get')
-  Future<Response<Stream<List<int>>>> getStreamTest();
+  Future<Stream<List<int>>> getStreamTest();
 
   @Get(path: '')
-  Future<Response> getAll();
+  Future getAll();
 
   @Get(path: '/')
-  Future<Response> getAllWithTrailingSlash();
+  Future getAllWithTrailingSlash();
 
   @Get(path: 'query')
-  Future<Response> getQueryTest({
+  Future getQueryTest({
     @Query('name') String name = '',
     @Query('int') int? number,
     @Query('default_value') int? def = 42,
   });
 
   @Get(path: 'query_map')
-  Future<Response> getQueryMapTest(@QueryMap() Map<String, dynamic> query);
+  Future getQueryMapTest(@QueryMap() Map<String, dynamic> query);
 
   @Get(path: 'query_map')
-  Future<Response> getQueryMapTest2(
+  Future getQueryMapTest2(
     @QueryMap() Map<String, dynamic> query, {
     @Query('test') bool? test,
   });
 
   @Get(path: 'query_map')
-  Future<Response> getQueryMapTest3({
+  Future getQueryMapTest3({
     @Query('name') String name = '',
     @Query('number') int? number,
     @QueryMap() Map<String, dynamic> filters = const {},
   });
 
   @Get(path: 'query_map')
-  Future<Response> getQueryMapTest4({
+  Future getQueryMapTest4({
     @Query('name') String name = '',
     @Query('number') int? number,
     @QueryMap() Map<String, dynamic>? filters,
   });
 
   @Get(path: 'query_map')
-  Future<Response> getQueryMapTest5({
+  Future getQueryMapTest5({
     @QueryMap() Map<String, dynamic>? filters,
   });
 
   @Get(path: 'get_body')
-  Future<Response> getBody(@Body() dynamic body);
+  Future getBody(@Body() dynamic body);
 
   @Post(path: 'post')
-  Future<Response> postTest(@Body() String data);
+  Future postTest(@Body() String data);
 
   @Post(path: 'post')
-  Future<Response> postStreamTest(@Body() Stream<List<int>> byteStream);
+  Future postStreamTest(@Body() Stream<List<int>> byteStream);
 
   @Put(path: 'put/{id}')
-  Future<Response> putTest(@Path('id') String test, @Body() String data);
+  Future putTest(@Path('id') String test, @Body() String data);
 
   @Delete(path: 'delete/{id}', headers: {'foo': 'bar'})
-  Future<Response> deleteTest(@Path() String id);
+  Future deleteTest(@Path() String id);
 
   @Patch(path: 'patch/{id}')
-  Future<Response> patchTest(@Path() String id, @Body() String data);
+  Future patchTest(@Path() String id, @Body() String data);
 
   @Post(path: 'map')
-  Future<Response> mapTest(@Body() Map<String, String> map);
+  Future mapTest(@Body() Map<String, String> map);
 
   @FactoryConverter(request: convertForm)
   @Post(path: 'form/body')
-  Future<Response> postForm(@Body() Map<String, String> fields);
+  Future postForm(@Body() Map<String, String> fields);
 
   @Post(path: 'form/body', headers: {contentTypeKey: formEncodedHeaders})
-  Future<Response> postFormUsingHeaders(@Body() Map<String, String> fields);
+  Future postFormUsingHeaders(@Body() Map<String, String> fields);
 
   @FactoryConverter(request: convertForm)
   @Post(path: 'form/body/fields')
-  Future<Response> postFormFields(@Field() String foo, @Field() int bar);
+  Future postFormFields(@Field() String foo, @Field() int bar);
 
   @Post(path: 'map/json')
   @FactoryConverter(
     request: customConvertRequest,
     response: customConvertResponse,
   )
-  Future<Response> forceJsonTest(@Body() Map map);
+  Future forceJsonTest(@Body() Map map);
 
   @Post(path: 'multi')
   @multipart
-  Future<Response> postResources(
+  Future postResources(
     @Part('1') Map a,
     @Part('2') Map b,
   );
 
   @Post(path: 'file')
   @multipart
-  Future<Response> postFile(
+  Future postFile(
     @PartFile('file') List<int> bytes,
   );
 
   @Post(path: 'image')
   @multipart
-  Future<Response> postImage(
+  Future postImage(
     @PartFile('image') List<int> imageData,
   );
 
   @Post(path: 'file')
   @multipart
-  Future<Response> postMultipartFile(
+  Future postMultipartFile(
     @PartFile() MultipartFile file, {
     @Part() String? id,
   });
 
   @Post(path: 'files')
   @multipart
-  Future<Response> postListFiles(@PartFile() List<MultipartFile> files);
+  Future postListFiles(@PartFile() List<MultipartFile> files);
 
   @Post(path: 'multipart_list')
   @multipart
-  Future<Response> postMultipartList({
+  Future postMultipartList({
     @Part('ints') required List<int> ints,
     @Part('doubles') required List<double> doubles,
     @Part('nums') required List<num> nums,
@@ -148,33 +146,33 @@ abstract class HttpTestServiceVariable extends ChopperService {
   });
 
   @Get(path: 'https://test.com')
-  Future<Response> fullUrl();
+  Future fullUrl();
 
   @Get(path: '/list/string')
-  Future<Response<List<String>>> listString();
+  Future<List<String>> listString();
 
   @Post(path: 'no-body')
-  Future<Response> noBody();
+  Future noBody();
 
   @Get(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
-  Future<Response<String>> getUsingQueryParamIncludeNullQueryVars({
+  Future<String> getUsingQueryParamIncludeNullQueryVars({
     @Query('foo') String? foo,
     @Query('bar') String? bar,
     @Query('baz') String? baz,
   });
 
   @Get(path: '/list_query_param')
-  Future<Response<String>> getUsingListQueryParam(
+  Future<String> getUsingListQueryParam(
     @Query('value') List<String> value,
   );
 
   @Get(path: '/list_query_param_with_brackets', useBrackets: true)
-  Future<Response<String>> getUsingListQueryParamWithBrackets(
+  Future<String> getUsingListQueryParamWithBrackets(
     @Query('value') List<String> value,
   );
 
   @Get(path: '/map_query_param')
-  Future<Response<String>> getUsingMapQueryParam(
+  Future<String> getUsingMapQueryParam(
     @Query('value') Map<String, dynamic> value,
   );
 
@@ -182,14 +180,23 @@ abstract class HttpTestServiceVariable extends ChopperService {
     path: '/map_query_param_include_null_query_vars',
     includeNullQueryVars: true,
   )
-  Future<Response<String>> getUsingMapQueryParamIncludeNullQueryVars(
+  Future<String> getUsingMapQueryParamIncludeNullQueryVars(
     @Query('value') Map<String, dynamic> value,
   );
 
   @Get(path: '/map_query_param_with_brackets', useBrackets: true)
-  Future<Response<String>> getUsingMapQueryParamWithBrackets(
+  Future<String> getUsingMapQueryParamWithBrackets(
     @Query('value') Map<String, dynamic> value,
   );
+
+  @Get(path: 'headers')
+  Future<String> getHeaders({
+    @Header('x-string') required String stringHeader,
+    @Header('x-boolean') bool? boolHeader,
+    @Header('x-int') int? intHeader,
+    @Header('x-double') double? doubleHeader,
+    @Header('x-enum') ExampleEnum? enumHeader,
+  });
 }
 
 Request customConvertRequest(Request req) {
@@ -217,4 +224,13 @@ Request convertForm(Request req) {
   }
 
   return req;
+}
+
+enum ExampleEnum {
+  foo,
+  bar,
+  baz;
+
+  @override
+  String toString() => name;
 }


### PR DESCRIPTION
Added the possibility to omit Response when creating a service to reduce some boilerplate if the Response object is not really needed.

This give the developer the choice to make use of the Response and its meta data is needed. This might not always be case because a error converter deals with the error logic. 

**TODO**:
Update documentation for this feature

Previously a `ChopperService` was created like this (still valid):
```dart
@ChopperApi(baseUrl: '/test')
abstract class MyChopperService extends ChopperService {
  static MyChopperService create([ChopperClient? client]) =>
      _$MyChopperService(client);

  @Get(path: 'get/{id}')
  Future<Response<String>> getSomething(
    @Path() String id, {
    @Header('test') required String dynamicHeader,
  });
}
```

Which creates:
```dart
final class _$MyChopperService extends MyChopperService {
  _$MyChopperService([ChopperClient? client]) {
    if (client == null) return;
    this.client = client;
  }

  @override
  final Type definitionType = MyChopperService;

  @override
  Future<Response<String>> getSomething(
    String id, {
    required String dynamicHeader,
  }) {
    final Uri $url = Uri.parse('/test/get/${id}');
    final Map<String, String> $headers = {
      'test': dynamicHeader,
    };
    final Request $request = Request(
      'GET',
      $url,
      client.baseUrl,
      headers: $headers,
    );
    return client.send<String, String>($request);
  }
```

Now its also possible to specify a service like this:
```dart
@ChopperApi(baseUrl: '/test')
abstract class MyChopperService extends ChopperService {
  static MyChopperService create([ChopperClient? client]) =>
      _$MyChopperService(client);

  @Get(path: 'get/{id}')
  Future<String> getSomething(
    @Path() String id, {
    @Header('test') required String dynamicHeader,
  });
}
```

Which creates this:
```dart
final class _$MyChopperService extends MyChopperService {
  _$MyChopperService([ChopperClient? client]) {
    if (client == null) return;
    this.client = client;
  }

  @override
  final Type definitionType = MyChopperService;

  @override
  Future<String> getSomething(
    String id, {
    required String dynamicHeader,
  }) async {
    final Uri $url = Uri.parse('/test/get/${id}');
    final Map<String, String> $headers = {
      'test': dynamicHeader,
    };
    final Request $request = Request(
      'GET',
      $url,
      client.baseUrl,
      headers: $headers,
    );
    final Response $response = await client.send<String, String>($request);
    return $response.bodyOrThrow;
  }
```