### PR TITLE
:sparkles: add option to override build_extension

### DIFF
--- a/chopper_generator/lib/src/builder_factory.dart
+++ b/chopper_generator/lib/src/builder_factory.dart
@@ -1,23 +1,61 @@
 import 'package:build/build.dart';
 import 'package:chopper/chopper.dart' show ChopperApi;
 import 'package:source_gen/source_gen.dart';
+import 'package:yaml/yaml.dart';
 
 import 'generator.dart';
 
 /// Creates a [PartBuilder] used to generate code for [ChopperApi] annotated
 /// classes. The [options] are provided by Dart's build system and read from the
 /// `build.yaml` file.
-Builder chopperGeneratorFactory(BuilderOptions options) => PartBuilder(
+Builder chopperGeneratorFactory(BuilderOptions options) {
+  final String buildExtension = _getBuildExtension(options);
+
+  return PartBuilder(
+    [const ChopperGenerator()],
+    buildExtension,
+    header: options.config['header'],
+    formatOutput: PartBuilder(
       [const ChopperGenerator()],
-      '.chopper.dart',
-      header: options.config['header'],
-      formatOutput:
-          PartBuilder([const ChopperGenerator()], '.chopper.dart').formatOutput,
-      options: !options.config.containsKey('build_extensions')
-          ? options.overrideWith(
-              BuilderOptions({
-                'build_extensions': {'.dart': '.chopper.dart'},
-              }),
-            )
-          : options,
-    );
+      buildExtension,
+    ).formatOutput,
+    options: !options.config.containsKey('build_extensions')
+        ? options.overrideWith(
+            BuilderOptions({
+              'build_extensions': {
+                '.dart': [buildExtension]
+              },
+            }),
+          )
+        : options,
+  );
+}
+
+/// Returns the build extension for the generated file.
+///
+/// If the `build.yaml` file contains a `build_extensions` key, it will be used
+/// to determine the extension. Otherwise, the default extension `.chopper.dart`
+/// will be used.
+///
+/// Example `build.yaml`:
+///
+/// ```yaml
+/// targets:
+///   $default:
+///     builders:
+///       chopper_generator:
+///         options:
+///           build_extensions: {".dart": [".chopper.g.dart"]}
+/// ```
+String _getBuildExtension(BuilderOptions options) {
+  if (options.config.containsKey('build_extensions')) {
+    final YamlMap buildExtensions = options.config['build_extensions'];
+    if (buildExtensions.containsKey('.dart')) {
+      final YamlList dartBuildExtensions = buildExtensions['.dart'];
+      if (dartBuildExtensions.isNotEmpty) {
+        return dartBuildExtensions.first;
+      }
+    }
+  }
+  return '.chopper.dart';
+}

--- a/chopper_generator/pubspec.yaml
+++ b/chopper_generator/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   logging: ^1.2.0
   meta: ^1.9.1
   source_gen: ^1.4.0
+  yaml: ^3.1.2
 
 dev_dependencies:
   build_runner: ^2.4.6

--- a/faq.md
+++ b/faq.md
@@ -347,6 +347,22 @@ It goes without saying that running the code generation is a pre-requisite at th
 flutter pub run build_runner build
 ```
 
+##### Changing the default extension of the generated files
+
+If you want to change the default extension of the generated files from `.chopper.dart` to
+something else, you can do so by adding the following to your `build.yaml` file:
+
+```yaml
+targets:
+  $default:
+    builders:
+      chopper_generator:
+        options:
+          # This assumes you want the files to end with `.chopper.g.dart`
+          # instead of the default `.chopper.dart`.
+          build_extensions: { ".dart": [ ".chopper.g.dart" ] }
+```
+
 #### Configure a WorkerPool and run the example
 
 ```dart

--- a/faq.md
+++ b/faq.md
@@ -2,20 +2,17 @@
 
 ## \*.chopper.dart not found ?
 
-If you have this error, you probably forgot to run the `build` package. To do that, simply run the following command in
-your shell.
+If you have this error, you probably forgot to run the `build` package. To do that, simply run the following command in your shell.
 
 `pub run build_runner build`
 
