### PR TITLE
:arrow_up: update dependencies

### DIFF
--- a/chopper/example/definition.chopper.dart
+++ b/chopper/example/definition.chopper.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 part of 'definition.dart';

--- a/chopper/example/tag.chopper.dart
+++ b/chopper/example/tag.chopper.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 part of 'tag.dart';

--- a/chopper/lib/src/request.dart
+++ b/chopper/lib/src/request.dart
@@ -10,6 +10,7 @@ import 'package:qs_dart/qs_dart.dart' show ListFormat;
 /// {@template request}
 /// This class represents an HTTP request that can be made with Chopper.
 /// {@endtemplate}
+// ignore: must_be_immutable
 base class Request extends http.BaseRequest with EquatableMixin {
   final Uri uri;
   final Uri baseUri;

--- a/chopper/pubspec.yaml
+++ b/chopper/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   http: ^1.1.0
   logging: ^1.2.0
   meta: ^1.9.1
-  qs_dart: ^1.2.3
+  qs_dart: ^1.3.0
 
 dev_dependencies:
   build_runner: ^2.4.9

--- a/chopper/test/test_service.chopper.dart
+++ b/chopper/test/test_service.chopper.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 part of 'test_service.dart';

--- a/chopper/test/test_service_base_url.chopper.dart
+++ b/chopper/test/test_service_base_url.chopper.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 part of 'test_service_base_url.dart';

--- a/chopper/test/test_service_variable.chopper.dart
+++ b/chopper/test/test_service_variable.chopper.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 part of 'test_service_variable.dart';

--- a/chopper/test/test_without_response_service.chopper.dart
+++ b/chopper/test/test_without_response_service.chopper.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 part of 'test_without_response_service.dart';

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -12,7 +12,6 @@ import 'package:chopper_generator/src/extensions.dart';
 import 'package:chopper_generator/src/utils.dart';
 import 'package:chopper_generator/src/vars.dart';
 import 'package:code_builder/code_builder.dart';
-import 'package:dart_style/dart_style.dart';
 import 'package:logging/logging.dart';
 import 'package:source_gen/source_gen.dart';
 
@@ -101,7 +100,7 @@ final class ChopperGenerator
         '// ignore_for_file: type=lint';
     final DartEmitter emitter = DartEmitter(useNullSafetySyntax: true);
 
-    return DartFormatter().format('$ignore\n${classBuilder.accept(emitter)}');
+    return '$ignore\n${classBuilder.accept(emitter)}';
   }
 
   static Constructor _generateConstructor() => Constructor(
@@ -518,8 +517,8 @@ final class ChopperGenerator
   }
 
   static String _factoryForFunction(FunctionTypedElement function) =>
-      function.enclosingElement is ClassElement
-          ? '${function.enclosingElement!.name}.${function.name}'
+      function.enclosingElement3 is ClassElement
+          ? '${function.enclosingElement3!.name}.${function.name}'
           : function.name!;
 
   static Map<String, ConstantReader> _getAnnotation(
@@ -636,12 +635,16 @@ final class ChopperGenerator
 
     if (generic == null ||
         _typeChecker(Map).isExactlyType(type) ||
-        _typeChecker(BuiltMap).isExactlyType(type)) return type;
+        _typeChecker(BuiltMap).isExactlyType(type)) {
+      return type;
+    }
 
-    if (generic.isDynamic) return null;
+    if (generic is DynamicType) return null;
 
     if (_typeChecker(List).isExactlyType(type) ||
-        _typeChecker(BuiltList).isExactlyType(type)) return generic;
+        _typeChecker(BuiltList).isExactlyType(type)) {
+      return generic;
+    }
 
     return _getResponseInnerType(generic);
   }

--- a/chopper_generator/pubspec.yaml
+++ b/chopper_generator/pubspec.yaml
@@ -8,15 +8,14 @@ environment:
   sdk: ^3.0.0
 
 dependencies:
