### PR TITLE
Revert ":arrow_up: Bump codecov/codecov-action from 3 to 4 (#571)"

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -133,7 +133,7 @@ jobs:
         if: "always() && steps.chopper_pub_upgrade.conclusion == 'success'"
         working-directory: chopper
       - name: Upload coverage to codecov.io
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           files: chopper/coverage/lcov.info
           fail_ci_if_error: true
@@ -148,7 +148,7 @@ jobs:
         if: "always() && steps.chopper_built_value_pub_upgrade.conclusion == 'success'"
         working-directory: chopper_built_value
       - name: Upload coverage to codecov.io
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           files: chopper_built_value/coverage/lcov.info
           fail_ci_if_error: true
@@ -163,7 +163,7 @@ jobs:
         if: "always() && steps.chopper_generator_pub_upgrade.conclusion == 'success'"
         working-directory: chopper_generator
       - name: Upload coverage to codecov.io
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           files: chopper_generator/coverage/lcov.info
           fail_ci_if_error: true


### PR DESCRIPTION
This reverts commit 3af6e4e06c35aa8768432e9ec3516de8cb9de9ad.

---

Codecov v4 requires a token and since I do not have permission to add a secret to this Github repository I'm reverting this commit by dependabot.