### PR TITLE
:art: remove duplicate null-coalescing responseTypeReference

### DIFF
--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -193,9 +193,8 @@ final class ChopperGenerator
 
     // Set Response with generic types
     final Reference responseTypeReference = refer(
-        responseType?.getDisplayString(withNullability: false) ??
-            responseType?.getDisplayString(withNullability: false) ??
-            'dynamic');
+      responseType?.getDisplayString(withNullability: false) ?? 'dynamic',
+    );
     // Set the return type
     final returnType = isResponseObject
         ? refer(m.returnType.getDisplayString(withNullability: false))


### PR DESCRIPTION
While looking at the generator I found a duplicate null-coalescing `responseTypeReference`. Probably left there by mistake. It's not a bug per-se, it just looks up the response type 2x for no reason.

CC/ @Guldem 