### PR TITLE
:sparkles: add per-request timeout

### DIFF
--- a/chopper/lib/src/annotations.dart
+++ b/chopper/lib/src/annotations.dart
@@ -235,6 +235,9 @@ sealed class Method {
   /// The above code produces hxxp://path/to/script&foo=foo_var&bar=&baz=baz_var
   final bool? includeNullQueryVars;
 
+  /// Set a timeout for the request
+  final Duration? timeout;
+
   /// {@macro Method}
   const Method(
     this.method, {
@@ -244,6 +247,7 @@ sealed class Method {
     this.listFormat,
     @Deprecated('Use listFormat instead') this.useBrackets,
     this.includeNullQueryVars,
+    this.timeout,
   });
 }
 
@@ -261,6 +265,7 @@ final class Get extends Method {
     super.listFormat,
     super.useBrackets,
     super.includeNullQueryVars,
+    super.timeout,
   }) : super(HttpMethod.Get);
 }
 
@@ -280,6 +285,7 @@ final class Post extends Method {
     super.listFormat,
     super.useBrackets,
     super.includeNullQueryVars,
+    super.timeout,
   }) : super(HttpMethod.Post);
 }
 
@@ -297,6 +303,7 @@ final class Delete extends Method {
     super.listFormat,
     super.useBrackets,
     super.includeNullQueryVars,
+    super.timeout,
   }) : super(HttpMethod.Delete);
 }
 
@@ -316,6 +323,7 @@ final class Put extends Method {
     super.listFormat,
     super.useBrackets,
     super.includeNullQueryVars,
+    super.timeout,
   }) : super(HttpMethod.Put);
 }
 
@@ -334,6 +342,7 @@ final class Patch extends Method {
     super.listFormat,
     super.useBrackets,
     super.includeNullQueryVars,
+    super.timeout,
   }) : super(HttpMethod.Patch);
 }
 
@@ -351,6 +360,7 @@ final class Head extends Method {
     super.listFormat,
     super.useBrackets,
     super.includeNullQueryVars,
+    super.timeout,
   }) : super(HttpMethod.Head);
 }
 
@@ -368,6 +378,7 @@ final class Options extends Method {
     super.listFormat,
     super.useBrackets,
     super.includeNullQueryVars,
+    super.timeout,
   }) : super(HttpMethod.Options);
 }
 

--- a/chopper/test/test_service.chopper.dart
+++ b/chopper/test/test_service.chopper.dart
@@ -820,4 +820,43 @@ final class _$HttpTestService extends HttpTestService {
       requestConverter: FormUrlEncodedConverter.requestFactory,
     );
   }
+
+  @override
+  Future<Response<String>> getTimeoutTest() {
+    final Uri $url = Uri.parse('/test/get_timeout');
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+    );
+    return client
+        .send<String, String>($request)
+        .timeout(const Duration(microseconds: 42000000));
+  }
+
+  @override
+  Future<Response<String>> getTimeoutTestZero() {
+    final Uri $url = Uri.parse('/test/get_timeout_zero');
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+    );
+    return client
+        .send<String, String>($request)
+        .timeout(const Duration(microseconds: 0));
+  }
+
+  @override
+  Future<Response<String>> getTimeoutTestNeg() {
+    final Uri $url = Uri.parse('/test/get_timeout_neg');
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+    );
+    return client
+        .send<String, String>($request)
+        .timeout(const Duration(microseconds: 0));
+  }
 }

--- a/chopper/test/test_service.dart
+++ b/chopper/test/test_service.dart
@@ -253,6 +253,15 @@ abstract class HttpTestService extends ChopperService {
     @Field() final List<int> positives, [
     @Field() final String? signature,
   ]);
+
+  @Get(path: 'get_timeout', timeout: Duration(seconds: 42))
+  Future<Response<String>> getTimeoutTest();
+
+  @Get(path: 'get_timeout_zero', timeout: Duration(seconds: 0))
+  Future<Response<String>> getTimeoutTestZero();
+
+  @Get(path: 'get_timeout_neg', timeout: Duration(seconds: -1))
+  Future<Response<String>> getTimeoutTestNeg();
 }
 
 Request customConvertRequest(Request req) {

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -410,6 +410,8 @@ final class ChopperGenerator
 
       final bool? includeNullQueryVars = Utils.getIncludeNullQueryVars(method);
 
+      final Duration? timeout = Utils.getTimeout(method);
+
       blocks.add(
         declareFinal(Vars.request.toString(), type: refer('Request'))
             .assign(
@@ -454,12 +456,19 @@ final class ChopperGenerator
         ]);
       }
 
