### PR TITLE
:bug: properly escape single quote in cURL interceptor output

### DIFF
--- a/chopper/lib/src/interceptors/curl_interceptor.dart
+++ b/chopper/lib/src/interceptors/curl_interceptor.dart
@@ -25,7 +25,7 @@ class CurlInterceptor implements Interceptor {
     if (baseRequest is http.Request) {
       final String body = baseRequest.body;
       if (body.isNotEmpty) {
-        curlParts.add("-d '$body'");
+        curlParts.add("-d '${body.replaceAll("'", r"'\''")}'");
       }
     }
     if (baseRequest is http.MultipartRequest) {
@@ -36,7 +36,7 @@ class CurlInterceptor implements Interceptor {
         curlParts.add("-f '${file.field}: ${file.filename ?? ''}'");
       }
     }
-    curlParts.add('"${baseRequest.url}"');
+    curlParts.add("'${baseRequest.url}'");
     chopperLogger.info(curlParts.join(' '));
 
     return chain.proceed(chain.request);


### PR DESCRIPTION
I noticed that a single quote `'` is not properly escaped in the cURL output so I escaped it according to [this](https://stackoverflow.com/questions/32122586).

For example
```dart
final fakeRequest = Request(
  'POST',
  Uri.parse('/'),
  Uri.parse('base'),
  body: r"""Lorem's ipsum "dolor" sit amet""",
);
```

should generate this cURL output

```
curl -v -X POST -H 'content-type: text/plain; charset=utf-8' -d 'Lorem'\''s ipsum "dolor" sit amet' 'base/'
```

and not fail when you paste it into your shell or Postman.