### PR TITLE
:sparkles: add `onlyErrors` option to `HttpLoggingInterceptor`

### DIFF
--- a/chopper/lib/src/interceptors/http_logging_interceptor.dart
+++ b/chopper/lib/src/interceptors/http_logging_interceptor.dart
@@ -160,7 +160,7 @@ class HttpLoggingInterceptor implements Interceptor {
       );
     }
 
-    if (level == Level.none) {
+    if (level == Level.none || (onlyErrors && response.statusCode < 400)) {
       return response;
     }
 

--- a/chopper/lib/src/interceptors/http_logging_interceptor.dart
+++ b/chopper/lib/src/interceptors/http_logging_interceptor.dart
@@ -160,10 +160,6 @@ class HttpLoggingInterceptor implements Interceptor {
       );
     }
 
-    if (level == Level.none || (onlyErrors && response.statusCode < 400)) {
-      return response;
-    }
-
     final http.BaseResponse baseResponse = response.base;
 
     final StringBuffer bytes = StringBuffer();

--- a/chopper/test/http_logging_interceptor_test.dart
+++ b/chopper/test/http_logging_interceptor_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 import 'helpers/fake_chain.dart';
 
 void main() {
-  final fakeRequest = Request(
+  final Request fakeRequest = Request(
     'POST',
     Uri.parse('/'),
     Uri.parse('base'),
@@ -16,289 +16,671 @@ void main() {
     headers: {'foo': 'bar'},
   );
 
-  group('http logging requests', () {
-    test('Http logger interceptor none level request', () async {
-      final logger = HttpLoggingInterceptor(level: Level.none);
+  group('standard', () {
+    group('http logging requests', () {
+      test('Http logger interceptor none level request', () async {
+        final logger = HttpLoggingInterceptor(level: Level.none);
 
-      final logs = [];
-      chopperLogger.onRecord.listen((r) => logs.add(r.message));
-      await logger.intercept(FakeChain(fakeRequest));
+        final logs = [];
+        chopperLogger.onRecord.listen((r) => logs.add(r.message));
+        await logger.intercept(FakeChain(fakeRequest));
 
-      expect(
-        logs,
-        equals(
-          [],
-        ),
-      );
+        expect(
+          logs,
+          equals(
+            [],
+          ),
+        );
+      });
+
+      test('Http logger interceptor basic level request', () async {
+        final logger = HttpLoggingInterceptor(level: Level.basic);
+
+        final logs = [];
+        chopperLogger.onRecord.listen((r) => logs.add(r.message));
+        await logger.intercept(FakeChain(fakeRequest));
+
+        expect(
+          logs,
+          containsAll(
+            [
+              '',
+              '--> POST base/ (4-byte body)',
+            ],
+          ),
+        );
+      });
+
+      test('Http logger interceptor basic level request', () async {
+        final logger = HttpLoggingInterceptor(level: Level.headers);
+
+        final logs = [];
+        chopperLogger.onRecord.listen((r) => logs.add(r.message));
+        await logger.intercept(FakeChain(fakeRequest));
+
+        expect(
+          logs,
+          containsAll(
+            [
+              '',
+              '--> POST base/',
+              'foo: bar',
+              'content-type: text/plain; charset=utf-8',
+              'content-length: 4',
+              '--> END POST',
+            ],
+          ),
+        );
+      });
+
+      test('Http logger interceptor body level request', () async {
+        final logger = HttpLoggingInterceptor(level: Level.body);
+
+        final logs = [];
+        chopperLogger.onRecord.listen((r) => logs.add(r.message));
+        await logger.intercept(FakeChain(fakeRequest));
+
+        expect(
+          logs,
+          containsAll(
+            [
+              '',
+              '--> POST base/',
+              'foo: bar',
+              'content-type: text/plain; charset=utf-8',
+              'content-length: 4',
+              '',
+              'test',
+              '--> END POST',
+            ],
+          ),
+        );
+      });
     });
 
-    test('Http logger interceptor basic level request', () async {
-      final logger = HttpLoggingInterceptor(level: Level.basic);
+    group('http logging interceptor response logging', () {
+      late Response fakeResponse;
 
-      final logs = [];
-      chopperLogger.onRecord.listen((r) => logs.add(r.message));
-      await logger.intercept(FakeChain(fakeRequest));
+      setUp(() async {
+        fakeResponse = Response<String>(
+          http.Response(
+            'responseBodyBase',
+            200,
+            headers: {'foo': 'bar'},
+            request: await fakeRequest.toBaseRequest(),
+          ),
+          'responseBody',
+        );
+      });
 
-      expect(
-        logs,
-        containsAll(
-          [
-            '',
-            '--> POST base/ (4-byte body)',
-          ],
-        ),
-      );
+      test('Http logger interceptor none level response', () async {
+        final logger = HttpLoggingInterceptor(level: Level.none);
+
+        final logs = [];
+        chopperLogger.onRecord.listen((r) => logs.add(r.message));
+        await logger.intercept(FakeChain(fakeRequest));
+
+        expect(
+          logs,
+          equals(
+            [],
+          ),
+        );
+      });
+
+      test('Http logger interceptor basic level response', () async {
+        final logger = HttpLoggingInterceptor(level: Level.basic);
+
+        final logs = [];
+        chopperLogger.onRecord.listen((r) => logs.add(r.message));
+        await logger.intercept(FakeChain(fakeRequest, response: fakeResponse));
+
+        expect(
+          logs,
+          containsAll(
+            [
+              '',
+              '<-- 200 POST base/ (0ms, 16-byte body)',
+            ],
+          ),
+        );
+      });
+
+      test('Http logger interceptor headers level response', () async {
+        final logger = HttpLoggingInterceptor(level: Level.headers);
+
+        final logs = [];
+        chopperLogger.onRecord.listen((r) => logs.add(r.message));
+        await logger.intercept(FakeChain(fakeRequest, response: fakeResponse));
+
+        expect(
+          logs,
+          containsAll(
+            [
+              '',
+              '<-- 200 POST base/ (0ms)',
+              'foo: bar',
+              'content-length: 16',
+              '<-- END HTTP',
+            ],
+          ),
+        );
+      });
+
+      test('Http logger interceptor body level response', () async {
+        final logger = HttpLoggingInterceptor(level: Level.body);
+
+        final logs = [];
+        chopperLogger.onRecord.listen((r) => logs.add(r.message));
+        await logger.intercept(FakeChain(fakeRequest, response: fakeResponse));
+
+        expect(
+          logs,
+          containsAll(
+            [
+              '',
+              '<-- 200 POST base/ (0ms)',
+              'foo: bar',
+              'content-length: 16',
+              '',
+              'responseBodyBase',
+              '<-- END HTTP',
+            ],
+          ),
+        );
+      });
     });
 
-    test('Http logger interceptor basic level request', () async {
-      final logger = HttpLoggingInterceptor(level: Level.headers);
+    group('headers content-length not overridden', () {
+      late Response fakeResponse;
 
-      final logs = [];
-      chopperLogger.onRecord.listen((r) => logs.add(r.message));
-      await logger.intercept(FakeChain(fakeRequest));
+      setUp(() async {
+        fakeResponse = Response<String>(
+          http.Response(
+            'responseBodyBase',
+            200,
+            headers: {
+              'foo': 'bar',
+              'content-length': '42',
+            },
+            request: await fakeRequest.toBaseRequest(),
+          ),
+          'responseBody',
+        );
+      });
 
-      expect(
-        logs,
-        containsAll(
-          [
-            '',
-            '--> POST base/',
-            'foo: bar',
-            'content-type: text/plain; charset=utf-8',
-            'content-length: 4',
-            '--> END POST',
-          ],
-        ),
-      );
-    });
+      test('request header level content-length', () async {
+        final logger = HttpLoggingInterceptor(level: Level.headers);
 
-    test('Http logger interceptor body level request', () async {
-      final logger = HttpLoggingInterceptor(level: Level.body);
+        final logs = [];
+        chopperLogger.onRecord.listen((r) => logs.add(r.message));
 
-      final logs = [];
-      chopperLogger.onRecord.listen((r) => logs.add(r.message));
-      await logger.intercept(FakeChain(fakeRequest));
+        await logger.intercept(FakeChain(fakeRequest.copyWith(
+            headers: {...fakeRequest.headers, 'content-length': '42'})));
 
-      expect(
-        logs,
-        containsAll(
-          [
-            '',
-            '--> POST base/',
-            'foo: bar',
-            'content-type: text/plain; charset=utf-8',
-            'content-length: 4',
-            '',
-            'test',
-            '--> END POST',
-          ],
-        ),
-      );
+        expect(
+          logs,
+          containsAll(
+            [
+              '',
+              '--> POST base/',
+              'foo: bar',
+              'content-length: 42',
+              'content-type: text/plain; charset=utf-8',
+              '--> END POST',
+            ],
+          ),
+        );
+      });
+
+      test('request body level content-length', () async {
+        final logger = HttpLoggingInterceptor(level: Level.body);
+
+        final logs = [];
+        chopperLogger.onRecord.listen((r) => logs.add(r.message));
+
+        await logger.intercept(FakeChain(fakeRequest.copyWith(
+            headers: {...fakeRequest.headers, 'content-length': '42'})));
+
+        expect(
+          logs,
+          containsAll(
+            [
+              '',
+              '--> POST base/',
+              'foo: bar',
+              'content-length: 42',
+              'content-type: text/plain; charset=utf-8',
+              '',
+              'test',
+              '--> END POST',
+            ],
+          ),
+        );
+      });
+
+      test('response header level content-length', () async {
+        final logger = HttpLoggingInterceptor(level: Level.headers);
+
+        final logs = [];
+        chopperLogger.onRecord.listen((r) => logs.add(r.message));
+        await logger.intercept(FakeChain(fakeRequest, response: fakeResponse));
+
+        expect(
+          logs,
+          containsAll(
+            [
+              '',
+              '<-- 200 POST base/ (0ms)',
+              'foo: bar',
+              'content-length: 42',
+              '<-- END HTTP',
+            ],
+          ),
+        );
+      });
+      test('response body level content-length', () async {
+        final logger = HttpLoggingInterceptor(level: Level.body);
+
+        final logs = [];
+        chopperLogger.onRecord.listen((r) => logs.add(r.message));
+        await logger.intercept(FakeChain(fakeRequest, response: fakeResponse));
+
+        expect(
+          logs,
+          containsAll(
+            [
+              '',
+              '<-- 200 POST base/ (0ms)',
+              'foo: bar',
+              'content-length: 42',
+              '',
+              'responseBodyBase',
+              '<-- END HTTP',
+            ],
+          ),
+        );
+      });
     });
   });
 
-  group('http logging interceptor response logging', () {
-    late Response fakeResponse;
+  group('only errors', () {
+    group('http logging requests', () {
+      test('Http logger interceptor none level request', () async {
+        final logger =
+            HttpLoggingInterceptor(level: Level.none, onlyErrors: true);
 
-    setUp(() async {
-      fakeResponse = Response<String>(
-        http.Response(
-          'responseBodyBase',
-          200,
-          headers: {'foo': 'bar'},
-          request: await fakeRequest.toBaseRequest(),
-        ),
-        'responseBody',
-      );
+        final logs = [];
+        chopperLogger.onRecord.listen((r) => logs.add(r.message));
+        await logger.intercept(FakeChain(fakeRequest));
+
+        expect(logs, equals([]));
+      });
+
+      test('Http logger interceptor basic level request', () async {
+        final logger =
+            HttpLoggingInterceptor(level: Level.basic, onlyErrors: true);
+
+        final logs = [];
+        chopperLogger.onRecord.listen((r) => logs.add(r.message));
+        await logger.intercept(FakeChain(fakeRequest));
+
+        expect(logs, equals([]));
+      });
+
+      test('Http logger interceptor basic level request', () async {
+        final logger =
+            HttpLoggingInterceptor(level: Level.headers, onlyErrors: true);
+
+        final logs = [];
+        chopperLogger.onRecord.listen((r) => logs.add(r.message));
+        await logger.intercept(FakeChain(fakeRequest));
+
+        expect(logs, equals([]));
+      });
+
+      test('Http logger interceptor body level request', () async {
+        final logger =
+            HttpLoggingInterceptor(level: Level.body, onlyErrors: true);
+
+        final logs = [];
+        chopperLogger.onRecord.listen((r) => logs.add(r.message));
+        await logger.intercept(FakeChain(fakeRequest));
+
+        expect(logs, equals([]));
+      });
     });
 
-    test('Http logger interceptor none level response', () async {
-      final logger = HttpLoggingInterceptor(level: Level.none);
+    group('HTTP 200', () {
+      group('http logging interceptor response logging', () {
+        late Response fakeResponse;
 
-      final logs = [];
-      chopperLogger.onRecord.listen((r) => logs.add(r.message));
-      await logger.intercept(FakeChain(fakeRequest));
+        setUp(() async {
+          fakeResponse = Response<String>(
+            http.Response(
+              'responseBodyBase',
+              200,
+              headers: {'foo': 'bar'},
+              request: await fakeRequest.toBaseRequest(),
+            ),
+            'responseBody',
+          );
+        });
 
-      expect(
-        logs,
-        equals(
-          [],
-        ),
-      );
+        test('Http logger interceptor none level response', () async {
+          final logger =
+              HttpLoggingInterceptor(level: Level.none, onlyErrors: true);
+
+          final logs = [];
+          chopperLogger.onRecord.listen((r) => logs.add(r.message));
+          await logger.intercept(FakeChain(fakeRequest));
+
+          expect(
+            logs,
+            equals(
+              [],
+            ),
+          );
+        });
+
+        test('Http logger interceptor basic level response', () async {
+          final logger =
+              HttpLoggingInterceptor(level: Level.basic, onlyErrors: true);
+
+          final logs = [];
+          chopperLogger.onRecord.listen((r) => logs.add(r.message));
+          await logger
+              .intercept(FakeChain(fakeRequest, response: fakeResponse));
+
+          expect(logs, equals([]));
+        });
+
+        test('Http logger interceptor headers level response', () async {
+          final logger =
+              HttpLoggingInterceptor(level: Level.headers, onlyErrors: true);
+
+          final logs = [];
+          chopperLogger.onRecord.listen((r) => logs.add(r.message));
+          await logger
+              .intercept(FakeChain(fakeRequest, response: fakeResponse));
+
+          expect(logs, equals([]));
+        });
+
+        test('Http logger interceptor body level response', () async {
+          final logger =
+              HttpLoggingInterceptor(level: Level.body, onlyErrors: true);
+
+          final logs = [];
+          chopperLogger.onRecord.listen((r) => logs.add(r.message));
+          await logger
+              .intercept(FakeChain(fakeRequest, response: fakeResponse));
+
+          expect(logs, equals([]));
+        });
+      });
+
+      group('headers content-length not overridden', () {
+        late Response fakeResponse;
+
+        setUp(() async {
+          fakeResponse = Response<String>(
+            http.Response(
+              'responseBodyBase',
+              200,
+              headers: {
+                'foo': 'bar',
+                'content-length': '42',
+              },
+              request: await fakeRequest.toBaseRequest(),
+            ),
+            'responseBody',
+          );
+        });
+
+        test('request header level content-length', () async {
+          final logger =
+              HttpLoggingInterceptor(level: Level.headers, onlyErrors: true);
+
+          final logs = [];
+          chopperLogger.onRecord.listen((r) => logs.add(r.message));
+
+          await logger.intercept(FakeChain(fakeRequest.copyWith(
+              headers: {...fakeRequest.headers, 'content-length': '42'})));
+
+          expect(logs, equals([]));
+        });
+
+        test('request body level content-length', () async {
+          final logger =
+              HttpLoggingInterceptor(level: Level.body, onlyErrors: true);
+
+          final logs = [];
+          chopperLogger.onRecord.listen((r) => logs.add(r.message));
+
+          await logger.intercept(FakeChain(fakeRequest.copyWith(
+              headers: {...fakeRequest.headers, 'content-length': '42'})));
+
+          expect(logs, equals([]));
+        });
+
+        test('response header level content-length', () async {
+          final logger =
+              HttpLoggingInterceptor(level: Level.headers, onlyErrors: true);
+
+          final logs = [];
+          chopperLogger.onRecord.listen((r) => logs.add(r.message));
+          await logger
+              .intercept(FakeChain(fakeRequest, response: fakeResponse));
+
+          expect(logs, equals([]));
+        });
+        test('response body level content-length', () async {
+          final logger =
+              HttpLoggingInterceptor(level: Level.body, onlyErrors: true);
+
+          final logs = [];
+          chopperLogger.onRecord.listen((r) => logs.add(r.message));
+          await logger
+              .intercept(FakeChain(fakeRequest, response: fakeResponse));
+
+          expect(logs, equals([]));
+        });
+      });
     });
 
-    test('Http logger interceptor basic level response', () async {
-      final logger = HttpLoggingInterceptor(level: Level.basic);
+    group('HTTP 400', () {
+      group('http logging interceptor response logging', () {
+        late Response fakeResponse;
 
-      final logs = [];
-      chopperLogger.onRecord.listen((r) => logs.add(r.message));
-      await logger.intercept(FakeChain(fakeRequest, response: fakeResponse));
+        setUp(() async {
+          fakeResponse = Response<String>(
+            http.Response(
+              'responseBodyBase',
+              400,
+              headers: {'foo': 'bar'},
+              request: await fakeRequest.toBaseRequest(),
+            ),
+            'responseBody',
+          );
+        });
 
-      expect(
-        logs,
-        containsAll(
-          [
-            '',
-            '<-- 200 POST base/ (0ms, 16-byte body)',
-          ],
-        ),
-      );
-    });
+        test('Http logger interceptor none level response', () async {
+          final logger =
+              HttpLoggingInterceptor(level: Level.none, onlyErrors: true);
 
-    test('Http logger interceptor headers level response', () async {
-      final logger = HttpLoggingInterceptor(level: Level.headers);
+          final logs = [];
+          chopperLogger.onRecord.listen((r) => logs.add(r.message));
+          await logger.intercept(FakeChain(fakeRequest));
 
-      final logs = [];
-      chopperLogger.onRecord.listen((r) => logs.add(r.message));
-      await logger.intercept(FakeChain(fakeRequest, response: fakeResponse));
+          expect(
+            logs,
+            equals(
+              [],
+            ),
+          );
+        });
 
-      expect(
-        logs,
-        containsAll(
-          [
-            '',
-            '<-- 200 POST base/ (0ms)',
-            'foo: bar',
-            'content-length: 16',
-            '<-- END HTTP',
-          ],
-        ),
-      );
-    });
+        test('Http logger interceptor basic level response', () async {
+          final logger =
+              HttpLoggingInterceptor(level: Level.basic, onlyErrors: true);
 
-    test('Http logger interceptor body level response', () async {
-      final logger = HttpLoggingInterceptor(level: Level.body);
+          final logs = [];
+          chopperLogger.onRecord.listen((r) => logs.add(r.message));
+          await logger
+              .intercept(FakeChain(fakeRequest, response: fakeResponse));
 
-      final logs = [];
-      chopperLogger.onRecord.listen((r) => logs.add(r.message));
-      await logger.intercept(FakeChain(fakeRequest, response: fakeResponse));
+          expect(
+            logs,
+            containsAll(
+              [
+                '',
+                '<-- 400 POST base/ (0ms, 16-byte body)',
+              ],
+            ),
+          );
+        });
 
-      expect(
-        logs,
-        containsAll(
-          [
-            '',
-            '<-- 200 POST base/ (0ms)',
-            'foo: bar',
-            'content-length: 16',
-            '',
-            'responseBodyBase',
-            '<-- END HTTP',
-          ],
-        ),
-      );
-    });
-  });
+        test('Http logger interceptor headers level response', () async {
+          final logger =
+              HttpLoggingInterceptor(level: Level.headers, onlyErrors: true);
 
-  group('headers content-length not overridden', () {
-    late Response fakeResponse;
+          final logs = [];
+          chopperLogger.onRecord.listen((r) => logs.add(r.message));
+          await logger
+              .intercept(FakeChain(fakeRequest, response: fakeResponse));
 
-    setUp(() async {
-      fakeResponse = Response<String>(
-        http.Response(
-          'responseBodyBase',
-          200,
-          headers: {
-            'foo': 'bar',
-            'content-length': '42',
-          },
-          request: await fakeRequest.toBaseRequest(),
-        ),
-        'responseBody',
-      );
-    });
+          expect(
+            logs,
+            containsAll(
+              [
+                '',
+                '<-- 400 POST base/ (0ms)',
+                'foo: bar',
+                'content-length: 16',
+                '<-- END HTTP',
+              ],
+            ),
+          );
+        });
 
-    test('request header level content-length', () async {
-      final logger = HttpLoggingInterceptor(level: Level.headers);
+        test('Http logger interceptor body level response', () async {
+          final logger =
+              HttpLoggingInterceptor(level: Level.body, onlyErrors: true);
 
-      final logs = [];
-      chopperLogger.onRecord.listen((r) => logs.add(r.message));
+          final logs = [];
+          chopperLogger.onRecord.listen((r) => logs.add(r.message));
+          await logger
+              .intercept(FakeChain(fakeRequest, response: fakeResponse));
 
-      await logger.intercept(FakeChain(fakeRequest.copyWith(
-          headers: {...fakeRequest.headers, 'content-length': '42'})));
+          expect(
+            logs,
+            containsAll(
+              [
+                '',
+                '<-- 400 POST base/ (0ms)',
+                'foo: bar',
+                'content-length: 16',
+                '',
+                'responseBodyBase',
+                '<-- END HTTP',
+              ],
+            ),
+          );
+        });
+      });
 
-      expect(
-        logs,
-        containsAll(
-          [
-            '',
-            '--> POST base/',
-            'foo: bar',
-            'content-length: 42',
-            'content-type: text/plain; charset=utf-8',
-            '--> END POST',
-          ],
-        ),
-      );
-    });
+      group('headers content-length not overridden', () {
+        late Response fakeResponse;
 
-    test('request body level content-length', () async {
-      final logger = HttpLoggingInterceptor(level: Level.body);
+        setUp(() async {
+          fakeResponse = Response<String>(
+            http.Response(
+              'responseBodyBase',
+              400,
+              headers: {
+                'foo': 'bar',
+                'content-length': '42',
+              },
+              request: await fakeRequest.toBaseRequest(),
+            ),
+            'responseBody',
+          );
+        });
 
-      final logs = [];
-      chopperLogger.onRecord.listen((r) => logs.add(r.message));
+        test('request header level content-length', () async {
+          final logger =
+              HttpLoggingInterceptor(level: Level.headers, onlyErrors: true);
 
-      await logger.intercept(FakeChain(fakeRequest.copyWith(
-          headers: {...fakeRequest.headers, 'content-length': '42'})));
+          final logs = [];
+          chopperLogger.onRecord.listen((r) => logs.add(r.message));
 
-      expect(
-        logs,
-        containsAll(
-          [
-            '',
-            '--> POST base/',
-            'foo: bar',
-            'content-length: 42',
-            'content-type: text/plain; charset=utf-8',
-            '',
-            'test',
-            '--> END POST',
-          ],
-        ),
-      );
-    });
+          await logger.intercept(FakeChain(fakeRequest.copyWith(
+              headers: {...fakeRequest.headers, 'content-length': '42'})));
 
-    test('response header level content-length', () async {
-      final logger = HttpLoggingInterceptor(level: Level.headers);
+          expect(logs, equals([]));
+        });
 
-      final logs = [];
-      chopperLogger.onRecord.listen((r) => logs.add(r.message));
-      await logger.intercept(FakeChain(fakeRequest, response: fakeResponse));
+        test('request body level content-length', () async {
+          final logger =
+              HttpLoggingInterceptor(level: Level.body, onlyErrors: true);
 
-      expect(
-        logs,
-        containsAll(
-          [
-            '',
-            '<-- 200 POST base/ (0ms)',
-            'foo: bar',
-            'content-length: 42',
-            '<-- END HTTP',
-          ],
-        ),
-      );
-    });
-    test('response body level content-length', () async {
-      final logger = HttpLoggingInterceptor(level: Level.body);
+          final logs = [];
+          chopperLogger.onRecord.listen((r) => logs.add(r.message));
 
-      final logs = [];
-      chopperLogger.onRecord.listen((r) => logs.add(r.message));
-      await logger.intercept(FakeChain(fakeRequest, response: fakeResponse));
+          await logger.intercept(FakeChain(fakeRequest.copyWith(
+              headers: {...fakeRequest.headers, 'content-length': '42'})));
 
-      expect(
-        logs,
-        containsAll(
-          [
-            '',
-            '<-- 200 POST base/ (0ms)',
-            'foo: bar',
-            'content-length: 42',
-            '',
-            'responseBodyBase',
-            '<-- END HTTP',
-          ],
-        ),
-      );
+          expect(logs, equals([]));
+        });
+
+        test('response header level content-length', () async {
+          final logger =
+              HttpLoggingInterceptor(level: Level.headers, onlyErrors: true);
+
+          final logs = [];
+          chopperLogger.onRecord.listen((r) => logs.add(r.message));
+          await logger
+              .intercept(FakeChain(fakeRequest, response: fakeResponse));
+
+          expect(
+            logs,
+            containsAll(
+              [
+                '',
+                '<-- 400 POST base/ (0ms)',
+                'foo: bar',
+                'content-length: 42',
+                '<-- END HTTP',
+              ],
+            ),
+          );
+        });
+        test('response body level content-length', () async {
+          final logger =
+              HttpLoggingInterceptor(level: Level.body, onlyErrors: true);
+
+          final logs = [];
+          chopperLogger.onRecord.listen((r) => logs.add(r.message));
+          await logger
+              .intercept(FakeChain(fakeRequest, response: fakeResponse));
+
+          expect(
+            logs,
+            containsAll(
+              [
+                '',
+                '<-- 400 POST base/ (0ms)',
+                'foo: bar',
+                'content-length: 42',
+                '',
+                'responseBodyBase',
+                '<-- END HTTP',
+              ],
+            ),
+          );
+        });
+      });
     });
   });
 }


### PR DESCRIPTION
Add ability to `HttpLoggingInterceptor` to **only** log HTTP errors.

### Rationale
The `HttpLoggingInterceptor` amazing, however, due to its verbosity the level of output can sometimes seem overwhelming. Having the ability to only show verbose logs for HTTP errors is therefore in my mind a nice feature.

### Usage

Passing `onlyErrors: true` to the constructor will limit the logger to only log **responses** with an HTTP status code of 400 and above.

---
This PR is a response/solution to @Guldem's https://github.com/lejard-h/chopper/pull/609#issuecomment-2098284779