-It will generate the code that actually do the HTTP request \(YOUR_FILE.chopper.dart\). If you wish to update the code
-automatically when you change your definition run the `watch` command.
+It will generate the code that actually do the HTTP request \(YOUR_FILE.chopper.dart\). If you wish to update the code automatically when you change your definition run the `watch` command.
 
 `pub run build_runner watch`
 
 ## How to increase timeout ?
 
-Connection timeout is very limited for now due to http package
-\(see: [dart-lang/http\#21](https://github.com/dart-lang/http/issues/21)\)
+Connection timeout is very limited for now due to http package \(see: [dart-lang/http\#21](https://github.com/dart-lang/http/issues/21)\)
 
 But if you are on VM or Flutter you can set the `connectionTimeout` you want
 
@@ -24,11 +21,10 @@ import 'package:http/io_client.dart' as http;
 import 'dart:io';
 
 final chopper = ChopperClient(
-  client: http.IOClient(
-    HttpClient()
-      ..connectionTimeout = const Duration(seconds: 60),
-  ),
-);
+    client: http.IOClient(
+      HttpClient()..connectionTimeout = const Duration(seconds: 60),
+    ),
+  );
 ```
 
 ## Add query parameter to all requests
@@ -36,9 +32,8 @@ final chopper = ChopperClient(
 Possible using an interceptor.
 
 ```dart
-
 final chopper = ChopperClient(
-  interceptors: [_addQuery],
+    interceptors: [_addQuery],
 );
 
 Request _addQuery(Request req) {
@@ -59,7 +54,8 @@ Request compressRequest(Request request) {
   request = applyHeader(request, 'Content-Encoding', 'gzip');
   request = request.replace(body: gzip.encode(request.body));
   return request;
-}...
+}
+...
 
 @FactoryConverter(request: compressRequest)
 @Post()
@@ -68,20 +64,15 @@ Future<Response> postRequest(@Body() Map<String, String> data);
 
 ## Runtime baseUrl change
 
-You may need to change the base URL of your network calls during runtime, for example, if you have to use different
-servers or routes dynamically in your app in case of a "regular" or a "paid" user. You can store the current server base
-url in your SharedPreferences (encrypt/decrypt it if needed) and use it in an interceptor like this:
+You may need to change the base URL of your network calls during runtime, for example, if you have to use different servers or routes dynamically in your app in case of a "regular" or a "paid" user. You can store the current server base url in your SharedPreferences (encrypt/decrypt it if needed) and use it in an interceptor like this:
 
 ```dart
-...(Request request) async =>
-SharedPreferences.containsKey('baseUrl')
-? request.copyWith(
-baseUri: Uri.parse(SharedPreferences.getString('baseUrl'
-)
-)
-)
-:
-request
+...
+(Request request) async =>
+              SharedPreferences.containsKey('baseUrl')
+                  ? request.copyWith(
+                      baseUri: Uri.parse(SharedPreferences.getString('baseUrl'))
+                  ): request
 ...
 ```
 
@@ -89,9 +80,7 @@ request
 
 Chopper is built on top of `http` package.
 
-So, one can just use the mocking API of the HTTP package. See the documentation for
-the [http.testing library](https://pub.dev/documentation/http/latest/http.testing/http.testing-library.html) and for
-the [MockClient class](https://pub.dev/documentation/http/latest/http.testing/MockClient-class.html).
+So, one can just use the mocking API of the HTTP package. See the documentation for the [http.testing library](https://pub.dev/documentation/http/latest/http.testing/http.testing-library.html) and for the [MockClient class](https://pub.dev/documentation/http/latest/http.testing/MockClient-class.html).
 
 Also, you can follow this code by [ozburo](https://github.com/ozburo):
 
@@ -143,19 +132,12 @@ import 'dart:io';
 import 'package:http/io_client.dart' as http;
 
 final ioc = new HttpClient();
-ioc.findProxy = (
-url) => 'PROXY 192.168.0.102:9090';
+ioc.findProxy = (url) => 'PROXY 192.168.0.102:9090';
 ioc.badCertificateCallback = (X509Certificate cert, String host, int port)
-=> true;
+  => true;
 
 final chopper = ChopperClient(
-client: http
-.
-IOClient
-(
-ioc
-)
-,
+  client: http.IOClient(ioc),
 );
 ```
 
@@ -163,8 +145,7 @@ ioc
 
 Basically, the algorithm goes like this (credits to [stewemetal](https://github.com/stewemetal)):
 
-Add the authentication token to the request (by "Authorization" header, for example) -> try the request -> if it fails
-use the refresh token to get a new auth token ->
+Add the authentication token to the request (by "Authorization" header, for example) -> try the request -> if it fails use the refresh token to get a new auth token ->
 if that succeeds, save the auth token and retry the original request with it
 if the refresh token is not valid anymore, drop the session (and navigate to the login screen, for example)
 
@@ -172,28 +153,25 @@ Simple code example:
 
 ```dart
 interceptors: [
-// Auth Interceptor
-(
-Request request) async => applyHeader(request, 'authorization',
-SharedPrefs.localStorage.getString(tokenHeader),
-override: false),
-(Response response) async {
-if (response?.statusCode == 401) {
-SharedPrefs.localStorage.remove(tokenHeader);
-// Navigate to some login page or just request new token
-}
-return response;
-},
+  // Auth Interceptor
+  (Request request) async => applyHeader(request, 'authorization',
+      SharedPrefs.localStorage.getString(tokenHeader),
+      override: false),
+  (Response response) async {
+    if (response?.statusCode == 401) {
+      SharedPrefs.localStorage.remove(tokenHeader);
+      // Navigate to some login page or just request new token
+    }
+    return response;
+  },
 ]
 ```
 
-The actual implementation of the algorithm above may vary based on how the backend API - more precisely the login and
-session handling - of your app looks like.
+The actual implementation of the algorithm above may vary based on how the backend API - more precisely the login and session handling - of your app looks like.
 
 ### Authorized HTTP requests using the special Authenticator interceptor
 
-Similar to
-OkHTTP's [authenticator](https://github.com/square/okhttp/blob/480c20e46bb1745e280e42607bbcc73b2c953d97/okhttp/src/main/kotlin/okhttp3/Authenticator.kt),
+Similar to OkHTTP's [authenticator](https://github.com/square/okhttp/blob/480c20e46bb1745e280e42607bbcc73b2c953d97/okhttp/src/main/kotlin/okhttp3/Authenticator.kt),
 the idea here is to provide a reactive authentication in the event that an auth challenge is raised. It returns a
 nullable Request that contains a possible update to the original Request to satisfy the authentication challenge.
 
@@ -207,10 +185,11 @@ import 'package:chopper/chopper.dart';
 /// [response]. It returns `null` if the challenge cannot be satisfied.
 class MyAuthenticator extends Authenticator {
   @override
-  FutureOr<Request?> authenticate(Request request,
-      Response response, [
-        Request? originalRequest,
-      ]) async {
+  FutureOr<Request?> authenticate(
+    Request request,
+    Response response, [
+    Request? originalRequest,
+  ]) async {
     if (response.statusCode == HttpStatus.unauthorized) {
       final String? newToken = await refreshToken();
 
@@ -236,7 +215,6 @@ class MyAuthenticator extends Authenticator {
 
 /// When initializing your ChopperClient
 final client = ChopperClient(
-
   /// register your Authenticator here
   authenticator: MyAuthenticator(),
 );
@@ -281,8 +259,7 @@ Extracted from the [full example here](example/lib/json_decode_service.dart).
 
 #### Write a custom JsonConverter
 
-Using [json_serializable](https://pub.dev/packages/json_serializable) we'll create
-a [JsonConverter](https://github.com/lejard-h/chopper/blob/master/chopper/lib/src/interceptor.dart#L228)
+Using [json_serializable](https://pub.dev/packages/json_serializable) we'll create a [JsonConverter](https://github.com/lejard-h/chopper/blob/master/chopper/lib/src/interceptor.dart#L228)
 which works with or without a [WorkerPool](https://github.com/d-markey/squadron#features).
 
 ```dart
@@ -299,7 +276,7 @@ class JsonSerializableWorkerPoolConverter extends JsonConverter {
   const JsonSerializableWorkerPoolConverter(this.factories, [this.workerPool]);
 
   final Map<Type, JsonFactory> factories;
-
+  
   /// Make the WorkerPool optional so that the JsonConverter still works without it
   final JsonDecodeServiceWorkerPool? workerPool;
 
@@ -319,7 +296,7 @@ class JsonSerializableWorkerPoolConverter extends JsonConverter {
       return data;
     }
   }
-
+  
   T? _decodeMap<T>(Map<String, dynamic> values) {
     final jsonFactory = factories[T];
     if (jsonFactory == null || jsonFactory is! JsonFactory<T>) {
@@ -341,7 +318,9 @@ class JsonSerializableWorkerPoolConverter extends JsonConverter {
   }
 
   @override
-  FutureOr<Response<ResultType>> convertResponse<ResultType, Item>(Response response,) async {
+  FutureOr<Response<ResultType>> convertResponse<ResultType, Item>(
+    Response response,
+  ) async {
     final jsonRes = await super.convertResponse(response);
 
     return jsonRes.copyWith<ResultType>(body: _decode<Item>(jsonRes.body));
@@ -366,22 +345,6 @@ It goes without saying that running the code generation is a pre-requisite at th
 
 ```bash
 flutter pub run build_runner build
-```
-
-##### Changing the default extension of the generated files
-
-If you want to change the default extension of the generated files from `.chopper.dart` to
-something else, you can do so by adding the following to your `build.yaml` file:
-
-```yaml
-targets:
-  $default:
-    builders:
-      chopper_generator:
-        options:
-          # This assumes you want the files to end with `.chopper.g.dart`
-          # instead of the default `.chopper.dart`.
-          build_extensions: { ".dart": [ ".chopper.g.dart" ] }
 ```
 
 #### Configure a WorkerPool and run the example
@@ -412,7 +375,6 @@ Future<void> main() async {
     {
       Resource: Resource.fromJsonFactory,
     },
-
     /// make sure to provide the WorkerPool to the JsonConverter
     jsonDecodeServiceWorkerPool,
   );
@@ -434,7 +396,7 @@ Future<void> main() async {
 
   /// Do stuff with myService
   final myService = chopper.getService<MyService>();
-
+  
   /// ...stuff...
 
   /// stop the Worker Pool once done
@@ -447,19 +409,16 @@ Future<void> main() async {
 #### Further reading
 
 This barely scratches the surface. If you want to know more about [squadron](https://github.com/d-markey/squadron) and
-[squadron_builder](https://github.com/d-markey/squadron_builder) make sure to head over to their respective
-repositories.
+[squadron_builder](https://github.com/d-markey/squadron_builder) make sure to head over to their respective repositories.
 
-[David Markey](https://github.com/d-markey]), the author of squadron, was kind enough as to provide us with
-an [excellent Flutter example](https://github.com/d-markey/squadron_builder) using
+[David Markey](https://github.com/d-markey]), the author of squadron, was kind enough as to provide us with an [excellent Flutter example](https://github.com/d-markey/squadron_builder) using
 both packages.
 
 ## How to use Chopper with [Injectable](https://pub.dev/packages/injectable)
 
 ### Create a module for your ChopperClient
 
-Define a module for your ChopperClient. You can use the `@lazySingleton` (or other type if preferred) annotation to make
-sure that only one is created.
+Define a module for your ChopperClient. You can use the `@lazySingleton` (or other type if preferred) annotation to make sure that only one is created.
 
 ```dart
 @module
@@ -476,9 +435,7 @@ abstract class ChopperModule {
 
 ### Create ChopperService with Injectable
 
-Define your ChopperService as usual. Annotate the class with `@lazySingleton` (or other type if preferred) and use
-the `@factoryMethod` annotation to specify the factory method for the service. This would normally be the static create
-method.
+Define your ChopperService as usual. Annotate the class with `@lazySingleton` (or other type if preferred) and use the `@factoryMethod` annotation to specify the factory method for the service. This would normally be the static create method.
 
 ```dart
 @lazySingleton

--- a/faq.md
+++ b/faq.md
@@ -2,17 +2,20 @@
 
 ## \*.chopper.dart not found ?
 
-If you have this error, you probably forgot to run the `build` package. To do that, simply run the following command in your shell.
+If you have this error, you probably forgot to run the `build` package. To do that, simply run the following command in
+your shell.
 
 `pub run build_runner build`
 
-It will generate the code that actually do the HTTP request \(YOUR_FILE.chopper.dart\). If you wish to update the code automatically when you change your definition run the `watch` command.
+It will generate the code that actually do the HTTP request \(YOUR_FILE.chopper.dart\). If you wish to update the code
+automatically when you change your definition run the `watch` command.
 
 `pub run build_runner watch`
 
 ## How to increase timeout ?
 
-Connection timeout is very limited for now due to http package \(see: [dart-lang/http\#21](https://github.com/dart-lang/http/issues/21)\)
+Connection timeout is very limited for now due to http package
+\(see: [dart-lang/http\#21](https://github.com/dart-lang/http/issues/21)\)
 
 But if you are on VM or Flutter you can set the `connectionTimeout` you want
 
@@ -21,10 +24,11 @@ import 'package:http/io_client.dart' as http;
 import 'dart:io';
 
 final chopper = ChopperClient(
-    client: http.IOClient(
-      HttpClient()..connectionTimeout = const Duration(seconds: 60),
-    ),
-  );
+  client: http.IOClient(
+    HttpClient()
+      ..connectionTimeout = const Duration(seconds: 60),
+  ),
+);
 ```
 
 ## Add query parameter to all requests
@@ -32,8 +36,9 @@ final chopper = ChopperClient(
 Possible using an interceptor.
 
 ```dart
+
 final chopper = ChopperClient(
-    interceptors: [_addQuery],
+  interceptors: [_addQuery],
 );
 
 Request _addQuery(Request req) {
@@ -54,8 +59,7 @@ Request compressRequest(Request request) {
   request = applyHeader(request, 'Content-Encoding', 'gzip');
   request = request.replace(body: gzip.encode(request.body));
   return request;
-}
-...
+}...
 
 @FactoryConverter(request: compressRequest)
 @Post()
@@ -64,15 +68,20 @@ Future<Response> postRequest(@Body() Map<String, String> data);
 
 ## Runtime baseUrl change
 
-You may need to change the base URL of your network calls during runtime, for example, if you have to use different servers or routes dynamically in your app in case of a "regular" or a "paid" user. You can store the current server base url in your SharedPreferences (encrypt/decrypt it if needed) and use it in an interceptor like this:
+You may need to change the base URL of your network calls during runtime, for example, if you have to use different
+servers or routes dynamically in your app in case of a "regular" or a "paid" user. You can store the current server base
+url in your SharedPreferences (encrypt/decrypt it if needed) and use it in an interceptor like this:
 
 ```dart
-...
-(Request request) async =>
-              SharedPreferences.containsKey('baseUrl')
-                  ? request.copyWith(
-                      baseUri: Uri.parse(SharedPreferences.getString('baseUrl'))
-                  ): request
+...(Request request) async =>
+SharedPreferences.containsKey('baseUrl')
+? request.copyWith(
+baseUri: Uri.parse(SharedPreferences.getString('baseUrl'
+)
+)
+)
+:
+request
 ...
 ```
 
@@ -80,7 +89,9 @@ You may need to change the base URL of your network calls during runtime, for ex
 
 Chopper is built on top of `http` package.
 
-So, one can just use the mocking API of the HTTP package. See the documentation for the [http.testing library](https://pub.dev/documentation/http/latest/http.testing/http.testing-library.html) and for the [MockClient class](https://pub.dev/documentation/http/latest/http.testing/MockClient-class.html).
+So, one can just use the mocking API of the HTTP package. See the documentation for
+the [http.testing library](https://pub.dev/documentation/http/latest/http.testing/http.testing-library.html) and for
+the [MockClient class](https://pub.dev/documentation/http/latest/http.testing/MockClient-class.html).
 
 Also, you can follow this code by [ozburo](https://github.com/ozburo):
 
@@ -132,12 +143,19 @@ import 'dart:io';
 import 'package:http/io_client.dart' as http;
 
 final ioc = new HttpClient();
-ioc.findProxy = (url) => 'PROXY 192.168.0.102:9090';
+ioc.findProxy = (
+url) => 'PROXY 192.168.0.102:9090';
 ioc.badCertificateCallback = (X509Certificate cert, String host, int port)
-  => true;
+=> true;
 
 final chopper = ChopperClient(
-  client: http.IOClient(ioc),
+client: http
+.
+IOClient
+(
+ioc
+)
+,
 );
 ```
 
@@ -145,7 +163,8 @@ final chopper = ChopperClient(
 
 Basically, the algorithm goes like this (credits to [stewemetal](https://github.com/stewemetal)):
 
-Add the authentication token to the request (by "Authorization" header, for example) -> try the request -> if it fails use the refresh token to get a new auth token ->
+Add the authentication token to the request (by "Authorization" header, for example) -> try the request -> if it fails
+use the refresh token to get a new auth token ->
 if that succeeds, save the auth token and retry the original request with it
 if the refresh token is not valid anymore, drop the session (and navigate to the login screen, for example)
 
@@ -153,25 +172,28 @@ Simple code example:
 
 ```dart
 interceptors: [
-  // Auth Interceptor
-  (Request request) async => applyHeader(request, 'authorization',
-      SharedPrefs.localStorage.getString(tokenHeader),
-      override: false),
-  (Response response) async {
-    if (response?.statusCode == 401) {
-      SharedPrefs.localStorage.remove(tokenHeader);
-      // Navigate to some login page or just request new token
-    }
-    return response;
-  },
+// Auth Interceptor
+(
+Request request) async => applyHeader(request, 'authorization',
+SharedPrefs.localStorage.getString(tokenHeader),
+override: false),
+(Response response) async {
+if (response?.statusCode == 401) {
+SharedPrefs.localStorage.remove(tokenHeader);
+// Navigate to some login page or just request new token
+}
+return response;
+},
 ]
 ```
 
-The actual implementation of the algorithm above may vary based on how the backend API - more precisely the login and session handling - of your app looks like.
+The actual implementation of the algorithm above may vary based on how the backend API - more precisely the login and
+session handling - of your app looks like.
 
 ### Authorized HTTP requests using the special Authenticator interceptor
 
-Similar to OkHTTP's [authenticator](https://github.com/square/okhttp/blob/480c20e46bb1745e280e42607bbcc73b2c953d97/okhttp/src/main/kotlin/okhttp3/Authenticator.kt),
+Similar to
+OkHTTP's [authenticator](https://github.com/square/okhttp/blob/480c20e46bb1745e280e42607bbcc73b2c953d97/okhttp/src/main/kotlin/okhttp3/Authenticator.kt),
 the idea here is to provide a reactive authentication in the event that an auth challenge is raised. It returns a
 nullable Request that contains a possible update to the original Request to satisfy the authentication challenge.
 
@@ -185,11 +207,10 @@ import 'package:chopper/chopper.dart';
 /// [response]. It returns `null` if the challenge cannot be satisfied.
 class MyAuthenticator extends Authenticator {
   @override
-  FutureOr<Request?> authenticate(
-    Request request,
-    Response response, [
-    Request? originalRequest,
-  ]) async {
+  FutureOr<Request?> authenticate(Request request,
+      Response response, [
+        Request? originalRequest,
+      ]) async {
     if (response.statusCode == HttpStatus.unauthorized) {
       final String? newToken = await refreshToken();
 
@@ -215,6 +236,7 @@ class MyAuthenticator extends Authenticator {
 
 /// When initializing your ChopperClient
 final client = ChopperClient(
+
   /// register your Authenticator here
   authenticator: MyAuthenticator(),
 );
@@ -259,7 +281,8 @@ Extracted from the [full example here](example/lib/json_decode_service.dart).
 
 #### Write a custom JsonConverter
 
-Using [json_serializable](https://pub.dev/packages/json_serializable) we'll create a [JsonConverter](https://github.com/lejard-h/chopper/blob/master/chopper/lib/src/interceptor.dart#L228)
+Using [json_serializable](https://pub.dev/packages/json_serializable) we'll create
+a [JsonConverter](https://github.com/lejard-h/chopper/blob/master/chopper/lib/src/interceptor.dart#L228)
 which works with or without a [WorkerPool](https://github.com/d-markey/squadron#features).
 
 ```dart
@@ -276,7 +299,7 @@ class JsonSerializableWorkerPoolConverter extends JsonConverter {
   const JsonSerializableWorkerPoolConverter(this.factories, [this.workerPool]);
 
   final Map<Type, JsonFactory> factories;
-  
+
   /// Make the WorkerPool optional so that the JsonConverter still works without it
   final JsonDecodeServiceWorkerPool? workerPool;
 
@@ -296,7 +319,7 @@ class JsonSerializableWorkerPoolConverter extends JsonConverter {
       return data;
     }
   }
-  
+
   T? _decodeMap<T>(Map<String, dynamic> values) {
     final jsonFactory = factories[T];
     if (jsonFactory == null || jsonFactory is! JsonFactory<T>) {
@@ -318,9 +341,7 @@ class JsonSerializableWorkerPoolConverter extends JsonConverter {
   }
 
   @override
-  FutureOr<Response<ResultType>> convertResponse<ResultType, Item>(
-    Response response,
-  ) async {
+  FutureOr<Response<ResultType>> convertResponse<ResultType, Item>(Response response,) async {
     final jsonRes = await super.convertResponse(response);
 
     return jsonRes.copyWith<ResultType>(body: _decode<Item>(jsonRes.body));
@@ -345,6 +366,22 @@ It goes without saying that running the code generation is a pre-requisite at th
 
 ```bash
 flutter pub run build_runner build
+```
+
+##### Changing the default extension of the generated files
+
+If you want to change the default extension of the generated files from `.chopper.dart` to
+something else, you can do so by adding the following to your `build.yaml` file:
+
+```yaml
+targets:
+  $default:
+    builders:
+      chopper_generator:
+        options:
+          # This assumes you want the files to end with `.chopper.g.dart`
+          # instead of the default `.chopper.dart`.
+          build_extensions: { ".dart": [ ".chopper.g.dart" ] }
 ```
 
 #### Configure a WorkerPool and run the example
@@ -375,6 +412,7 @@ Future<void> main() async {
     {
       Resource: Resource.fromJsonFactory,
     },
+
     /// make sure to provide the WorkerPool to the JsonConverter
     jsonDecodeServiceWorkerPool,
   );
@@ -396,7 +434,7 @@ Future<void> main() async {
 
   /// Do stuff with myService
   final myService = chopper.getService<MyService>();
-  
+
   /// ...stuff...
 
   /// stop the Worker Pool once done
@@ -409,16 +447,19 @@ Future<void> main() async {
 #### Further reading
 
 This barely scratches the surface. If you want to know more about [squadron](https://github.com/d-markey/squadron) and
-[squadron_builder](https://github.com/d-markey/squadron_builder) make sure to head over to their respective repositories.
+[squadron_builder](https://github.com/d-markey/squadron_builder) make sure to head over to their respective
+repositories.
 
-[David Markey](https://github.com/d-markey]), the author of squadron, was kind enough as to provide us with an [excellent Flutter example](https://github.com/d-markey/squadron_builder) using
+[David Markey](https://github.com/d-markey]), the author of squadron, was kind enough as to provide us with
+an [excellent Flutter example](https://github.com/d-markey/squadron_builder) using
 both packages.
 
 ## How to use Chopper with [Injectable](https://pub.dev/packages/injectable)
 
 ### Create a module for your ChopperClient
 
-Define a module for your ChopperClient. You can use the `@lazySingleton` (or other type if preferred) annotation to make sure that only one is created.
+Define a module for your ChopperClient. You can use the `@lazySingleton` (or other type if preferred) annotation to make
+sure that only one is created.
 
 ```dart
 @module
@@ -435,7 +476,9 @@ abstract class ChopperModule {
 
 ### Create ChopperService with Injectable
 
-Define your ChopperService as usual. Annotate the class with `@lazySingleton` (or other type if preferred) and use the `@factoryMethod` annotation to specify the factory method for the service. This would normally be the static create method.
+Define your ChopperService as usual. Annotate the class with `@lazySingleton` (or other type if preferred) and use
+the `@factoryMethod` annotation to specify the factory method for the service. This would normally be the static create
+method.
 
 ```dart
 @lazySingleton


### PR DESCRIPTION
Gives the user the ability to override the generated file extension from `.chopper.dart` to whatever they want, i.e. `.chopper.g.dart`.

To use this feature you have to create a `build.yaml` file in your project's root directory and add the following lines

```yaml
targets:
  $default:
    builders:
      chopper_generator:
        options:
          # This assumes you want the files to end with `.chopper.g.dart`
          # instead of the default `.chopper.dart`.
          build_extensions: {".dart": [".chopper.g.dart"]}
```

Note that using this feature means that you will **also** have to change the `part` declarations in your dart files, i.e.

from
```dart
part 'my_service.chopper.dart';
```
to
```dart
part 'my_service.chopper.g.dart';
```


---

Addresses #560 