### PR TITLE
Support @FormUrlEncoded

### DIFF
--- a/chopper/lib/src/annotations.dart
+++ b/chopper/lib/src/annotations.dart
@@ -536,13 +536,13 @@ final class PartFileMap {
 /// {@template FormUrlEncoded}
 ///
 ///
-//  Denotes that the request body will use form URL encoding. Fields should be declared as parameters
-//  and annotated with [Field]/[FieldMap].
-//
-//  Requests made with this annotation will have application/x-www-form-urlencoded MIME
-//  type. Field names and values will be UTF-8 encoded before being URI-encoded in accordance to <a
-//  href="https://datatracker.ietf.org/doc/html/rfc3986">RFC-3986</a>.
-//
+/// Denotes that the request body will use form URL encoding. Fields should be declared as parameters
+/// and annotated with [Field]/[FieldMap].
+///
+/// Requests made with this annotation will have application/x-www-form-urlencoded MIME
+/// type. Field names and values will be UTF-8 encoded before being URI-encoded in accordance to <a
+/// href="https://datatracker.ietf.org/doc/html/rfc3986">RFC-3986</a>.
+///
 ///
 /// ```dart
 /// @Post(path: '/something')

--- a/chopper/lib/src/annotations.dart
+++ b/chopper/lib/src/annotations.dart
@@ -433,7 +433,7 @@ final class Field {
 ///
 /// ```dart
 /// @Post(path: '/something')
-/// Future<Response> fetch(@FieldMap List<Map<String, dynamic>> query);
+/// Future<Response> fetch(@FieldMap Map<String, dynamic> query);
 /// ```
 /// {@endtemplate}
 @immutable
@@ -533,6 +533,30 @@ final class PartFileMap {
   const PartFileMap();
 }
 
+/// {@template FormUrlEncoded}
+///
+///
+//  Denotes that the request body will use form URL encoding. Fields should be declared as parameters
+//  and annotated with [Field]/[FieldMap].
+//
+//  Requests made with this annotation will have application/x-www-form-urlencoded MIME
+//  type. Field names and values will be UTF-8 encoded before being URI-encoded in accordance to <a
+//  href="https://datatracker.ietf.org/doc/html/rfc3986">RFC-3986</a>.
+//
+///
+/// ```dart
+/// @Post(path: '/something')
+/// @FormUrlEncoded
+/// Future<Response> fetch(@Field("param") String? param);
+/// ```
+/// {@endtemplate}
+@immutable
+@Target({TargetKind.method})
+final class FormUrlEncoded {
+  /// {@macro FormUrlEncoded}
+  const FormUrlEncoded();
+}
+
 /// {@macro ChopperApi}
 const chopperApi = ChopperApi();
 
@@ -595,3 +619,6 @@ const partFile = PartFile();
 
 /// {@macro PartFileMap}
 const partFileMap = PartFileMap();
+
+/// {@macro FormUrlEncoded}
+const formUrlEncoded = FormUrlEncoded();

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -313,7 +313,7 @@ final class ChopperGenerator
         } else {
           blocks.add(
             declareFinal(Vars.body.toString())
-                .assign(_generateMap(fields, isStringValue: formUrlEncoded))
+                .assign(_generateMap(fields, enableToString: formUrlEncoded))
                 .statement,
           );
         }
@@ -723,19 +723,19 @@ final class ChopperGenerator
 
   static Expression _generateMap(
     Map<ParameterElement, ConstantReader> queries, {
-    bool isStringValue = false,
+    bool enableToString = false,
   }) =>
       literalMap(
         {
           for (final MapEntry<ParameterElement, ConstantReader> query
               in queries.entries)
             query.value.peek('name')?.stringValue ?? query.key.displayName:
-                isStringValue
+                enableToString
                     ? refer(query.key.displayName).property('toString').call([])
                     : refer(query.key.displayName),
         },
         refer('String'),
-        refer(isStringValue ? 'String' : 'dynamic'),
+        refer(enableToString ? 'String' : 'dynamic'),
       );
 
   static Expression _generateList(

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -302,7 +302,7 @@ final class ChopperGenerator
           final DartType bodyType = m.parameters
               .firstWhere((p) => _typeChecker(chopper.Body).hasAnnotationOf(p))
               .type;
-          final map = (formUrlEncoded &&
+          final Expression map = (formUrlEncoded &&
                   _isMap(bodyType) &&
                   !_isMapStringString(bodyType))
               ? _generateMapToStringExpression(refer(body.keys.first))
@@ -325,9 +325,10 @@ final class ChopperGenerator
             .firstWhere(
                 (p) => _typeChecker(chopper.FieldMap).hasAnnotationOf(p))
             .type;
-        final map = (formUrlEncoded && !_isMapStringString(fieldMapType))
-            ? _generateMapToStringExpression(refer(fieldMap.keys.first))
-            : refer(fieldMap.keys.first);
+        final Expression map =
+            (formUrlEncoded && !_isMapStringString(fieldMapType))
+                ? _generateMapToStringExpression(refer(fieldMap.keys.first))
+                : refer(fieldMap.keys.first);
         if (hasBody) {
           blocks.add(
             refer(Vars.body.toString()).property('addAll').call(
@@ -621,7 +622,7 @@ final class ChopperGenerator
         _typeChecker(Map).isExactlyType(type) ||
         _typeChecker(BuiltMap).isExactlyType(type)) return type;
 
-// ignore: deprecated_member_use
+    // ignore: deprecated_member_use
     if (generic.isDynamic) return null;
 
     if (_typeChecker(List).isExactlyType(type) ||

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -302,13 +302,13 @@ final class ChopperGenerator
           final DartType bodyType = m.parameters
               .firstWhere((p) => _typeChecker(chopper.Body).hasAnnotationOf(p))
               .type;
-          final mapExpression = (formUrlEncoded &&
+          final map = (formUrlEncoded &&
                   _isMap(bodyType) &&
                   !_isMapStringString(bodyType))
               ? _generateMapToStringExpression(refer(body.keys.first))
               : refer(body.keys.first);
           blocks.add(
-            declareFinal(Vars.body.toString()).assign(mapExpression).statement,
+            declareFinal(Vars.body.toString()).assign(map).statement,
           );
         } else {
           blocks.add(

--- a/chopper_generator/test/test_service.chopper.dart
+++ b/chopper_generator/test/test_service.chopper.dart
@@ -394,6 +394,101 @@ final class _$HttpTestService extends HttpTestService {
   }
 
   @override
+  Future<Response<dynamic>> postFormUrlEncodeBody(
+    HashMap<dynamic, dynamic> hashMapBody,
+    Map<String, String> map,
+  ) {
+    final Uri $url = Uri.parse('/test/formUrlEncoded');
+    final Map<String, String> $headers = {
+      'content-type': 'application/x-www-form-urlencoded',
+    };
+    final $body = hashMapBody.map<String, String>((
+      key,
+      value,
+    ) {
+      return MapEntry(
+        key.toString(),
+        value.toString(),
+      );
+    });
+    $body.addAll(map);
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      body: $body,
+      headers: $headers,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postFormUrlEncodeField(
+    String a,
+    String a2,
+  ) {
+    final Uri $url = Uri.parse('/test/formUrlEncoded');
+    final Map<String, String> $headers = {
+      'content-type': 'application/x-www-form-urlencoded',
+    };
+    final $body = <String, String>{
+      'a': a.toString(),
+      'a1': a2.toString(),
+    };
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      body: $body,
+      headers: $headers,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postFormUrlEncodeFieldMap(Map<String, String> c) {
+    final Uri $url = Uri.parse('/test/formUrlEncoded');
+    final Map<String, String> $headers = {
+      'content-type': 'application/x-www-form-urlencoded',
+    };
+    final $body = c;
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      body: $body,
+      headers: $headers,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> postFormUrlEncodeFieldDynamicMap(
+      Map<String, dynamic> c) {
+    final Uri $url = Uri.parse('/test/formUrlEncoded');
+    final Map<String, String> $headers = {
+      'content-type': 'application/x-www-form-urlencoded',
+    };
+    final $body = c.map<String, String>((
+      key,
+      value,
+    ) {
+      return MapEntry(
+        key.toString(),
+        value.toString(),
+      );
+    });
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      body: $body,
+      headers: $headers,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
   Future<Response<dynamic>> postFile(List<int> bytes) {
     final Uri $url = Uri.parse('/test/file');
     final List<PartValue> $parts = <PartValue>[

--- a/chopper_generator/test/test_service.dart
+++ b/chopper_generator/test/test_service.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 import 'dart:convert';
 
 import 'package:chopper/chopper.dart';
@@ -111,6 +112,32 @@ abstract class HttpTestService extends ChopperService {
   Future<Response> postResources(
     @Part('1') Map a,
     @Part('2') Map b,
+  );
+
+  @Post(path: 'formUrlEncoded')
+  @FormUrlEncoded()
+  Future<Response> postFormUrlEncodeBody(
+    @Body() HashMap hashMapBody,
+    @FieldMap() Map<String, String> map,
+  );
+
+  @Post(path: 'formUrlEncoded')
+  @FormUrlEncoded()
+  Future<Response> postFormUrlEncodeField(
+    @Field('a') String a,
+    @Field('a1') String a2,
+  );
+
+  @Post(path: 'formUrlEncoded')
+  @FormUrlEncoded()
+  Future<Response> postFormUrlEncodeFieldMap(
+    @FieldMap() Map<String, String> c,
+  );
+
+  @Post(path: 'formUrlEncoded')
+  @FormUrlEncoded()
+  Future<Response> postFormUrlEncodeFieldDynamicMap(
+    @FieldMap() Map<String, dynamic> c,
   );
 
   @Post(path: 'file')

--- a/requests.md
+++ b/requests.md
@@ -2,25 +2,26 @@
 
 ## Available Request annotations
 
-| Annotation                                 | HTTP verb | Description                                   |
-|--------------------------------------------|-----------|-----------------------------------------------|
-| `@Get()`, `@get`                           | `GET`     | Defines a `GET` request.                      |
-| `@Post()`, `@post`                         | `POST`    | Defines a `POST` request.                     |
-| `@Put()`, `@put`                           | `PUT`     | Defines a `PUT` request.                      |
-| `@Patch()`, `@patch`                       | `PATCH`   | Defines a `PATCH` request.                    |
-| `@Delete()`, `@delete`                     | `DELETE`  | Defines a `DELETE` request.                   |
-| `@Head()`, `@head`                         | `HEAD`    | Defines a `HEAD` request.                     |
-| `@Body()`, `@body`                         | -         | Defines the request's body.                   |
-| `@Multipart()`, `@multipart`               | -         | Defines a `multipart/form-data` request.      |         
-| `@Query()`, `@query`                       | -         | Defines a query parameter.                    |             
-| `@QueryMap()`, `@queryMap`                 | -         | Defines a query parameter map.                |          
-| `@FactoryConverter()`, `@factoryConverter` | -         | Defines a request/response converter factory. |  
-| `@Field()`, `@field`                       | -         | Defines a form field.                         |             
-| `@FieldMap()`, `@fieldMap`                 | -         | Defines a form field map.                     |          
-| `@Part()`, `@part`                         | -         | Defines a multipart part.                     |              
-| `@PartMap()`, `@partMap`                   | -         | Defines a multipart part map.                 |           
-| `@PartFile()`, `@partFile`                 | -         | Defines a multipart file part.                |          
-| `@PartFileMap()`, `@partFileMap`           | -         | Defines a multipart file part map.            |
+| Annotation                                 | HTTP verb | Description                                            |
+|--------------------------------------------|-----------|--------------------------------------------------------|
+| `@Get()`, `@get`                           | `GET`     | Defines a `GET` request.                               |
+| `@Post()`, `@post`                         | `POST`    | Defines a `POST` request.                              |
+| `@Put()`, `@put`                           | `PUT`     | Defines a `PUT` request.                               |
+| `@Patch()`, `@patch`                       | `PATCH`   | Defines a `PATCH` request.                             |
+| `@Delete()`, `@delete`                     | `DELETE`  | Defines a `DELETE` request.                            |
+| `@Head()`, `@head`                         | `HEAD`    | Defines a `HEAD` request.                              |
+| `@Body()`, `@body`                         | -         | Defines the request's body.                            |
+| `@FormUrlEncoded`, `@formUrlEncoded`       | -         | Defines a `application/x-www-form-urlencoded` request. |
+| `@Multipart()`, `@multipart`               | -         | Defines a `multipart/form-data` request.               |         
+| `@Query()`, `@query`                       | -         | Defines a query parameter.                             |             
+| `@QueryMap()`, `@queryMap`                 | -         | Defines a query parameter map.                         |          
+| `@FactoryConverter()`, `@factoryConverter` | -         | Defines a request/response converter factory.          |  
+| `@Field()`, `@field`                       | -         | Defines a form field.                                  |             
+| `@FieldMap()`, `@fieldMap`                 | -         | Defines a form field map.                              |          
+| `@Part()`, `@part`                         | -         | Defines a multipart part.                              |              
+| `@PartMap()`, `@partMap`                   | -         | Defines a multipart part map.                          |           
+| `@PartFile()`, `@partFile`                 | -         | Defines a multipart file part.                         |          
+| `@PartFileMap()`, `@partFileMap`           | -         | Defines a multipart file part map.                     |
 
 ## Path resolution
 
@@ -170,12 +171,27 @@ Future<Response> fetch(@Header("foo") String bar);
 
 ## Sending `application/x-www-form-urlencoded` data
 
-If no Converter is specified for a request (neither on a `ChopperClient` nor with the `@FactoryConverter` annotation)
+If no Converter (neither on a `ChopperClient` nor with the `@FactoryConverter` annotation) or formUrlEncoded (`@FormUrlEncoded` annotation) is specified for a request
 and the request body is of type `Map<String, String>`, the body will be sent as form URL encoded data.
 
 > This is the default behavior of the http package.
 
-You can also use `FormUrlEncodedConverter` that will add the correct `content-type` and convert a `Map`
+### FormUrlEncoded annotation
+
+We recommend annotation `@formUrlEncoded` on method that will add the correct `content-type` and convert a `Map`
+into `Map<String, String>` for requests.
+
+```dart
+@Post(
+  path: "form",
+)
+@formUrlEncoded
+Future<Response> postForm(@Body() Map<String, String> fields);
+```
+
+### FormUrlEncodedConverter
+
+you can also use `FormUrlEncodedConverter` that also will add the correct `content-type` and convert a `Map`
 into `Map<String, String>` for requests.
 
 ```dart
@@ -185,7 +201,6 @@ final chopper = ChopperClient(
 );
 ```
 
-### On a single method
 
 To do only a single type of request with form encoding in a service, use the provided `FormUrlEncodedConverter`'
 s `requestFactory` method with the `@FactoryConverter` annotation.
@@ -208,9 +223,7 @@ the parameter's name is used as the field's name.
 
 ```dart
 @Post(path: "form")
-@FactoryConverter(
-  request: FormUrlEncodedConverter.requestFactory,
-)
+@formUrlEncoded
 Future<Response> post(@Field() String foo, @Field("b") int bar);
 ```
 


### PR DESCRIPTION
fix https://github.com/lejard-h/chopper/issues/577

* Support @FormUrlEncoded，
* auto add content-type application/x-www-form-urlencoded 
* set ket.toString and value.toString() for @Body / @Field / @FieldMap data,  if data is `Map` and  `Map` is not `Map<String, String>`