### PR TITLE
:bookmark: release chopper v8.0.1+1 (for real)

### DIFF
--- a/chopper/pubspec.yaml
+++ b/chopper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chopper
 description: Chopper is an http client generator using source_gen, inspired by Retrofit
-version: 8.0.1
+version: 8.0.1+1
 documentation: https://hadrien-lejard.gitbook.io/chopper
 repository: https://github.com/lejard-h/chopper
 


### PR DESCRIPTION
In https://github.com/lejard-h/chopper/pull/627#issuecomment-2198520115 I forgot to bump the version in `chopper/pubspec.yaml` so there was no release to pub.dev.

CC / @JEuler @Guldem 