-      final returnStatement =
+      Expression returnStatement =
           refer(Vars.client.toString()).property('send').call(
         [refer(Vars.request.toString())],
         namedArguments,
         typeArguments,
       );
+      if (timeout != null) {
+        returnStatement = returnStatement.property('timeout').call([
+          refer('Duration').constInstance([], {
+            'microseconds': literalNum(timeout.inMicroseconds),
+          }),
+        ]);
+      }
 
       if (isResponseObject) {
         // Return the response object directly from chopper.send

--- a/chopper_generator/lib/src/utils.dart
+++ b/chopper_generator/lib/src/utils.dart
@@ -1,3 +1,5 @@
+import 'dart:math' show max;
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:chopper_generator/src/extensions.dart';
 import 'package:code_builder/code_builder.dart';
@@ -32,6 +34,19 @@ final class Utils {
 
   static bool? getIncludeNullQueryVars(ConstantReader method) =>
       method.peek('includeNullQueryVars')?.boolValue;
+
+  static Duration? getTimeout(ConstantReader method) {
+    final ConstantReader? timeout = method.peek('timeout');
+    if (timeout != null) {
+      final int? microseconds =
+          timeout.objectValue.getField('_duration')?.toIntValue();
+      if (microseconds != null) {
+        return Duration(microseconds: max(microseconds, 0));
+      }
+    }
+
+    return null;
+  }
 
   /// All positional required params must support nullability
   static Parameter buildRequiredPositionalParam(ParameterElement p) =>

--- a/chopper_generator/test/test_service.chopper.dart
+++ b/chopper_generator/test/test_service.chopper.dart
@@ -919,4 +919,43 @@ final class _$HttpTestService extends HttpTestService {
     );
     return client.send<void, void>($request);
   }
+
+  @override
+  Future<Response<String>> getTimeoutTest() {
+    final Uri $url = Uri.parse('/test/get_timeout');
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+    );
+    return client
+        .send<String, String>($request)
+        .timeout(const Duration(microseconds: 42000000));
+  }
+
+  @override
+  Future<Response<String>> getTimeoutTestZero() {
+    final Uri $url = Uri.parse('/test/get_timeout_zero');
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+    );
+    return client
+        .send<String, String>($request)
+        .timeout(const Duration(microseconds: 0));
+  }
+
+  @override
+  Future<Response<String>> getTimeoutTestNeg() {
+    final Uri $url = Uri.parse('/test/get_timeout_neg');
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+    );
+    return client
+        .send<String, String>($request)
+        .timeout(const Duration(microseconds: 0));
+  }
 }

--- a/chopper_generator/test/test_service.dart
+++ b/chopper_generator/test/test_service.dart
@@ -279,6 +279,15 @@ abstract class HttpTestService extends ChopperService {
     @Field('fool') final String foo,
     @Tag() Object? t1,
   );
+
+  @Get(path: 'get_timeout', timeout: Duration(seconds: 42))
+  Future<Response<String>> getTimeoutTest();
+
+  @Get(path: 'get_timeout_zero', timeout: Duration(seconds: 0))
+  Future<Response<String>> getTimeoutTestZero();
+
+  @Get(path: 'get_timeout_neg', timeout: Duration(seconds: -1))
+  Future<Response<String>> getTimeoutTestNeg();
 }
 
 Request customConvertRequest(Request req) {


### PR DESCRIPTION
This PR adds a new `timeout` annotation
```dart
/// Set a timeout for the request
final Duration? timeout;
```
that can be used like
```dart
@Get(path: 'get_timeout', timeout: Duration(seconds: 42))
Future<Response<String>> getTimeoutTest();
```
and generates the following code
```dart
@override
Future<Response<String>> getTimeoutTest() {
  final Uri $url = Uri.parse('/test/get_timeout');
  final Request $request = Request(
    'GET',
    $url,
    client.baseUrl,
  );
  return client
      .send<String, String>($request)
      .timeout(const Duration(microseconds: 42000000));
}
```

---
Addresses #603
Addresses https://github.com/dart-lang/http/issues/1186