### PR TITLE
:memo: Improved documentation + added const annotations

### DIFF
--- a/chopper/lib/src/annotations.dart
+++ b/chopper/lib/src/annotations.dart
@@ -5,6 +5,7 @@ import 'package:chopper/src/request.dart';
 import 'package:chopper/src/response.dart';
 import 'package:meta/meta.dart';
 
+/// {@template ChopperApi}
 /// Defines a Chopper API.
 ///
 /// Must be used on an abstract class that extends the [ChopperService] class.
@@ -19,6 +20,7 @@ import 'package:meta/meta.dart';
 /// ```
 ///
 /// See [Method] to define an HTTP request
+/// {@endtemplate}
 @immutable
 final class ChopperApi {
   /// A part of a URL that every request defined inside a class annotated with [ChopperApi] will be prefixed with.
@@ -26,11 +28,13 @@ final class ChopperApi {
   /// The `baseUrl` can be a top level constant string variable.
   final String baseUrl;
 
+  /// {@macro ChopperApi}
   const ChopperApi({
     this.baseUrl = '',
   });
 }
 
+/// {@template Path}
 /// Provides a parameter in the url.
 ///
 /// Declared as follows inside the path String:
@@ -43,6 +47,7 @@ final class ChopperApi {
 /// @Get(path: '/{param}')
 /// Future<Response> fetch(@Path() String param);
 /// ```
+/// {@endtemplate}
 @immutable
 final class Path {
   /// Name is used to bind a method parameter to
@@ -53,9 +58,11 @@ final class Path {
   /// ```
   final String? name;
 
+  /// {@macro Path}
   const Path([this.name]);
 }
 
+/// {@template Query}
 /// Provides the query parameters of a request.
 ///
 /// [Query] is used to add query parameters after the request url.
@@ -66,6 +73,7 @@ final class Path {
 /// ```
 ///
 /// See [QueryMap] to pass an [Map<String, dynamic>] as value
+/// {@endtemplate}
 @immutable
 final class Query {
   /// Name is used to bind a method parameter to
@@ -76,9 +84,11 @@ final class Query {
   /// ```
   final String? name;
 
+  /// {@macro Query}
   const Query([this.name]);
 }
 
+/// {@template QueryMap}
 /// Provides query parameters of a request as [Map<String, dynamic>].
 ///
 /// ```dart
@@ -91,11 +101,14 @@ final class Query {
 /// fetch({'foo':'bar','list':[1,2]});
 /// // something?foo=bar&list=1&list=2
 /// ```
+/// {@endtemplate}
 @immutable
 final class QueryMap {
+  /// {@macro QueryMap}
   const QueryMap();
 }
 
+/// {@template Body}
 /// Declares the Body of [Post], [Put], and [Patch] requests
 ///
 /// ```dart
@@ -105,11 +118,14 @@ final class QueryMap {
 ///
 /// The body can be of any type, but chopper does not automatically convert it to JSON.
 /// See [Converter] to apply conversion to the body.
+/// {@endtemplate}
 @immutable
 final class Body {
+  /// {@macro Body}
   const Body();
 }
 
+/// {@template Header}
 /// Passes a value to the header of the request.
 ///
 /// Use the name of the method parameter or the name specified in the annotation.
@@ -118,6 +134,7 @@ final class Body {
 /// @Get()
 /// Future<Response> fetch(@Header() String foo);
 /// ```
+/// {@endtemplate}
 @immutable
 final class Header {
   /// Name is used to bind a method parameter to
@@ -128,9 +145,11 @@ final class Header {
   /// ```
   final String? name;
 
+  /// {@macro Header}
   const Header([this.name]);
 }
 
+/// {@template Method}
 /// Defines an HTTP method.
 ///
 /// Must be used inside a [ChopperApi] definition.
@@ -148,6 +167,7 @@ final class Header {
 /// The [Response] type also supports typed parameters like `Future<Response<MyObject>>`.
 /// However, chopper will not automatically convert the body response to your type.
 /// A [Converter] needs to be specified for conversion.
+/// {@endtemplate}
 @immutable
 sealed class Method {
   /// HTTP method for the request
@@ -197,6 +217,7 @@ sealed class Method {
   /// The above code produces hxxp://path/to/script&foo=foo_var&bar=&baz=baz_var
   final bool includeNullQueryVars;
 
+  /// {@macro Method}
   const Method(
     this.method, {
     this.optionalBody = false,
@@ -207,9 +228,12 @@ sealed class Method {
   });
 }
 
+/// {@template Get}
 /// Defines a method as an HTTP GET request.
+/// {@endtemplate}
 @immutable
 final class Get extends Method {
+  /// {@macro Get}
   const Get({
     super.optionalBody = true,
     super.path,
@@ -219,11 +243,14 @@ final class Get extends Method {
   }) : super(HttpMethod.Get);
 }
 
+/// {@template Post}
 /// Defines a method as an HTTP POST request.
 ///
 /// Use the [Body] annotation to pass data to send.
+/// {@endtemplate}
 @immutable
 final class Post extends Method {
+  /// {@macro Post}
   const Post({
     super.optionalBody,
     super.path,
@@ -233,9 +260,12 @@ final class Post extends Method {
   }) : super(HttpMethod.Post);
 }
 
+/// {@template Delete}
 /// Defines a method as an HTTP DELETE request.
+/// {@endtemplate}
 @immutable
 final class Delete extends Method {
+  /// {@macro Delete}
   const Delete({
     super.optionalBody = true,
     super.path,
@@ -245,11 +275,14 @@ final class Delete extends Method {
   }) : super(HttpMethod.Delete);
 }
 
+/// {@template Put}
 /// Defines a method as an HTTP PUT request.
 ///
 /// Use the [Body] annotation to pass data to send.
+/// {@endtemplate}
 @immutable
 final class Put extends Method {
+  /// {@macro Put}
   const Put({
     super.optionalBody,
     super.path,
@@ -259,10 +292,13 @@ final class Put extends Method {
   }) : super(HttpMethod.Put);
 }
 
+/// {@template Patch}
 /// Defines a method as an HTTP PATCH request.
 /// Use the [Body] annotation to pass data to send.
+/// {@endtemplate}
 @immutable
 final class Patch extends Method {
+  /// {@macro Patch}
   const Patch({
     super.optionalBody,
     super.path,
@@ -272,9 +308,12 @@ final class Patch extends Method {
   }) : super(HttpMethod.Patch);
 }
 
+/// {@template Head}
 /// Defines a method as an HTTP HEAD request.
+/// {@endtemplate}
 @immutable
 final class Head extends Method {
+  /// {@macro Head}
   const Head({
     super.optionalBody = true,
     super.path,
@@ -284,8 +323,12 @@ final class Head extends Method {
   }) : super(HttpMethod.Head);
 }
 
+/// {@template Options}
+/// Defines a method as an HTTP OPTIONS request.
+/// {@endtemplate}
 @immutable
 final class Options extends Method {
+  /// {@macro Options}
   const Options({
     super.optionalBody = true,
     super.path,
@@ -302,6 +345,7 @@ typedef ConvertRequest = FutureOr<Request> Function(Request request);
 /// representation to a Dart object.
 typedef ConvertResponse<T> = FutureOr<Response> Function(Response response);
 
+/// {@template FactoryConverter}
 /// Defines custom [Converter] methods for a single network API endpoint.
 /// See [ConvertRequest], [ConvertResponse].
 ///
@@ -331,17 +375,20 @@ typedef ConvertResponse<T> = FutureOr<Response> Function(Response response);
 ///   Future<Response<Todo>> getTodo(@Path("id"));
 /// }
 /// ```
+/// {@endtemplate}
 @immutable
 final class FactoryConverter {
   final ConvertRequest? request;
   final ConvertResponse? response;
 
+  /// {@macro FactoryConverter}
   const FactoryConverter({
     this.request,
     this.response,
   });
 }
 
+/// {@template Field}
 /// Defines a field for a `x-www-form-urlencoded` request.
 /// Automatically binds to the name of the method parameter.
 ///
@@ -350,6 +397,7 @@ final class FactoryConverter {
 /// Future<Response> create(@Field() String name);
 /// ```
 /// Will be converted to `{ 'name': value }`.
+/// {@endtemplate}
 @immutable
 final class Field {
   /// Name can be use to specify the name of the field
@@ -359,20 +407,25 @@ final class Field {
   /// ```
   final String? name;
 
+  /// {@macro Field}
   const Field([this.name]);
 }
 
+/// {@template FieldMap}
 /// Provides field parameters of a request as [Map<String, dynamic>].
 ///
 /// ```dart
 /// @Post(path: '/something')
 /// Future<Response> fetch(@FieldMap List<Map<String, dynamic>> query);
 /// ```
+/// {@endtemplate}
 @immutable
 final class FieldMap {
+  /// {@macro FieldMap}
   const FieldMap();
 }
 
+/// {@template Multipart}
 /// Defines a multipart request.
 ///
 /// ```dart
@@ -383,23 +436,29 @@ final class FieldMap {
 ///
 /// Use [Part] annotation to send simple data.
 /// Use [PartFile] annotation to send `File` or `List<int>`.
+/// {@endtemplate}
 @immutable
 final class Multipart {
+  /// {@macro Multipart}
   const Multipart();
 }
 
+/// {@template Part}
 /// Use [Part] to define a part of a [Multipart] request.
 ///
 /// All values will be converted to [String] using their [toString] method.
 ///
 /// Also accepts `MultipartFile` (from package:http).
+/// {@endtemplate}
 @immutable
 final class Part {
   final String? name;
 
+  /// {@macro Part}
   const Part([this.name]);
 }
 
+/// {@template PartMap}
 /// Provides part parameters of a request as [PartValue].
 ///
 /// ```dart
@@ -407,11 +466,14 @@ final class Part {
 /// @Multipart
 /// Future<Response> fetch(@PartMap() List<PartValue> query);
 /// ```
+/// {@endtemplate}
 @immutable
 final class PartMap {
+  /// {@macro PartMap}
   const PartMap();
 }
 
+///   {@template PartFile}
 /// Use [PartFile] to define a file field for a [Multipart] request.
 ///
 /// ```dart
@@ -424,13 +486,16 @@ final class PartMap {
 ///   - `List<int>`
 ///   - [String] (path of your file)
 ///   - `MultipartFile` (from package:http)
+///   {@endtemplate}
 @immutable
 final class PartFile {
   final String? name;
 
+  ///   {@macro PartFile}
   const PartFile([this.name]);
 }
 
+/// {@template PartFileMap}
 /// Provides partFile parameters of a request as [PartValueFile].
 ///
 /// ```dart
@@ -438,10 +503,13 @@ final class PartFile {
 /// @Multipart
 /// Future<Response> fetch(@PartFileMap() List<PartValueFile> query);
 /// ```
+/// {@endtemplate}
 @immutable
 final class PartFileMap {
+  /// {@macro PartFileMap}
   const PartFileMap();
 }
 
 const multipart = Multipart();
+/// {@macro Body}
 const body = Body();

--- a/chopper/lib/src/annotations.dart
+++ b/chopper/lib/src/annotations.dart
@@ -510,6 +510,45 @@ final class PartFileMap {
   const PartFileMap();
 }
 
+/// {@macro ChopperApi}
+const chopperApi = ChopperApi();
+/// {@macro Multipart}
 const multipart = Multipart();
 /// {@macro Body}
 const body = Body();
+/// {@macro Path}
+const path = Path();
+/// {@macro Query}
+const query = Query();
+/// {@macro QueryMap}
+const queryMap = QueryMap();
+/// {@macro Header}
+const header = Header();
+/// {@macro Get}
+const get = Get();
+/// {@macro Post}
+const post = Post();
+/// {@macro Delete}
+const delete = Delete();
+/// {@macro Put}
+const put = Put();
+/// {@macro Patch}
+const patch = Patch();
+/// {@macro Head}
+const head = Head();
+/// {@macro Options}
+const options = Options();
+/// {@macro FactoryConverter}
+const factoryConverter = FactoryConverter();
+/// {@macro Field}
+const field = Field();
+/// {@macro FieldMap}
+const fieldMap = FieldMap();
+/// {@macro Part}
+const part = Part();
+/// {@macro PartMap}
+const partMap = PartMap();
+/// {@macro PartFile}
+const partFile = PartFile();
+/// {@macro PartFileMap}
+const partFileMap = PartFileMap();

--- a/chopper/lib/src/annotations.dart
+++ b/chopper/lib/src/annotations.dart
@@ -512,43 +512,63 @@ final class PartFileMap {
 
 /// {@macro ChopperApi}
 const chopperApi = ChopperApi();
+
 /// {@macro Multipart}
 const multipart = Multipart();
+
 /// {@macro Body}
 const body = Body();
+
 /// {@macro Path}
 const path = Path();
+
 /// {@macro Query}
 const query = Query();
+
 /// {@macro QueryMap}
 const queryMap = QueryMap();
+
 /// {@macro Header}
 const header = Header();
+
 /// {@macro Get}
 const get = Get();
+
 /// {@macro Post}
 const post = Post();
+
 /// {@macro Delete}
 const delete = Delete();
+
 /// {@macro Put}
 const put = Put();
+
 /// {@macro Patch}
 const patch = Patch();
+
 /// {@macro Head}
 const head = Head();
+
 /// {@macro Options}
 const options = Options();
+
 /// {@macro FactoryConverter}
 const factoryConverter = FactoryConverter();
+
 /// {@macro Field}
 const field = Field();
+
 /// {@macro FieldMap}
 const fieldMap = FieldMap();
+
 /// {@macro Part}
 const part = Part();
+
 /// {@macro PartMap}
 const partMap = PartMap();
+
 /// {@macro PartFile}
 const partFile = PartFile();
+
 /// {@macro PartFileMap}
 const partFileMap = PartFileMap();

--- a/chopper/lib/src/http_logging_interceptor.dart
+++ b/chopper/lib/src/http_logging_interceptor.dart
@@ -60,6 +60,7 @@ enum Level {
   body,
 }
 
+/// {@template http_logging_interceptor}
 /// A [RequestInterceptor] and [ResponseInterceptor] implementation which logs
 /// HTTP request and response data.
 ///
@@ -70,9 +71,11 @@ enum Level {
 /// leak sensitive information, such as `Authorization` headers and user data
 /// in response bodies. This interceptor should only be used in a controlled way
 /// or in a non-production environment.
+/// {@endtemplate}
 @immutable
 class HttpLoggingInterceptor
     implements RequestInterceptor, ResponseInterceptor {
+  /// {@macro http_logging_interceptor}
   HttpLoggingInterceptor({this.level = Level.body, Logger? logger})
       : _logger = logger ?? chopperLogger,
         _logBody = level == Level.body,

--- a/chopper/lib/src/interceptor.dart
+++ b/chopper/lib/src/interceptor.dart
@@ -100,14 +100,17 @@ abstract interface class ErrorConverter {
   FutureOr<Response> convertError<BodyType, InnerType>(Response response);
 }
 
+/// {@template HeadersInterceptor}
 /// A [RequestInterceptor] that adds [headers] to every request.
 ///
 /// Note that this interceptor will overwrite existing headers having the same
 /// keys as [headers].
+/// {@endtemplate}
 @immutable
 class HeadersInterceptor implements RequestInterceptor {
   final Map<String, String> headers;
 
+  /// {@macro HeadersInterceptor}
   const HeadersInterceptor(this.headers);
 
   @override
@@ -163,6 +166,7 @@ class CurlInterceptor implements RequestInterceptor {
   }
 }
 
+/// {@template JsonConverter}
 /// A [Converter] implementation that calls [json.encode] on [Request]s and
 /// [json.decode] on [Response]s using the [dart:convert](https://api.dart.dev/stable/2.10.3/dart-convert/dart-convert-library.html)
 /// package's [utf8] and [json] utilities.
@@ -176,8 +180,10 @@ class CurlInterceptor implements RequestInterceptor {
 /// If content type header is modified (for example by using
 /// `@Post(headers: {'content-type': '...'})`), `JsonConverter` won't add the
 /// header and it won't call json.encode if content type is not JSON.
+/// {@endtemplate}
 @immutable
 class JsonConverter implements Converter, ErrorConverter {
+  /// {@macro JsonConverter}
   const JsonConverter();
 
   @override
@@ -270,13 +276,16 @@ class JsonConverter implements Converter, ErrorConverter {
   }
 }
 
+/// {@template FormUrlEncodedConverter}
 /// A [Converter] implementation that converts only [Request]s having a [Map] as their body.
 ///
 /// This `Converter` also adds the `content-type: application/x-www-form-urlencoded`
 /// header to each request, but only if the `content-type` header is not set in
 /// the original request.
+/// {@endtemplate}
 @immutable
 class FormUrlEncodedConverter implements Converter, ErrorConverter {
+  /// {@macro FormUrlEncodedConverter}
   const FormUrlEncodedConverter();
 
   @override

--- a/chopper/lib/src/request.dart
+++ b/chopper/lib/src/request.dart
@@ -6,7 +6,9 @@ import 'package:equatable/equatable.dart' show EquatableMixin;
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 
+/// {@template request}
 /// This class represents an HTTP request that can be made with Chopper.
+/// {@endtemplate}
 base class Request extends http.BaseRequest with EquatableMixin {
   final Uri uri;
   final Uri baseUri;
@@ -17,6 +19,7 @@ base class Request extends http.BaseRequest with EquatableMixin {
   final bool useBrackets;
   final bool includeNullQueryVars;
 
+  /// {@macro request}
   Request(
     String method,
     this.uri,

--- a/chopper/lib/src/response.dart
+++ b/chopper/lib/src/response.dart
@@ -5,6 +5,7 @@ import 'package:equatable/equatable.dart' show EquatableMixin;
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 
+/// {@template response}
 /// A [http.BaseResponse] wrapper representing a response of a Chopper network call.
 ///
 /// ```dart
@@ -16,6 +17,7 @@ import 'package:meta/meta.dart';
 /// @Get(path: '/items/{id}')
 /// Future<Response<Item>> fetchItem();
 /// ```
+/// {@endtemplate}
 @immutable
 base class Response<BodyType> with EquatableMixin {
   /// The [http.BaseResponse] from `package:http` that this [Response] wraps.
@@ -31,6 +33,7 @@ base class Response<BodyType> with EquatableMixin {
   /// The body of the response if [isSuccessful] is false.
   final Object? error;
 
+  /// {@macro response}
   const Response(this.base, this.body, {this.error});
 
   /// Makes a copy of this Response, replacing original values with the given ones.

--- a/faq.md
+++ b/faq.md
@@ -2,17 +2,20 @@
 
 ## \*.chopper.dart not found ?
 
-If you have this error, you probably forgot to run the `build` package. To do that, simply run the following command in your shell.
+If you have this error, you probably forgot to run the `build` package. To do that, simply run the following command in
+your shell.
 
 `pub run build_runner build`
 
-It will generate the code that actually do the HTTP request \(YOUR_FILE.chopper.dart\). If you wish to update the code automatically when you change your definition run the `watch` command.
+It will generate the code that actually do the HTTP request \(YOUR_FILE.chopper.dart\). If you wish to update the code
+automatically when you change your definition run the `watch` command.
 
 `pub run build_runner watch`
 
 ## How to increase timeout ?
 
-Connection timeout is very limited for now due to http package \(see: [dart-lang/http\#21](https://github.com/dart-lang/http/issues/21)\)
+Connection timeout is very limited for now due to http package
+\(see: [dart-lang/http\#21](https://github.com/dart-lang/http/issues/21)\)
 
 But if you are on VM or Flutter you can set the `connectionTimeout` you want
 
@@ -21,10 +24,11 @@ import 'package:http/io_client.dart' as http;
 import 'dart:io';
 
 final chopper = ChopperClient(
-    client: http.IOClient(
-      HttpClient()..connectionTimeout = const Duration(seconds: 60),
-    ),
-  );
+  client: http.IOClient(
+    HttpClient()
+      ..connectionTimeout = const Duration(seconds: 60),
+  ),
+);
 ```
 
 ## Add query parameter to all requests
@@ -32,8 +36,9 @@ final chopper = ChopperClient(
 Possible using an interceptor.
 
 ```dart
+
 final chopper = ChopperClient(
-    interceptors: [_addQuery],
+  interceptors: [_addQuery],
 );
 
 Request _addQuery(Request req) {
@@ -54,8 +59,7 @@ Request compressRequest(Request request) {
   request = applyHeader(request, 'Content-Encoding', 'gzip');
   request = request.replace(body: gzip.encode(request.body));
   return request;
-}
-...
+}...
 
 @FactoryConverter(request: compressRequest)
 @Post()
@@ -64,15 +68,20 @@ Future<Response> postRequest(@Body() Map<String, String> data);
 
 ## Runtime baseUrl change
 
-You may need to change the base URL of your network calls during runtime, for example, if you have to use different servers or routes dynamically in your app in case of a "regular" or a "paid" user. You can store the current server base url in your SharedPreferences (encrypt/decrypt it if needed) and use it in an interceptor like this:
+You may need to change the base URL of your network calls during runtime, for example, if you have to use different
+servers or routes dynamically in your app in case of a "regular" or a "paid" user. You can store the current server base
+url in your SharedPreferences (encrypt/decrypt it if needed) and use it in an interceptor like this:
 
 ```dart
-...
-(Request request) async =>
-              SharedPreferences.containsKey('baseUrl')
-                  ? request.copyWith(
-                      baseUri: Uri.parse(SharedPreferences.getString('baseUrl'))
-                  ): request
+...(Request request) async =>
+SharedPreferences.containsKey('baseUrl')
+? request.copyWith(
+baseUri: Uri.parse(SharedPreferences.getString('baseUrl'
+)
+)
+)
+:
+request
 ...
 ```
 
@@ -80,7 +89,9 @@ You may need to change the base URL of your network calls during runtime, for ex
 
 Chopper is built on top of `http` package.
 
-So, one can just use the mocking API of the HTTP package. See the documentation for the [http.testing library](https://pub.dev/documentation/http/latest/http.testing/http.testing-library.html) and for the [MockClient class](https://pub.dev/documentation/http/latest/http.testing/MockClient-class.html).
+So, one can just use the mocking API of the HTTP package. See the documentation for
+the [http.testing library](https://pub.dev/documentation/http/latest/http.testing/http.testing-library.html) and for
+the [MockClient class](https://pub.dev/documentation/http/latest/http.testing/MockClient-class.html).
 
 Also, you can follow this code by [ozburo](https://github.com/ozburo):
 
@@ -132,12 +143,19 @@ import 'dart:io';
 import 'package:http/io_client.dart' as http;
 
 final ioc = new HttpClient();
-ioc.findProxy = (url) => 'PROXY 192.168.0.102:9090';
+ioc.findProxy = (
+url) => 'PROXY 192.168.0.102:9090';
 ioc.badCertificateCallback = (X509Certificate cert, String host, int port)
-  => true;
+=> true;
 
 final chopper = ChopperClient(
-  client: http.IOClient(ioc),
+client: http
+.
+IOClient
+(
+ioc
+)
+,
 );
 ```
 
@@ -145,7 +163,8 @@ final chopper = ChopperClient(
 
 Basically, the algorithm goes like this (credits to [stewemetal](https://github.com/stewemetal)):
 
-Add the authentication token to the request (by "Authorization" header, for example) -> try the request -> if it fails use the refresh token to get a new auth token ->
+Add the authentication token to the request (by "Authorization" header, for example) -> try the request -> if it fails
+use the refresh token to get a new auth token ->
 if that succeeds, save the auth token and retry the original request with it
 if the refresh token is not valid anymore, drop the session (and navigate to the login screen, for example)
 
@@ -153,26 +172,29 @@ Simple code example:
 
 ```dart
 interceptors: [
-  // Auth Interceptor
-  (Request request) async => applyHeader(request, 'authorization',
-      SharedPrefs.localStorage.getString(tokenHeader),
-      override: false),
-  (Response response) async {
-    if (response?.statusCode == 401) {
-      SharedPrefs.localStorage.remove(tokenHeader);
-      // Navigate to some login page or just request new token
-    }
-    return response;
-  },
+// Auth Interceptor
+(
+Request request) async => applyHeader(request, 'authorization',
+SharedPrefs.localStorage.getString(tokenHeader),
+override: false),
+(Response response) async {
+if (response?.statusCode == 401) {
+SharedPrefs.localStorage.remove(tokenHeader);
+// Navigate to some login page or just request new token
+}
+return response;
+},
 ]
 ```
 
-The actual implementation of the algorithm above may vary based on how the backend API - more precisely the login and session handling - of your app looks like.
+The actual implementation of the algorithm above may vary based on how the backend API - more precisely the login and
+session handling - of your app looks like.
 
 ### Authorized HTTP requests using the special Authenticator interceptor
 
-Similar to OkHTTP's [authenticator](https://github.com/square/okhttp/blob/480c20e46bb1745e280e42607bbcc73b2c953d97/okhttp/src/main/kotlin/okhttp3/Authenticator.kt),
-the idea here is to provide a reactive authentication in the event that an auth challenge is raised. It returns a 
+Similar to
+OkHTTP's [authenticator](https://github.com/square/okhttp/blob/480c20e46bb1745e280e42607bbcc73b2c953d97/okhttp/src/main/kotlin/okhttp3/Authenticator.kt),
+the idea here is to provide a reactive authentication in the event that an auth challenge is raised. It returns a
 nullable Request that contains a possible update to the original Request to satisfy the authentication challenge.
 
 ```dart
@@ -185,11 +207,10 @@ import 'package:chopper/chopper.dart';
 /// [response]. It returns `null` if the challenge cannot be satisfied.
 class MyAuthenticator extends Authenticator {
   @override
-  FutureOr<Request?> authenticate(
-    Request request,
-    Response response, [
-    Request? originalRequest,
-  ]) async {
+  FutureOr<Request?> authenticate(Request request,
+      Response response, [
+        Request? originalRequest,
+      ]) async {
     if (response.statusCode == HttpStatus.unauthorized) {
       final String? newToken = await refreshToken();
 
@@ -215,6 +236,7 @@ class MyAuthenticator extends Authenticator {
 
 /// When initializing your ChopperClient
 final client = ChopperClient(
+
   /// register your Authenticator here
   authenticator: MyAuthenticator(),
 );
@@ -223,7 +245,7 @@ final client = ChopperClient(
 ## Decoding JSON using Isolates
 
 Sometimes you want to decode JSON outside the main thread in order to reduce janking. In this example we're going to go
-even further and implement a Worker Pool using [Squadron](https://pub.dev/packages/squadron/install) which can 
+even further and implement a Worker Pool using [Squadron](https://pub.dev/packages/squadron/install) which can
 dynamically spawn a maximum number of Workers as they become needed.
 
 #### Install the dependencies
@@ -259,7 +281,8 @@ Extracted from the [full example here](example/lib/json_decode_service.dart).
 
 #### Write a custom JsonConverter
 
-Using [json_serializable](https://pub.dev/packages/json_serializable) we'll create a [JsonConverter](https://github.com/lejard-h/chopper/blob/master/chopper/lib/src/interceptor.dart#L228) 
+Using [json_serializable](https://pub.dev/packages/json_serializable) we'll create
+a [JsonConverter](https://github.com/lejard-h/chopper/blob/master/chopper/lib/src/interceptor.dart#L228)
 which works with or without a [WorkerPool](https://github.com/d-markey/squadron#features).
 
 ```dart
@@ -276,7 +299,7 @@ class JsonSerializableWorkerPoolConverter extends JsonConverter {
   const JsonSerializableWorkerPoolConverter(this.factories, [this.workerPool]);
 
   final Map<Type, JsonFactory> factories;
-  
+
   /// Make the WorkerPool optional so that the JsonConverter still works without it
   final JsonDecodeServiceWorkerPool? workerPool;
 
@@ -296,7 +319,7 @@ class JsonSerializableWorkerPoolConverter extends JsonConverter {
       return data;
     }
   }
-  
+
   T? _decodeMap<T>(Map<String, dynamic> values) {
     final jsonFactory = factories[T];
     if (jsonFactory == null || jsonFactory is! JsonFactory<T>) {
@@ -318,9 +341,7 @@ class JsonSerializableWorkerPoolConverter extends JsonConverter {
   }
 
   @override
-  FutureOr<Response<ResultType>> convertResponse<ResultType, Item>(
-    Response response,
-  ) async {
+  FutureOr<Response<ResultType>> convertResponse<ResultType, Item>(Response response,) async {
     final jsonRes = await super.convertResponse(response);
 
     return jsonRes.copyWith<ResultType>(body: _decode<Item>(jsonRes.body));
@@ -375,6 +396,7 @@ Future<void> main() async {
     {
       Resource: Resource.fromJsonFactory,
     },
+
     /// make sure to provide the WorkerPool to the JsonConverter
     jsonDecodeServiceWorkerPool,
   );
@@ -396,7 +418,7 @@ Future<void> main() async {
 
   /// Do stuff with myService
   final myService = chopper.getService<MyService>();
-  
+
   /// ...stuff...
 
   /// stop the Worker Pool once done
@@ -409,7 +431,45 @@ Future<void> main() async {
 #### Further reading
 
 This barely scratches the surface. If you want to know more about [squadron](https://github.com/d-markey/squadron) and
-[squadron_builder](https://github.com/d-markey/squadron_builder) make sure to head over to their respective repositories.
+[squadron_builder](https://github.com/d-markey/squadron_builder) make sure to head over to their respective
+repositories.
 
-[David Markey](https://github.com/d-markey]), the author of squadron, was kind enough as to provide us with an [excellent Flutter example](https://github.com/d-markey/squadron_builder) using
+[David Markey](https://github.com/d-markey]), the author of squadron, was kind enough as to provide us with
+an [excellent Flutter example](https://github.com/d-markey/squadron_builder) using
 both packages.
+
+## How to use Chopper with [Injectable](https://pub.dev/packages/injectable)
+
+### Create a module for your ChopperClient
+
+Define a module for your ChopperClient. You can use the `@lazySingleton` (or other type if preferred) annotation to make sure that only one is created.
+
+```dart
+@module
+abstract class ChopperModule {
+
+  @lazySingleton
+  ChopperClient get chopperClient =>
+      ChopperClient(
+        baseUrl: 'https://base-url.com',
+        converter: JsonConverter(),
+      );
+}
+```
+
+### Create ChopperService with Injectable
+
+Define your ChopperService as usual. Annotate the class with `@lazySingleton` (or other type if preferred) and use the `@factoryMethod` annotation to specify the factory method for the service. This would normally be the static create method.
+
+```dart
+@lazySingleton
+@ChopperApi(baseUrl: '/todos')
+abstract class TodosListService extends ChopperService {
+
+  @factoryMethod
+  static TodosListService create(ChopperClient client) => _$TodosListService(client);
+
+  @Get()
+  Future<Response<List<Todo>>> getTodos();
+}
+```

--- a/faq.md
+++ b/faq.md
@@ -2,20 +2,17 @@
 
 ## \*.chopper.dart not found ?
 
-If you have this error, you probably forgot to run the `build` package. To do that, simply run the following command in
-your shell.
+If you have this error, you probably forgot to run the `build` package. To do that, simply run the following command in your shell.
 
 `pub run build_runner build`
 
-It will generate the code that actually do the HTTP request \(YOUR_FILE.chopper.dart\). If you wish to update the code
-automatically when you change your definition run the `watch` command.
+It will generate the code that actually do the HTTP request \(YOUR_FILE.chopper.dart\). If you wish to update the code automatically when you change your definition run the `watch` command.
 
 `pub run build_runner watch`
 
 ## How to increase timeout ?
 
-Connection timeout is very limited for now due to http package
-\(see: [dart-lang/http\#21](https://github.com/dart-lang/http/issues/21)\)
+Connection timeout is very limited for now due to http package \(see: [dart-lang/http\#21](https://github.com/dart-lang/http/issues/21)\)
 
 But if you are on VM or Flutter you can set the `connectionTimeout` you want
 
@@ -24,11 +21,10 @@ import 'package:http/io_client.dart' as http;
 import 'dart:io';
 
 final chopper = ChopperClient(
-  client: http.IOClient(
-    HttpClient()
-      ..connectionTimeout = const Duration(seconds: 60),
-  ),
-);
+    client: http.IOClient(
+      HttpClient()..connectionTimeout = const Duration(seconds: 60),
+    ),
+  );
 ```
 
 ## Add query parameter to all requests
@@ -36,9 +32,8 @@ final chopper = ChopperClient(
 Possible using an interceptor.
 
 ```dart
-
 final chopper = ChopperClient(
-  interceptors: [_addQuery],
+    interceptors: [_addQuery],
 );
 
 Request _addQuery(Request req) {
@@ -59,7 +54,8 @@ Request compressRequest(Request request) {
   request = applyHeader(request, 'Content-Encoding', 'gzip');
   request = request.replace(body: gzip.encode(request.body));
   return request;
-}...
+}
+...
 
 @FactoryConverter(request: compressRequest)
 @Post()
@@ -68,20 +64,15 @@ Future<Response> postRequest(@Body() Map<String, String> data);
 
 ## Runtime baseUrl change
 
-You may need to change the base URL of your network calls during runtime, for example, if you have to use different
-servers or routes dynamically in your app in case of a "regular" or a "paid" user. You can store the current server base
-url in your SharedPreferences (encrypt/decrypt it if needed) and use it in an interceptor like this:
+You may need to change the base URL of your network calls during runtime, for example, if you have to use different servers or routes dynamically in your app in case of a "regular" or a "paid" user. You can store the current server base url in your SharedPreferences (encrypt/decrypt it if needed) and use it in an interceptor like this:
 
 ```dart
-...(Request request) async =>
-SharedPreferences.containsKey('baseUrl')
-? request.copyWith(
-baseUri: Uri.parse(SharedPreferences.getString('baseUrl'
-)
-)
-)
-:
-request
+...
+(Request request) async =>
+              SharedPreferences.containsKey('baseUrl')
+                  ? request.copyWith(
+                      baseUri: Uri.parse(SharedPreferences.getString('baseUrl'))
+                  ): request
 ...
 ```
 
@@ -89,9 +80,7 @@ request
 
 Chopper is built on top of `http` package.
 
-So, one can just use the mocking API of the HTTP package. See the documentation for
-the [http.testing library](https://pub.dev/documentation/http/latest/http.testing/http.testing-library.html) and for
-the [MockClient class](https://pub.dev/documentation/http/latest/http.testing/MockClient-class.html).
+So, one can just use the mocking API of the HTTP package. See the documentation for the [http.testing library](https://pub.dev/documentation/http/latest/http.testing/http.testing-library.html) and for the [MockClient class](https://pub.dev/documentation/http/latest/http.testing/MockClient-class.html).
 
 Also, you can follow this code by [ozburo](https://github.com/ozburo):
 
@@ -143,19 +132,12 @@ import 'dart:io';
 import 'package:http/io_client.dart' as http;
 
 final ioc = new HttpClient();
-ioc.findProxy = (
-url) => 'PROXY 192.168.0.102:9090';
+ioc.findProxy = (url) => 'PROXY 192.168.0.102:9090';
 ioc.badCertificateCallback = (X509Certificate cert, String host, int port)
-=> true;
+  => true;
 
 final chopper = ChopperClient(
-client: http
-.
-IOClient
-(
-ioc
-)
-,
+  client: http.IOClient(ioc),
 );
 ```
 
@@ -163,8 +145,7 @@ ioc
 
 Basically, the algorithm goes like this (credits to [stewemetal](https://github.com/stewemetal)):
 
-Add the authentication token to the request (by "Authorization" header, for example) -> try the request -> if it fails
-use the refresh token to get a new auth token ->
+Add the authentication token to the request (by "Authorization" header, for example) -> try the request -> if it fails use the refresh token to get a new auth token ->
 if that succeeds, save the auth token and retry the original request with it
 if the refresh token is not valid anymore, drop the session (and navigate to the login screen, for example)
 
@@ -172,28 +153,25 @@ Simple code example:
 
 ```dart
 interceptors: [
-// Auth Interceptor
-(
-Request request) async => applyHeader(request, 'authorization',
-SharedPrefs.localStorage.getString(tokenHeader),
-override: false),
-(Response response) async {
-if (response?.statusCode == 401) {
-SharedPrefs.localStorage.remove(tokenHeader);
-// Navigate to some login page or just request new token
-}
-return response;
-},
+  // Auth Interceptor
+  (Request request) async => applyHeader(request, 'authorization',
+      SharedPrefs.localStorage.getString(tokenHeader),
+      override: false),
+  (Response response) async {
+    if (response?.statusCode == 401) {
+      SharedPrefs.localStorage.remove(tokenHeader);
+      // Navigate to some login page or just request new token
+    }
+    return response;
+  },
 ]
 ```
 
-The actual implementation of the algorithm above may vary based on how the backend API - more precisely the login and
-session handling - of your app looks like.
+The actual implementation of the algorithm above may vary based on how the backend API - more precisely the login and session handling - of your app looks like.
 
 ### Authorized HTTP requests using the special Authenticator interceptor
 
-Similar to
-OkHTTP's [authenticator](https://github.com/square/okhttp/blob/480c20e46bb1745e280e42607bbcc73b2c953d97/okhttp/src/main/kotlin/okhttp3/Authenticator.kt),
+Similar to OkHTTP's [authenticator](https://github.com/square/okhttp/blob/480c20e46bb1745e280e42607bbcc73b2c953d97/okhttp/src/main/kotlin/okhttp3/Authenticator.kt),
 the idea here is to provide a reactive authentication in the event that an auth challenge is raised. It returns a
 nullable Request that contains a possible update to the original Request to satisfy the authentication challenge.
 
@@ -207,10 +185,11 @@ import 'package:chopper/chopper.dart';
 /// [response]. It returns `null` if the challenge cannot be satisfied.
 class MyAuthenticator extends Authenticator {
   @override
-  FutureOr<Request?> authenticate(Request request,
-      Response response, [
-        Request? originalRequest,
-      ]) async {
+  FutureOr<Request?> authenticate(
+    Request request,
+    Response response, [
+    Request? originalRequest,
+  ]) async {
     if (response.statusCode == HttpStatus.unauthorized) {
       final String? newToken = await refreshToken();
 
@@ -236,7 +215,6 @@ class MyAuthenticator extends Authenticator {
 
 /// When initializing your ChopperClient
 final client = ChopperClient(
-
   /// register your Authenticator here
   authenticator: MyAuthenticator(),
 );
@@ -281,8 +259,7 @@ Extracted from the [full example here](example/lib/json_decode_service.dart).
 
 #### Write a custom JsonConverter
 
-Using [json_serializable](https://pub.dev/packages/json_serializable) we'll create
-a [JsonConverter](https://github.com/lejard-h/chopper/blob/master/chopper/lib/src/interceptor.dart#L228)
+Using [json_serializable](https://pub.dev/packages/json_serializable) we'll create a [JsonConverter](https://github.com/lejard-h/chopper/blob/master/chopper/lib/src/interceptor.dart#L228)
 which works with or without a [WorkerPool](https://github.com/d-markey/squadron#features).
 
 ```dart
@@ -299,7 +276,7 @@ class JsonSerializableWorkerPoolConverter extends JsonConverter {
   const JsonSerializableWorkerPoolConverter(this.factories, [this.workerPool]);
 
   final Map<Type, JsonFactory> factories;
-
+  
   /// Make the WorkerPool optional so that the JsonConverter still works without it
   final JsonDecodeServiceWorkerPool? workerPool;
 
@@ -319,7 +296,7 @@ class JsonSerializableWorkerPoolConverter extends JsonConverter {
       return data;
     }
   }
-
+  
   T? _decodeMap<T>(Map<String, dynamic> values) {
     final jsonFactory = factories[T];
     if (jsonFactory == null || jsonFactory is! JsonFactory<T>) {
@@ -341,7 +318,9 @@ class JsonSerializableWorkerPoolConverter extends JsonConverter {
   }
 
   @override
-  FutureOr<Response<ResultType>> convertResponse<ResultType, Item>(Response response,) async {
+  FutureOr<Response<ResultType>> convertResponse<ResultType, Item>(
+    Response response,
+  ) async {
     final jsonRes = await super.convertResponse(response);
 
     return jsonRes.copyWith<ResultType>(body: _decode<Item>(jsonRes.body));
@@ -396,7 +375,6 @@ Future<void> main() async {
     {
       Resource: Resource.fromJsonFactory,
     },
-
     /// make sure to provide the WorkerPool to the JsonConverter
     jsonDecodeServiceWorkerPool,
   );
@@ -418,7 +396,7 @@ Future<void> main() async {
 
   /// Do stuff with myService
   final myService = chopper.getService<MyService>();
-
+  
   /// ...stuff...
 
   /// stop the Worker Pool once done
@@ -431,11 +409,9 @@ Future<void> main() async {
 #### Further reading
 
 This barely scratches the surface. If you want to know more about [squadron](https://github.com/d-markey/squadron) and
-[squadron_builder](https://github.com/d-markey/squadron_builder) make sure to head over to their respective
-repositories.
+[squadron_builder](https://github.com/d-markey/squadron_builder) make sure to head over to their respective repositories.
 
-[David Markey](https://github.com/d-markey]), the author of squadron, was kind enough as to provide us with
-an [excellent Flutter example](https://github.com/d-markey/squadron_builder) using
+[David Markey](https://github.com/d-markey]), the author of squadron, was kind enough as to provide us with an [excellent Flutter example](https://github.com/d-markey/squadron_builder) using
 both packages.
 
 ## How to use Chopper with [Injectable](https://pub.dev/packages/injectable)

--- a/getting-started.md
+++ b/getting-started.md
@@ -25,8 +25,7 @@ Run `pub get` to start using Chopper in your project.
 
 ### ChopperApi
 
-To define a client, use the `@
-ChopperApi` annotation on an abstract class that extends the `ChopperService` class.
+To define a client, use the `@ChopperApi` annotation on an abstract class that extends the `ChopperService` class.
 
 ```dart
 // YOUR_FILE.dart
@@ -66,7 +65,9 @@ Use one of the following annotations on abstract methods of a service class to d
 
 * `@Head`
 
-Request methods must return with values of the type `Future<Response>` or `Future<Response<SomeType>>`.
+Request methods must return with values of the type `Future<Response>`, `Future<Response<SomeType>>` or `Future<SomeType>`.
+The `Response` class is a wrapper around the HTTP response that contains the response body, the status code and the error (if any) of the request.
+This class can be omitted if only the response body is needed. When omitting the `Response` class, the request will throw an exception if the response status code is not in the range of `< 200` to ` > 300`.
 
 To define a `GET` request to the endpoint `/todos` in the service class above, add one of the following method declarations to the class:
 
@@ -80,6 +81,13 @@ or
 ```dart
 @Get()
 Future<Response<List<Todo>>> getTodos();
+```
+
+or
+
+```dart
+@Get()
+Future<List<Todo>> getTodos();
 ```
 
 URL manipulation with dynamic path, and query parameters is also supported. To learn more about URL manipulation with Chopper, have a look at the [Requests](requests.md) section of the documentation. 

--- a/requests.md
+++ b/requests.md
@@ -1,63 +1,105 @@
 # Requests
 
+## Available Request annotations
+
+| Annotation                                 | HTTP verb | Description                                   |
+|--------------------------------------------|-----------|-----------------------------------------------|
+| `@Get()`, `@get`                           | `GET`     | Defines a `GET` request.                      |
+| `@Post()`, `@post`                         | `POST`    | Defines a `POST` request.                     |
+| `@Put()`, `@put`                           | `PUT`     | Defines a `PUT` request.                      |
+| `@Patch()`, `@patch`                       | `PATCH`   | Defines a `PATCH` request.                    |
+| `@Delete()`, `@delete`                     | `DELETE`  | Defines a `DELETE` request.                   |
+| `@Head()`, `@head`                         | `HEAD`    | Defines a `HEAD` request.                     |
+| `@Body()`, `@body`                         | -         | Defines the request's body.                   |
+| `@Multipart()`, `@multipart`               | -         | Defines a `multipart/form-data` request.      |         
+| `@Query()`, `@query`                       | -         | Defines a query parameter.                    |             
+| `@QueryMap()`, `@queryMap`                 | -         | Defines a query parameter map.                |          
+| `@FactoryConverter()`, `@factoryConverter` | -         | Defines a request/response converter factory. |  
+| `@Field()`, `@field`                       | -         | Defines a form field.                         |             
+| `@FieldMap()`, `@fieldMap`                 | -         | Defines a form field map.                     |          
+| `@Part()`, `@part`                         | -         | Defines a multipart part.                     |              
+| `@PartMap()`, `@partMap`                   | -         | Defines a multipart part map.                 |           
+| `@PartFile()`, `@partFile`                 | -         | Defines a multipart file part.                |          
+| `@PartFileMap()`, `@partFileMap`           | -         | Defines a multipart file part map.            |
+
 ## Path resolution
 
 Chopper handles paths passed to HTTP verb annotations' `path` parameter based on the path's content.
 
-If the `path` value is a relative path, it will be concatenated to the URL composed of the `baseUrl` of the `ChopperClient` and the `baseUrl` of the enclosing service class (provided as a parameter of the `@ChopperApi` annotation).
+If the `path` value is a relative path, it will be concatenated to the URL composed of the `baseUrl` of
+the `ChopperClient` and the `baseUrl` of the enclosing service class (provided as a parameter of the `@ChopperApi`
+annotation).
 
 Here are a few examples of the described behavior:
 
-* `ChopperClient` base URL: https://example.com/  
-    Path: profile  
-    Result: https://example.com/profile
+| Variable   | URI                         |
+|------------|-----------------------------|
+| base URL   | https://example.com/        |  
+| Path       | profile                     |
+| **Result** | https://example.com/profile |
 
-* `ChopperClient` base URL: https://example.com/  
-  Service base URL: profile  
-  Path: /image  
-  Result: https://example.com/profile/image
+| Variable         | URI                               |
+|------------------|-----------------------------------|
+| base URL         | https://example.com/              |  
+| Service base URL | profile                           |
+| Path             | /image                            |
+| **Result**       | https://example.com/profile/image |
 
-* `ChopperClient` base URL: https://example.com/  
-  Service base URL: profile  
-  Path: image  
-  Result: https://example.com/profile/image
+| Variable         | URI                               |
+|------------------|-----------------------------------|
+| base URL         | https://example.com/              |  
+| Service base URL | profile                           |
+| Path             | image                             |
+| **Result**       | https://example.com/profile/image |
 
-> Chopper detects and handles missing slash (`/`) characters on URL segment borders, but *does not* handle duplicate slashes.
+> Chopper detects and handles missing slash (`/`) characters on URL segment borders, but *does not* handle duplicate
+> slashes.
 
-If the service's `baseUrl` concatenated with the request's `path` results in a full URL, the `ChopperClient`'s `baseUrl` is ignored.
+If the service's `baseUrl` concatenated with the request's `path` results in a full URL, the `ChopperClient`'s `baseUrl`
+is ignored.
 
-* `ChopperClient` base URL: https://example.com/  
-Service base URL: https://api.github.com/  
-Path: user  
-Result: https://api.github.com/user  
+| Variable         | URI                         |
+|------------------|-----------------------------|
+| base URL         | https://example.com/        |  
+| Service base URL | https://api.github.com/     |
+| Path             | user                        |
+| **Result**       | https://api.github.com/user |
 
-A `path` containing a full URL replaces the base URLs of both the `ChopperClient` and the service class entirely for a request.
+A `path` containing a full URL replaces the base URLs of both the `ChopperClient` and the service class entirely for a
+request.
 
-* `ChopperClient` base URL: https://example.com/  
-  Path: https://api.github.com/user  
-  Result: https://api.github.com/user
-  
-* `ChopperClient` base URL: https://example.com/  
-  Service base URL: profile  
-  Path: https://api.github.com/user  
-  Result: https://api.github.com/user
+| Variable   | URI                         |
+|------------|-----------------------------|
+| base URL   | https://example.com/        |  
+| Path       | https://api.github.com/user |
+| **Result** | https://api.github.com/user |
+
+| Variable         | URI                         |
+|------------------|-----------------------------|
+| base URL         | https://example.com/        |  
+| Service base URL | profile                     |
+| Path             | https://api.github.com/user |
+| **Result**       | https://api.github.com/user |
 
 ## Path parameters
 
-Dynamic path parameters can be defined in the URL with replacement blocks. A replacement block is an alphanumeric substring of the path surrounded by `{` and `}`. In the following example `{id}` is a replacement block.
+Dynamic path parameters can be defined in the URL with replacement blocks. A replacement block is an alphanumeric
+substring of the path surrounded by `{` and `}`. In the following example `{id}` is a replacement block.
 
 ```dart
 @Get(path: "/{id}")
 ```
 
-Use the `@Path()` annotation to bind a parameter to a replacement block. This way the parameter's name must match a replacement block's string.
+Use the `@Path()` annotation to bind a parameter to a replacement block. This way the parameter's name must match a
+replacement block's string.
 
 ```dart
 @Get(path: "/{id}")
 Future<Response> getItemById(@Path() String id);
 ```
 
-As an alternative, you can set the `@Path` annotation's `name` parameter to match a replacement block's string while using a different parameter name, like in the following example:
+As an alternative, you can set the `@Path` annotation's `name` parameter to match a replacement block's string while
+using a different parameter name, like in the following example:
 
 ```dart
 @Get(path: "/{id}")
@@ -68,16 +110,17 @@ Future<Response> getItemById(@Path("id") int itemId);
 
 ## Query parameters
 
-Dynamic query parameters can be added to the URL by adding parameters to a request method annotated with the `@Query` annotation. Default values are supported.
+Dynamic query parameters can be added to the URL by adding parameters to a request method annotated with the `@Query`
+annotation. Default values are supported.
 
 ```dart
-Future<Response> search(
-    @Query() String name, {
-    @Query("count") int numberOfResults = 42,
+Future<Response> search(@Query() String name, {
+  @Query("count") int numberOfResults = 42,
 });
 ```
 
-If the parameter of the `@Query` annotation is not set, Chopper will use the actual name of the annotated parameter as the key for the query parameter in the URL.
+If the parameter of the `@Query` annotation is not set, Chopper will use the actual name of the annotated parameter as
+the key for the query parameter in the URL.
 
 If you prefer to pass a `Map` of query parameters, you can do so with the `@QueryMap` annotation.
 
@@ -97,50 +140,58 @@ Future<Response> postData(@Body() String data);
 {% hint style="warning" %}
 Chopper does not automatically convert `Object`s to `Map`then `JSON`.
 
-You have to pass a [Converter](converters/converters.md) instance to a `ChopperClient` for JSON conversion to happen. See [built\_value\_converter](converters/built-value-converter.md#built-value) for an example Converter implementation.
+You have to pass a [Converter](converters/converters.md) instance to a `ChopperClient` for JSON conversion to happen.
+See [built\_value\_converter](converters/built-value-converter.md#built-value) for an example Converter implementation.
 {% endhint %}
 
 ## Headers
 
-Request headers can be set by providing a `Map<String, String>` object to the `headers` parameter each of the HTTP verb annotations have.
+Request headers can be set by providing a `Map<String, String>` object to the `headers` parameter each of the HTTP verb
+annotations have.
 
 ```dart
 @Get(path: "/", headers: {"foo": "bar"})
 Future<Response> fetch();
 ```
 
-The `@Header` annotation can be used on method parameters to set headers dynamically for each request call. 
+The `@Header` annotation can be used on method parameters to set headers dynamically for each request call.
 
 ```dart
 @Get(path: "/")
 Future<Response> fetch(@Header("foo") String bar);
 ```
 
-> Setting request headers dynamically is also supported by [Interceptors](interceptors.md) and [Converters](converters/converters.md).
+> Setting request headers dynamically is also supported by [Interceptors](interceptors.md)
+> and [Converters](converters/converters.md).
 >
-> As Chopper invokes Interceptors and Converter(s) *after* creating a Request, Interceptors and Converters *can* override headers set with the `headers` parameter or `@Header` annotations.
+> As Chopper invokes Interceptors and Converter(s) *after* creating a Request, Interceptors and Converters *can*
+> override headers set with the `headers` parameter or `@Header` annotations.
 
 ## Sending `application/x-www-form-urlencoded` data
 
-If no Converter is specified for a request (neither on a `ChopperClient` nor with the `@FactoryConverter` annotation) and the request body is of type `Map<String, String>`, the body will be sent as form URL encoded data.
+If no Converter is specified for a request (neither on a `ChopperClient` nor with the `@FactoryConverter` annotation)
+and the request body is of type `Map<String, String>`, the body will be sent as form URL encoded data.
 
 > This is the default behavior of the http package.
 
-You can also use `FormUrlEncodedConverter` that will add the correct `content-type` and convert a `Map` into `Map<String, String>` for requests.
+You can also use `FormUrlEncodedConverter` that will add the correct `content-type` and convert a `Map`
+into `Map<String, String>` for requests.
 
 ```dart
+
 final chopper = ChopperClient(
-      converter: FormUrlEncodedConverter(),
+  converter: FormUrlEncodedConverter(),
 );
 ```
 
 ### On a single method
 
-To do only a single type of request with form encoding in a service, use the provided `FormUrlEncodedConverter`'s `requestFactory` method with the `@FactoryConverter` annotation.
+To do only a single type of request with form encoding in a service, use the provided `FormUrlEncodedConverter`'
+s `requestFactory` method with the `@FactoryConverter` annotation.
 
 ```dart
 @Post(
-  path: "form", 
+  path: "form",
   headers: {contentTypeKey: formEncodedHeaders},
 )
 @FactoryConverter(
@@ -151,7 +202,8 @@ Future<Response> postForm(@Body() Map<String, String> fields);
 
 ### Defining fields individually
 
-To specify fields individually, use the `@Field` annotation on method parameters. If the field's name is not provided, the parameter's name is used as the field's name.
+To specify fields individually, use the `@Field` annotation on method parameters. If the field's name is not provided,
+the parameter's name is used as the field's name.
 
 ```dart
 @Post(path: "form")
@@ -161,5 +213,51 @@ To specify fields individually, use the `@Field` annotation on method parameters
 Future<Response> post(@Field() String foo, @Field("b") int bar);
 ```
 
-## Sending files
+## Sending files with `@multipart`
 
+### Sending a file in bytes as `List<int>` using `@PartFile`
+
+```dart
+@Post(path: 'file')
+@multipart
+Future<Response> postFile(@PartFile('file') List<int> bytes,);
+```
+
+### Sending a file as `MultipartFile` using `@PartFile` with extra parameters via `@Part`
+
+```dart
+@Post(path: 'file')
+@multipart
+Future<Response> postMultipartFile(@PartFile() MultipartFile file, {
+  @Part() String? id,
+});
+```
+
+### Sending multiple files as `List<MultipartFile>` using `@PartFile`
+
+```dart
+@Post(path: 'files')
+@multipart
+Future<Response> postListFiles(@PartFile() List<MultipartFile> files);
+```
+
+## Defining Responses
+
+ChopperService methods need to return a `Future`. Its possible to define return types of `Future<Response>` or `Future<Response<T>>` where `T` is the type of the response body. 
+When `Response` is not needed for a request its also possible to define a return type of `Future<T>` where `T` is the type of the response body.
+
+Chopper will generate a client which will return the specified return type. When the method doesn't directly returns `Response` and the HTTP call fails a exception is thrown.
+
+```dart
+// Returns a Response<dynamic>
+@Get(path: "/")
+Future<Response> fetch();
+
+// Returns a Response<MyClass>
+@Get(path: "/")
+Future<Response<MyClass>> fetch();
+
+// Returns a MyClass
+@Get(path: "/")
+Future<MyClass> fetch();
+```

--- a/requests.md
+++ b/requests.md
@@ -116,7 +116,7 @@ annotation. Default values are supported.
 ```dart
 Future<Response> search(
     @Query() String name, {
-      @Query("count") int numberOfResults = 42,
+    @Query("count") int numberOfResults = 42,
     });
 ```
 

--- a/requests.md
+++ b/requests.md
@@ -114,9 +114,10 @@ Dynamic query parameters can be added to the URL by adding parameters to a reque
 annotation. Default values are supported.
 
 ```dart
-Future<Response> search(@Query() String name, {
-  @Query("count") int numberOfResults = 42,
-});
+Future<Response> search(
+    @Query() String name, {
+      @Query("count") int numberOfResults = 42,
+    });
 ```
 
 If the parameter of the `@Query` annotation is not set, Chopper will use the actual name of the annotated parameter as

--- a/requests.md
+++ b/requests.md
@@ -117,7 +117,7 @@ annotation. Default values are supported.
 Future<Response> search(
     @Query() String name, {
     @Query("count") int numberOfResults = 42,
-    });
+});
 ```
 
 If the parameter of the `@Query` annotation is not set, Chopper will use the actual name of the annotated parameter as

--- a/requests.md
+++ b/requests.md
@@ -261,3 +261,5 @@ Future<Response<MyClass>> fetch();
 @Get(path: "/")
 Future<MyClass> fetch();
 ```
+
+> Note: Chopper doesn't convert response bodies by itself to dart object. You need to use a [Converter](converters/converters.md) for that. 


### PR DESCRIPTION
- Added/Updated documentation with new `Response` omit functionality
- Updated/Improved `request.md` documentation
- Added dartdoc `@template` to shared dartdoc between class and constructor for:
  - HttpLoggingInterceptor
  - HeadersInterceptor
  - JsonConverter
  - FormUrlEncodedConverter
  - Request
  -  Response
  - All annotations
- Added const variants from all annotations. This make `@Get()` and `@get` both valid annotations.
- Added FAQ on using Chopper and Injectable together.