-  analyzer: ^6.4.1
+  analyzer: ">=6.9.0 <8.0.0"
   build: ^2.4.1
   built_collection: ^5.1.1
   chopper: ^8.0.1
   code_builder: ^4.10.0
-  dart_style: ^2.3.6
   logging: ^1.2.0
   meta: ^1.9.1
-  source_gen: ^1.5.0
+  source_gen: ">=1.5.0 <3.0.0"
   yaml: ^3.1.2
   collection: ^1.18.0
 

--- a/chopper_generator/test/test_service.chopper.dart
+++ b/chopper_generator/test/test_service.chopper.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 part of 'test_service.dart';

--- a/chopper_generator/test/test_service_variable.chopper.dart
+++ b/chopper_generator/test/test_service_variable.chopper.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 part of 'test_service_variable.dart';

--- a/chopper_generator/test/test_without_response_service.chopper.dart
+++ b/chopper_generator/test/test_without_response_service.chopper.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 part of 'test_without_response_service.dart';


### PR DESCRIPTION
This pull request includes various updates and improvements to the `chopper` and `chopper_generator` packages, focusing on code formatting, dependency updates, and minor refactoring. Below are the most important changes:

### Code Formatting

* Added a comment to specify the dart format width in several generated files to ensure consistent code formatting. [[1]](diffhunk://#diff-21d059db28290c3d399331c65bb63c2e961f5f23845fbf7f1239eb97332b2541R1) [[2]](diffhunk://#diff-1baca8bda3c75d5938c379948a3f5507b629739efee872512889c8ada0816fceR1) [[3]](diffhunk://#diff-9208d1cd8bf5194350aa65706d974792f0d07ff11177b4144b7c70686912a307R1) [[4]](diffhunk://#diff-6b5f3751ae468c26ed71791628283df37af08c5aa6b26d357c2c97e69b7a31adR1) [[5]](diffhunk://#diff-8d6401771709f899198cf463c6b14d730520c9d9b0b5bb0988be4c48621ac92aR1) [[6]](diffhunk://#diff-feaf4f196d90ff4b6607ab2106ea9e14508887c95cd1c368eb3f9f75c2e2dbe5R1) [[7]](diffhunk://#diff-1c81fc78cc2943a566dd148c10e7d743dbfc55d6fa94870658f17eb28246d22fR1)

### Dependency Updates

* Updated the `qs_dart` dependency from version `1.2.3` to `1.3.0` in `chopper/pubspec.yaml`.
* Updated the `analyzer` dependency to ">=6.9.0 <8.0.0" and `source_gen` dependency to ">=1.5.0 <3.0.0" in `chopper_generator/pubspec.yaml`. Removed the `dart_style` dependency.

### Codebase Simplification

* Removed the `dart_style` import and associated formatting logic in `chopper_generator/lib/src/generator.dart`. [[1]](diffhunk://#diff-4ecb249f56dad1d5911519c4e273c8baec4af12f830ff29d138fa1f4c953167fL15) [[2]](diffhunk://#diff-4ecb249f56dad1d5911519c4e273c8baec4af12f830ff29d138fa1f4c953167fL104-R103)
* Refactored the `_factoryForFunction` and `_getResponseInnerType` methods in `chopper_generator/lib/src/generator.dart` for better readability and maintainability. [[1]](diffhunk://#diff-4ecb249f56dad1d5911519c4e273c8baec4af12f830ff29d138fa1f4c953167fL521-R521) [[2]](diffhunk://#diff-4ecb249f56dad1d5911519c4e273c8baec4af12f830ff29d138fa1f4c953167fL639-R647)

### Code Annotations

* Added `// ignore: must_be_immutable` annotation to the `Request` class in `chopper/lib/src/request.dart` to suppress immutability warnings.

---

Supersedes https://github.com/lejard-h/chopper/pull/646