### PR TITLE
:alien: deprecate all lower-case method annotations

### DIFF
--- a/chopper/lib/src/annotations.dart
+++ b/chopper/lib/src/annotations.dart
@@ -115,10 +115,10 @@ final class QueryMap {
 }
 
 /// {@template Body}
-/// Declares the Body of [Post], [Put], and [Patch] requests
+/// Declares the Body of [POST], [PUT], and [PATCH] requests
 ///
 /// ```dart
-/// @Post()
+/// @POST()
 /// Future<Response> post(@Body() Map<String, dynamic> body);
 /// ```
 ///
@@ -163,7 +163,7 @@ final class Header {
 /// Must be used inside a [ChopperApi] definition.
 ///
 /// Recommended:
-/// [Get], [Post], [Put], [Delete], [Patch], or [Head] should be used instead.
+/// [GET], [POST], [PUT], [DELETE], [PATCH], or [HEAD] should be used instead.
 ///
 /// ```dart
 /// @Get(headers: const {'foo': 'bar' })
@@ -251,14 +251,14 @@ sealed class Method {
   });
 }
 
-/// {@template Get}
+/// {@template GET}
 /// Defines a method as an HTTP GET request.
 /// {@endtemplate}
 @immutable
 @Target({TargetKind.method})
-final class Get extends Method {
-  /// {@macro Get}
-  const Get({
+final class GET extends Method {
+  /// {@macro GET}
+  const GET({
     super.optionalBody = true,
     super.path,
     super.headers,
@@ -269,16 +269,35 @@ final class Get extends Method {
   }) : super(HttpMethod.Get);
 }
 
-/// {@template Post}
+/// {@template Get}
+/// Defines a method as an HTTP GET request.
+/// {@endtemplate}
+@immutable
+@Target({TargetKind.method})
+@Deprecated('Use GET instead')
+final class Get extends GET {
+  /// {@macro Get}
+  const Get({
+    super.optionalBody = true,
+    super.path,
+    super.headers,
+    super.listFormat,
+    super.useBrackets,
+    super.includeNullQueryVars,
+    super.timeout,
+  });
+}
+
+/// {@template POST}
 /// Defines a method as an HTTP POST request.
 ///
 /// Use the [Body] annotation to pass data to send.
 /// {@endtemplate}
 @immutable
 @Target({TargetKind.method})
-final class Post extends Method {
-  /// {@macro Post}
-  const Post({
+final class POST extends Method {
+  /// {@macro POST}
+  const POST({
     super.optionalBody,
     super.path,
     super.headers,
@@ -289,14 +308,35 @@ final class Post extends Method {
   }) : super(HttpMethod.Post);
 }
 
-/// {@template Delete}
+/// {@template Post}
+/// Defines a method as an HTTP POST request.
+///
+/// Use the [Body] annotation to pass data to send.
+/// {@endtemplate}
+@immutable
+@Target({TargetKind.method})
+@Deprecated('Use POST instead')
+final class Post extends POST {
+  /// {@macro Post}
+  const Post({
+    super.optionalBody,
+    super.path,
+    super.headers,
+    super.listFormat,
+    super.useBrackets,
+    super.includeNullQueryVars,
+    super.timeout,
+  });
+}
+
+/// {@template DELETE}
 /// Defines a method as an HTTP DELETE request.
 /// {@endtemplate}
 @immutable
 @Target({TargetKind.method})
-final class Delete extends Method {
-  /// {@macro Delete}
-  const Delete({
+final class DELETE extends Method {
+  /// {@macro DELETE}
+  const DELETE({
     super.optionalBody = true,
     super.path,
     super.headers,
@@ -307,16 +347,35 @@ final class Delete extends Method {
   }) : super(HttpMethod.Delete);
 }
 
-/// {@template Put}
+/// {@template Delete}
+/// Defines a method as an HTTP DELETE request.
+/// {@endtemplate}
+@immutable
+@Target({TargetKind.method})
+@Deprecated('Use DELETE instead')
+final class Delete extends DELETE {
+  /// {@macro Delete}
+  const Delete({
+    super.optionalBody = true,
+    super.path,
+    super.headers,
+    super.listFormat,
+    super.useBrackets,
+    super.includeNullQueryVars,
+    super.timeout,
+  });
+}
+
+/// {@template PUT}
 /// Defines a method as an HTTP PUT request.
 ///
 /// Use the [Body] annotation to pass data to send.
 /// {@endtemplate}
 @immutable
 @Target({TargetKind.method})
-final class Put extends Method {
-  /// {@macro Put}
-  const Put({
+final class PUT extends Method {
+  /// {@macro PUT}
+  const PUT({
     super.optionalBody,
     super.path,
     super.headers,
@@ -327,15 +386,36 @@ final class Put extends Method {
   }) : super(HttpMethod.Put);
 }
 
-/// {@template Patch}
+/// {@template Put}
+/// Defines a method as an HTTP PUT request.
+///
+/// Use the [Body] annotation to pass data to send.
+/// {@endtemplate}
+@immutable
+@Target({TargetKind.method})
+@Deprecated('Use PUT instead')
+final class Put extends PUT {
+  /// {@macro Put}
+  const Put({
+    super.optionalBody,
+    super.path,
+    super.headers,
+    super.listFormat,
+    super.useBrackets,
+    super.includeNullQueryVars,
+    super.timeout,
+  });
+}
+
+/// {@template PATCH}
 /// Defines a method as an HTTP PATCH request.
 /// Use the [Body] annotation to pass data to send.
 /// {@endtemplate}
 @immutable
 @Target({TargetKind.method})
-final class Patch extends Method {
-  /// {@macro Patch}
-  const Patch({
+final class PATCH extends Method {
+  /// {@macro PATCH}
+  const PATCH({
     super.optionalBody,
     super.path,
     super.headers,
@@ -346,14 +426,34 @@ final class Patch extends Method {
   }) : super(HttpMethod.Patch);
 }
 
-/// {@template Head}
+/// {@template Patch}
+/// Defines a method as an HTTP PATCH request.
+/// Use the [Body] annotation to pass data to send.
+/// {@endtemplate}
+@immutable
+@Target({TargetKind.method})
+@Deprecated('Use PATCH instead')
+final class Patch extends PATCH {
+  /// {@macro Patch}
+  const Patch({
+    super.optionalBody,
+    super.path,
+    super.headers,
+    super.listFormat,
+    super.useBrackets,
+    super.includeNullQueryVars,
+    super.timeout,
+  });
+}
+
+/// {@template HEAD}
 /// Defines a method as an HTTP HEAD request.
 /// {@endtemplate}
 @immutable
 @Target({TargetKind.method})
-final class Head extends Method {
-  /// {@macro Head}
-  const Head({
+final class HEAD extends Method {
+  /// {@macro HEAD}
+  const HEAD({
     super.optionalBody = true,
     super.path,
     super.headers,
@@ -364,12 +464,50 @@ final class Head extends Method {
   }) : super(HttpMethod.Head);
 }
 
+/// {@template Head}
+/// Defines a method as an HTTP HEAD request.
+/// {@endtemplate}
+@immutable
+@Target({TargetKind.method})
+@Deprecated('Use HEAD instead')
+final class Head extends HEAD {
+  /// {@macro Head}
+  const Head({
+    super.optionalBody = true,
+    super.path,
+    super.headers,
+    super.listFormat,
+    super.useBrackets,
+    super.includeNullQueryVars,
+    super.timeout,
+  });
+}
+
+/// {@template OPTIONS}
+/// Defines a method as an HTTP OPTIONS request.
+/// {@endtemplate}
+@immutable
+@Target({TargetKind.method})
+final class OPTIONS extends Method {
+  /// {@macro OPTIONS}
+  const OPTIONS({
+    super.optionalBody = true,
+    super.path,
+    super.headers,
+    super.listFormat,
+    super.useBrackets,
+    super.includeNullQueryVars,
+    super.timeout,
+  }) : super(HttpMethod.Options);
+}
+
 /// {@template Options}
 /// Defines a method as an HTTP OPTIONS request.
 /// {@endtemplate}
 @immutable
 @Target({TargetKind.method})
-final class Options extends Method {
+@Deprecated('Use OPTIONS instead')
+final class Options extends OPTIONS {
   /// {@macro Options}
   const Options({
     super.optionalBody = true,
@@ -379,7 +517,7 @@ final class Options extends Method {
     super.useBrackets,
     super.includeNullQueryVars,
     super.timeout,
-  }) : super(HttpMethod.Options);
+  });
 }
 
 /// A function that should convert the body of a [Request] to the HTTP representation.
@@ -626,26 +764,26 @@ const queryMap = QueryMap();
 /// {@macro Header}
 const header = Header();
 
-/// {@macro Get}
-const get = Get();
+/// {@macro GET}
+const get = GET();
 
-/// {@macro Post}
-const post = Post();
+/// {@macro POST}
+const post = POST();
 
-/// {@macro Delete}
-const delete = Delete();
+/// {@macro DELETE}
+const delete = DELETE();
 
-/// {@macro Put}
-const put = Put();
+/// {@macro PUT}
+const put = PUT();
 
-/// {@macro Patch}
-const patch = Patch();
+/// {@macro PATCH}
+const patch = PATCH();
 
-/// {@macro Head}
-const head = Head();
+/// {@macro HEAD}
+const head = HEAD();
 
-/// {@macro Options}
-const options = Options();
+/// {@macro OPTIONS}
+const options = OPTIONS();
 
 /// {@macro FactoryConverter}
 const factoryConverter = FactoryConverter();

--- a/chopper/test/test_service.dart
+++ b/chopper/test/test_service.dart
@@ -13,132 +13,132 @@ abstract class HttpTestService extends ChopperService {
   static HttpTestService create([ChopperClient? client]) =>
       _$HttpTestService(client);
 
-  @Get(path: 'get/{id}')
+  @GET(path: 'get/{id}')
   Future<Response<String>> getTest(
     @Path() String id, {
     @Header('test') required String dynamicHeader,
   });
 
-  @Head(path: 'head')
+  @HEAD(path: 'head')
   Future<Response> headTest();
 
-  @Options(path: 'options')
+  @OPTIONS(path: 'options')
   Future<Response> optionsTest();
 
-  @Get(path: 'get')
+  @GET(path: 'get')
   Future<Response<Stream<List<int>>>> getStreamTest();
 
-  @Get(path: '')
+  @GET(path: '')
   Future<Response> getAll();
 
-  @Get(path: '/')
+  @GET(path: '/')
   Future<Response> getAllWithTrailingSlash();
 
-  @Get(path: 'query')
+  @GET(path: 'query')
   Future<Response> getQueryTest({
     @Query('name') String name = '',
     @Query('int') int? number,
     @Query('default_value') int? def = 42,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest(@QueryMap() Map<String, dynamic> query);
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest2(
     @QueryMap() Map<String, dynamic> query, {
     @Query('test') bool? test,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest3({
     @Query('name') String name = '',
     @Query('number') int? number,
     @QueryMap() Map<String, dynamic> filters = const {},
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest4({
     @Query('name') String name = '',
     @Query('number') int? number,
     @QueryMap() Map<String, dynamic>? filters,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest5({
     @QueryMap() Map<String, dynamic>? filters,
   });
 
-  @Get(path: 'get_body')
+  @GET(path: 'get_body')
   Future<Response> getBody(@Body() dynamic body);
 
-  @Post(path: 'post')
+  @POST(path: 'post')
   Future<Response> postTest(@Body() String data);
 
-  @Post(path: 'post')
+  @POST(path: 'post')
   Future<Response> postStreamTest(@Body() Stream<List<int>> byteStream);
 
-  @Put(path: 'put/{id}')
+  @PUT(path: 'put/{id}')
   Future<Response> putTest(@Path('id') String test, @Body() String data);
 
-  @Delete(path: 'delete/{id}', headers: {'foo': 'bar'})
+  @DELETE(path: 'delete/{id}', headers: {'foo': 'bar'})
   Future<Response> deleteTest(@Path() String id);
 
-  @Patch(path: 'patch/{id}')
+  @PATCH(path: 'patch/{id}')
   Future<Response> patchTest(@Path() String id, @Body() String data);
 
-  @Post(path: 'map')
+  @POST(path: 'map')
   Future<Response> mapTest(@Body() Map<String, String> map);
 
   @FactoryConverter(request: convertForm)
-  @Post(path: 'form/body')
+  @POST(path: 'form/body')
   Future<Response> postForm(@Body() Map<String, String> fields);
 
-  @Post(path: 'form/body', headers: {contentTypeKey: formEncodedHeaders})
+  @POST(path: 'form/body', headers: {contentTypeKey: formEncodedHeaders})
   Future<Response> postFormUsingHeaders(@Body() Map<String, String> fields);
 
   @FactoryConverter(request: convertForm)
-  @Post(path: 'form/body/fields')
+  @POST(path: 'form/body/fields')
   Future<Response> postFormFields(@Field() String foo, @Field() int bar);
 
-  @Post(path: 'map/json')
+  @POST(path: 'map/json')
   @FactoryConverter(
     request: customConvertRequest,
     response: customConvertResponse,
   )
   Future<Response> forceJsonTest(@Body() Map map);
 
-  @Post(path: 'multi')
+  @POST(path: 'multi')
   @multipart
   Future<Response> postResources(
     @Part('1') Map a,
     @Part('2') Map b,
   );
 
-  @Post(path: 'file')
+  @POST(path: 'file')
   @multipart
   Future<Response> postFile(
     @PartFile('file') List<int> bytes,
   );
 
-  @Post(path: 'image')
+  @POST(path: 'image')
   @multipart
   Future<Response> postImage(
     @PartFile('image') List<int> imageData,
   );
 
-  @Post(path: 'file')
+  @POST(path: 'file')
   @multipart
   Future<Response> postMultipartFile(
     @PartFile() MultipartFile file, {
     @Part() String? id,
   });
 
-  @Post(path: 'files')
+  @POST(path: 'files')
   @multipart
   Future<Response> postListFiles(@PartFile() List<MultipartFile> files);
 
-  @Post(path: 'multipart_list')
+  @POST(path: 'multipart_list')
   @multipart
   Future<Response> postMultipartList({
     @Part('ints') required List<int> ints,
@@ -147,58 +147,58 @@ abstract class HttpTestService extends ChopperService {
     @Part('strings') required List<String> strings,
   });
 
-  @Get(path: 'https://test.com')
+  @GET(path: 'https://test.com')
   Future<Response> fullUrl();
 
-  @Get(path: '/list/string')
+  @GET(path: '/list/string')
   Future<Response<List<String>>> listString();
 
-  @Post(path: 'no-body')
+  @POST(path: 'no-body')
   Future<Response> noBody();
 
-  @Get(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
+  @GET(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
   Future<Response<String>> getUsingQueryParamIncludeNullQueryVars({
     @Query('foo') String? foo,
     @Query('bar') String? bar,
     @Query('baz') String? baz,
   });
 
-  @Get(path: '/list_query_param')
+  @GET(path: '/list_query_param')
   Future<Response<String>> getUsingListQueryParam(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_brackets_legacy', useBrackets: true)
+  @GET(path: '/list_query_param_with_brackets_legacy', useBrackets: true)
   Future<Response<String>> getUsingListQueryParamWithBracketsLegacy(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_brackets', listFormat: ListFormat.brackets)
+  @GET(path: '/list_query_param_with_brackets', listFormat: ListFormat.brackets)
   Future<Response<String>> getUsingListQueryParamWithBrackets(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_indices', listFormat: ListFormat.indices)
+  @GET(path: '/list_query_param_with_indices', listFormat: ListFormat.indices)
   Future<Response<String>> getUsingListQueryParamWithIndices(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_repeat', listFormat: ListFormat.repeat)
+  @GET(path: '/list_query_param_with_repeat', listFormat: ListFormat.repeat)
   Future<Response<String>> getUsingListQueryParamWithRepeat(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_comma', listFormat: ListFormat.comma)
+  @GET(path: '/list_query_param_with_comma', listFormat: ListFormat.comma)
   Future<Response<String>> getUsingListQueryParamWithComma(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/map_query_param')
+  @GET(path: '/map_query_param')
   Future<Response<String>> getUsingMapQueryParam(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(
+  @GET(
     path: '/map_query_param_include_null_query_vars',
     includeNullQueryVars: true,
   )
@@ -206,37 +206,37 @@ abstract class HttpTestService extends ChopperService {
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_brackets_legacy', useBrackets: true)
+  @GET(path: '/map_query_param_with_brackets_legacy', useBrackets: true)
   Future<Response<String>> getUsingMapQueryParamWithBracketsLegacy(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_brackets', listFormat: ListFormat.brackets)
+  @GET(path: '/map_query_param_with_brackets', listFormat: ListFormat.brackets)
   Future<Response<String>> getUsingMapQueryParamWithBrackets(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_indices', listFormat: ListFormat.indices)
+  @GET(path: '/map_query_param_with_indices', listFormat: ListFormat.indices)
   Future<Response<String>> getUsingMapQueryParamWithIndices(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_repeat', listFormat: ListFormat.repeat)
+  @GET(path: '/map_query_param_with_repeat', listFormat: ListFormat.repeat)
   Future<Response<String>> getUsingMapQueryParamWithRepeat(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_comma', listFormat: ListFormat.comma)
+  @GET(path: '/map_query_param_with_comma', listFormat: ListFormat.comma)
   Future<Response<String>> getUsingMapQueryParamWithComma(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/date_time')
+  @GET(path: '/date_time')
   Future<Response<String>> getDateTime(
     @Query('value') DateTime value,
   );
 
-  @Get(path: 'headers')
+  @GET(path: 'headers')
   Future<Response<String>> getHeaders({
     @Header('x-string') required String stringHeader,
     @Header('x-boolean') bool? boolHeader,
@@ -245,7 +245,7 @@ abstract class HttpTestService extends ChopperService {
     @Header('x-enum') ExampleEnum? enumHeader,
   });
 
-  @Post(path: 'publish')
+  @POST(path: 'publish')
   @FactoryConverter(request: FormUrlEncodedConverter.requestFactory)
   Future<Response<void>> publish(
     @Field('review_id') final String reviewId,
@@ -254,13 +254,13 @@ abstract class HttpTestService extends ChopperService {
     @Field() final String? signature,
   ]);
 
-  @Get(path: 'get_timeout', timeout: Duration(seconds: 42))
+  @GET(path: 'get_timeout', timeout: Duration(seconds: 42))
   Future<Response<String>> getTimeoutTest();
 
-  @Get(path: 'get_timeout_zero', timeout: Duration(seconds: 0))
+  @GET(path: 'get_timeout_zero', timeout: Duration(seconds: 0))
   Future<Response<String>> getTimeoutTestZero();
 
-  @Get(path: 'get_timeout_neg', timeout: Duration(seconds: -1))
+  @GET(path: 'get_timeout_neg', timeout: Duration(seconds: -1))
   Future<Response<String>> getTimeoutTestNeg();
 }
 

--- a/chopper/test/test_service_base_url.dart
+++ b/chopper/test/test_service_base_url.dart
@@ -10,58 +10,58 @@ abstract class HttpTestServiceBaseUrl extends ChopperService {
   static HttpTestServiceBaseUrl create([ChopperClient? client]) =>
       _$HttpTestServiceBaseUrl(client);
 
-  @Get(path: '')
+  @GET(path: '')
   Future<Response> getAll();
 
-  @Get(path: '/')
+  @GET(path: '/')
   Future<Response> getAllWithTrailingSlash();
 
-  @Get(path: '/list/string')
+  @GET(path: '/list/string')
   Future<Response<List<String>>> listString();
 
-  @Get(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
+  @GET(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
   Future<Response<String>> getUsingQueryParamIncludeNullQueryVars({
     @Query('foo') String? foo,
     @Query('bar') String? bar,
     @Query('baz') String? baz,
   });
 
-  @Get(path: '/list_query_param')
+  @GET(path: '/list_query_param')
   Future<Response<String>> getUsingListQueryParam(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_brackets_legacy', useBrackets: true)
+  @GET(path: '/list_query_param_with_brackets_legacy', useBrackets: true)
   Future<Response<String>> getUsingListQueryParamWithBracketsLegacy(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_brackets', listFormat: ListFormat.brackets)
+  @GET(path: '/list_query_param_with_brackets', listFormat: ListFormat.brackets)
   Future<Response<String>> getUsingListQueryParamWithBrackets(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_indices', listFormat: ListFormat.indices)
+  @GET(path: '/list_query_param_with_indices', listFormat: ListFormat.indices)
   Future<Response<String>> getUsingListQueryParamWithIndices(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_repeat', listFormat: ListFormat.repeat)
+  @GET(path: '/list_query_param_with_repeat', listFormat: ListFormat.repeat)
   Future<Response<String>> getUsingListQueryParamWithRepeat(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_comma', listFormat: ListFormat.comma)
+  @GET(path: '/list_query_param_with_comma', listFormat: ListFormat.comma)
   Future<Response<String>> getUsingListQueryParamWithComma(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/map_query_param')
+  @GET(path: '/map_query_param')
   Future<Response<String>> getUsingMapQueryParam(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(
+  @GET(
     path: '/map_query_param_include_null_query_vars',
     includeNullQueryVars: true,
   )
@@ -69,27 +69,27 @@ abstract class HttpTestServiceBaseUrl extends ChopperService {
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_brackets_legacy', useBrackets: true)
+  @GET(path: '/map_query_param_with_brackets_legacy', useBrackets: true)
   Future<Response<String>> getUsingMapQueryParamWithBracketsLegacy(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_brackets', listFormat: ListFormat.brackets)
+  @GET(path: '/map_query_param_with_brackets', listFormat: ListFormat.brackets)
   Future<Response<String>> getUsingMapQueryParamWithBrackets(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_indices', listFormat: ListFormat.indices)
+  @GET(path: '/map_query_param_with_indices', listFormat: ListFormat.indices)
   Future<Response<String>> getUsingMapQueryParamWithIndices(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_repeat', listFormat: ListFormat.repeat)
+  @GET(path: '/map_query_param_with_repeat', listFormat: ListFormat.repeat)
   Future<Response<String>> getUsingMapQueryParamWithRepeat(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_comma', listFormat: ListFormat.comma)
+  @GET(path: '/map_query_param_with_comma', listFormat: ListFormat.comma)
   Future<Response<String>> getUsingMapQueryParamWithComa(
     @Query('value') Map<String, dynamic> value,
   );

--- a/chopper/test/test_service_variable.dart
+++ b/chopper/test/test_service_variable.dart
@@ -13,132 +13,132 @@ abstract class HttpTestServiceVariable extends ChopperService {
   static HttpTestServiceVariable create([ChopperClient? client]) =>
       _$HttpTestServiceVariable(client);
 
-  @Get(path: 'get/{id}')
+  @GET(path: 'get/{id}')
   Future<Response<String>> getTest(
     @Path() String id, {
     @Header('test') required String dynamicHeader,
   });
 
-  @Head(path: 'head')
+  @HEAD(path: 'head')
   Future<Response> headTest();
 
-  @Options(path: 'options')
+  @OPTIONS(path: 'options')
   Future<Response> optionsTest();
 
-  @Get(path: 'get')
+  @GET(path: 'get')
   Future<Response<Stream<List<int>>>> getStreamTest();
 
-  @Get(path: '')
+  @GET(path: '')
   Future<Response> getAll();
 
-  @Get(path: '/')
+  @GET(path: '/')
   Future<Response> getAllWithTrailingSlash();
 
-  @Get(path: 'query')
+  @GET(path: 'query')
   Future<Response> getQueryTest({
     @Query('name') String name = '',
     @Query('int') int? number,
     @Query('default_value') int? def = 42,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest(@QueryMap() Map<String, dynamic> query);
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest2(
     @QueryMap() Map<String, dynamic> query, {
     @Query('test') bool? test,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest3({
     @Query('name') String name = '',
     @Query('number') int? number,
     @QueryMap() Map<String, dynamic> filters = const {},
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest4({
     @Query('name') String name = '',
     @Query('number') int? number,
     @QueryMap() Map<String, dynamic>? filters,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest5({
     @QueryMap() Map<String, dynamic>? filters,
   });
 
-  @Get(path: 'get_body')
+  @GET(path: 'get_body')
   Future<Response> getBody(@Body() dynamic body);
 
-  @Post(path: 'post')
+  @POST(path: 'post')
   Future<Response> postTest(@Body() String data);
 
-  @Post(path: 'post')
+  @POST(path: 'post')
   Future<Response> postStreamTest(@Body() Stream<List<int>> byteStream);
 
-  @Put(path: 'put/{id}')
+  @PUT(path: 'put/{id}')
   Future<Response> putTest(@Path('id') String test, @Body() String data);
 
-  @Delete(path: 'delete/{id}', headers: {'foo': 'bar'})
+  @DELETE(path: 'delete/{id}', headers: {'foo': 'bar'})
   Future<Response> deleteTest(@Path() String id);
 
-  @Patch(path: 'patch/{id}')
+  @PATCH(path: 'patch/{id}')
   Future<Response> patchTest(@Path() String id, @Body() String data);
 
-  @Post(path: 'map')
+  @POST(path: 'map')
   Future<Response> mapTest(@Body() Map<String, String> map);
 
   @FactoryConverter(request: convertForm)
-  @Post(path: 'form/body')
+  @POST(path: 'form/body')
   Future<Response> postForm(@Body() Map<String, String> fields);
 
-  @Post(path: 'form/body', headers: {contentTypeKey: formEncodedHeaders})
+  @POST(path: 'form/body', headers: {contentTypeKey: formEncodedHeaders})
   Future<Response> postFormUsingHeaders(@Body() Map<String, String> fields);
 
   @FactoryConverter(request: convertForm)
-  @Post(path: 'form/body/fields')
+  @POST(path: 'form/body/fields')
   Future<Response> postFormFields(@Field() String foo, @Field() int bar);
 
-  @Post(path: 'map/json')
+  @POST(path: 'map/json')
   @FactoryConverter(
     request: customConvertRequest,
     response: customConvertResponse,
   )
   Future<Response> forceJsonTest(@Body() Map map);
 
-  @Post(path: 'multi')
+  @POST(path: 'multi')
   @multipart
   Future<Response> postResources(
     @Part('1') Map a,
     @Part('2') Map b,
   );
 
-  @Post(path: 'file')
+  @POST(path: 'file')
   @multipart
   Future<Response> postFile(
     @PartFile('file') List<int> bytes,
   );
 
-  @Post(path: 'image')
+  @POST(path: 'image')
   @multipart
   Future<Response> postImage(
     @PartFile('image') List<int> imageData,
   );
 
-  @Post(path: 'file')
+  @POST(path: 'file')
   @multipart
   Future<Response> postMultipartFile(
     @PartFile() MultipartFile file, {
     @Part() String? id,
   });
 
-  @Post(path: 'files')
+  @POST(path: 'files')
   @multipart
   Future<Response> postListFiles(@PartFile() List<MultipartFile> files);
 
-  @Post(path: 'multipart_list')
+  @POST(path: 'multipart_list')
   @multipart
   Future<Response> postMultipartList({
     @Part('ints') required List<int> ints,
@@ -147,58 +147,58 @@ abstract class HttpTestServiceVariable extends ChopperService {
     @Part('strings') required List<String> strings,
   });
 
-  @Get(path: 'https://test.com')
+  @GET(path: 'https://test.com')
   Future<Response> fullUrl();
 
-  @Get(path: '/list/string')
+  @GET(path: '/list/string')
   Future<Response<List<String>>> listString();
 
-  @Post(path: 'no-body')
+  @POST(path: 'no-body')
   Future<Response> noBody();
 
-  @Get(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
+  @GET(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
   Future<Response<String>> getUsingQueryParamIncludeNullQueryVars({
     @Query('foo') String? foo,
     @Query('bar') String? bar,
     @Query('baz') String? baz,
   });
 
-  @Get(path: '/list_query_param')
+  @GET(path: '/list_query_param')
   Future<Response<String>> getUsingListQueryParam(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_brackets_legacy', useBrackets: true)
+  @GET(path: '/list_query_param_with_brackets_legacy', useBrackets: true)
   Future<Response<String>> getUsingListQueryParamWithBracketsLegacy(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_brackets', listFormat: ListFormat.brackets)
+  @GET(path: '/list_query_param_with_brackets', listFormat: ListFormat.brackets)
   Future<Response<String>> getUsingListQueryParamWithBrackets(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_indices', listFormat: ListFormat.indices)
+  @GET(path: '/list_query_param_with_indices', listFormat: ListFormat.indices)
   Future<Response<String>> getUsingListQueryParamWithIndices(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_repeat', listFormat: ListFormat.repeat)
+  @GET(path: '/list_query_param_with_repeat', listFormat: ListFormat.repeat)
   Future<Response<String>> getUsingListQueryParamWithRepeat(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_comma', listFormat: ListFormat.comma)
+  @GET(path: '/list_query_param_with_comma', listFormat: ListFormat.comma)
   Future<Response<String>> getUsingListQueryParamWithComma(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/map_query_param')
+  @GET(path: '/map_query_param')
   Future<Response<String>> getUsingMapQueryParam(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(
+  @GET(
     path: '/map_query_param_include_null_query_vars',
     includeNullQueryVars: true,
   )
@@ -206,27 +206,27 @@ abstract class HttpTestServiceVariable extends ChopperService {
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_brackets_legacy', useBrackets: true)
+  @GET(path: '/map_query_param_with_brackets_legacy', useBrackets: true)
   Future<Response<String>> getUsingMapQueryParamWithBracketsLegacy(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_brackets', listFormat: ListFormat.brackets)
+  @GET(path: '/map_query_param_with_brackets', listFormat: ListFormat.brackets)
   Future<Response<String>> getUsingMapQueryParamWithBrackets(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_indices', listFormat: ListFormat.indices)
+  @GET(path: '/map_query_param_with_indices', listFormat: ListFormat.indices)
   Future<Response<String>> getUsingMapQueryParamWithIndices(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_repeat', listFormat: ListFormat.repeat)
+  @GET(path: '/map_query_param_with_repeat', listFormat: ListFormat.repeat)
   Future<Response<String>> getUsingMapQueryParamWithRepeat(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_comma', listFormat: ListFormat.comma)
+  @GET(path: '/map_query_param_with_comma', listFormat: ListFormat.comma)
   Future<Response<String>> getUsingMapQueryParamWithComma(
     @Query('value') Map<String, dynamic> value,
   );

--- a/chopper/test/test_without_response_service.dart
+++ b/chopper/test/test_without_response_service.dart
@@ -11,132 +11,132 @@ abstract class HttpTestService extends ChopperService {
   static HttpTestService create([ChopperClient? client]) =>
       _$HttpTestService(client);
 
-  @Get(path: 'get/{id}')
+  @GET(path: 'get/{id}')
   Future<String> getTest(
     @Path() String id, {
     @Header('test') required String dynamicHeader,
   });
 
-  @Head(path: 'head')
+  @HEAD(path: 'head')
   Future headTest();
 
-  @Options(path: 'options')
+  @OPTIONS(path: 'options')
   Future optionsTest();
 
-  @Get(path: 'get')
+  @GET(path: 'get')
   Future<Stream<List<int>>> getStreamTest();
 
-  @Get(path: '')
+  @GET(path: '')
   Future getAll();
 
-  @Get(path: '/')
+  @GET(path: '/')
   Future getAllWithTrailingSlash();
 
-  @Get(path: 'query')
+  @GET(path: 'query')
   Future getQueryTest({
     @Query('name') String name = '',
     @Query('int') int? number,
     @Query('default_value') int? def = 42,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future getQueryMapTest(@QueryMap() Map<String, dynamic> query);
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future getQueryMapTest2(
     @QueryMap() Map<String, dynamic> query, {
     @Query('test') bool? test,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future getQueryMapTest3({
     @Query('name') String name = '',
     @Query('number') int? number,
     @QueryMap() Map<String, dynamic> filters = const {},
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future getQueryMapTest4({
     @Query('name') String name = '',
     @Query('number') int? number,
     @QueryMap() Map<String, dynamic>? filters,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future getQueryMapTest5({
     @QueryMap() Map<String, dynamic>? filters,
   });
 
-  @Get(path: 'get_body')
+  @GET(path: 'get_body')
   Future getBody(@Body() dynamic body);
 
-  @Post(path: 'post')
+  @POST(path: 'post')
   Future postTest(@Body() String data);
 
-  @Post(path: 'post')
+  @POST(path: 'post')
   Future postStreamTest(@Body() Stream<List<int>> byteStream);
 
-  @Put(path: 'put/{id}')
+  @PUT(path: 'put/{id}')
   Future putTest(@Path('id') String test, @Body() String data);
 
-  @Delete(path: 'delete/{id}', headers: {'foo': 'bar'})
+  @DELETE(path: 'delete/{id}', headers: {'foo': 'bar'})
   Future<void> deleteTest(@Path() String id);
 
-  @Patch(path: 'patch/{id}')
+  @PATCH(path: 'patch/{id}')
   Future patchTest(@Path() String id, @Body() String data);
 
-  @Post(path: 'map')
+  @POST(path: 'map')
   Future mapTest(@Body() Map<String, String> map);
 
   @FactoryConverter(request: convertForm)
-  @Post(path: 'form/body')
+  @POST(path: 'form/body')
   Future postForm(@Body() Map<String, String> fields);
 
-  @Post(path: 'form/body', headers: {contentTypeKey: formEncodedHeaders})
+  @POST(path: 'form/body', headers: {contentTypeKey: formEncodedHeaders})
   Future postFormUsingHeaders(@Body() Map<String, String> fields);
 
   @FactoryConverter(request: convertForm)
-  @Post(path: 'form/body/fields')
+  @POST(path: 'form/body/fields')
   Future postFormFields(@Field() String foo, @Field() int bar);
 
-  @Post(path: 'map/json')
+  @POST(path: 'map/json')
   @FactoryConverter(
     request: customConvertRequest,
     response: customConvertResponse,
   )
   Future forceJsonTest(@Body() Map map);
 
-  @Post(path: 'multi')
+  @POST(path: 'multi')
   @multipart
   Future postResources(
     @Part('1') Map a,
     @Part('2') Map b,
   );
 
-  @Post(path: 'file')
+  @POST(path: 'file')
   @multipart
   Future postFile(
     @PartFile('file') List<int> bytes,
   );
 
-  @Post(path: 'image')
+  @POST(path: 'image')
   @multipart
   Future postImage(
     @PartFile('image') List<int> imageData,
   );
 
-  @Post(path: 'file')
+  @POST(path: 'file')
   @multipart
   Future postMultipartFile(
     @PartFile() MultipartFile file, {
     @Part() String? id,
   });
 
-  @Post(path: 'files')
+  @POST(path: 'files')
   @multipart
   Future postListFiles(@PartFile() List<MultipartFile> files);
 
-  @Post(path: 'multipart_list')
+  @POST(path: 'multipart_list')
   @multipart
   Future postMultipartList({
     @Part('ints') required List<int> ints,
@@ -145,58 +145,58 @@ abstract class HttpTestService extends ChopperService {
     @Part('strings') required List<String> strings,
   });
 
-  @Get(path: 'https://test.com')
+  @GET(path: 'https://test.com')
   Future fullUrl();
 
-  @Get(path: '/list/string')
+  @GET(path: '/list/string')
   Future<List<String>> listString();
 
-  @Post(path: 'no-body')
+  @POST(path: 'no-body')
   Future noBody();
 
-  @Get(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
+  @GET(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
   Future<String> getUsingQueryParamIncludeNullQueryVars({
     @Query('foo') String? foo,
     @Query('bar') String? bar,
     @Query('baz') String? baz,
   });
 
-  @Get(path: '/list_query_param')
+  @GET(path: '/list_query_param')
   Future<String> getUsingListQueryParam(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_brackets_legacy', useBrackets: true)
+  @GET(path: '/list_query_param_with_brackets_legacy', useBrackets: true)
   Future<String> getUsingListQueryParamWithBracketsLegacy(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_brackets', listFormat: ListFormat.brackets)
+  @GET(path: '/list_query_param_with_brackets', listFormat: ListFormat.brackets)
   Future<String> getUsingListQueryParamWithBrackets(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_indices', listFormat: ListFormat.indices)
+  @GET(path: '/list_query_param_with_indices', listFormat: ListFormat.indices)
   Future<String> getUsingListQueryParamWithIndices(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_repeat', listFormat: ListFormat.repeat)
+  @GET(path: '/list_query_param_with_repeat', listFormat: ListFormat.repeat)
   Future<String> getUsingListQueryParamWithRepeat(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_comma', listFormat: ListFormat.comma)
+  @GET(path: '/list_query_param_with_comma', listFormat: ListFormat.comma)
   Future<String> getUsingListQueryParamWithComma(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/map_query_param')
+  @GET(path: '/map_query_param')
   Future<String> getUsingMapQueryParam(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(
+  @GET(
     path: '/map_query_param_include_null_query_vars',
     includeNullQueryVars: true,
   )
@@ -204,32 +204,32 @@ abstract class HttpTestService extends ChopperService {
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_brackets_legacy', useBrackets: true)
+  @GET(path: '/map_query_param_with_brackets_legacy', useBrackets: true)
   Future<String> getUsingMapQueryParamWithBracketsLegacy(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_brackets', listFormat: ListFormat.brackets)
+  @GET(path: '/map_query_param_with_brackets', listFormat: ListFormat.brackets)
   Future<String> getUsingMapQueryParamWithBrackets(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_indices', listFormat: ListFormat.indices)
+  @GET(path: '/map_query_param_with_indices', listFormat: ListFormat.indices)
   Future<String> getUsingMapQueryParamWithIndices(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_repeat', listFormat: ListFormat.repeat)
+  @GET(path: '/map_query_param_with_repeat', listFormat: ListFormat.repeat)
   Future<String> getUsingMapQueryParamWithRepeat(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_comma', listFormat: ListFormat.comma)
+  @GET(path: '/map_query_param_with_comma', listFormat: ListFormat.comma)
   Future<String> getUsingMapQueryParamWithComma(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: 'headers')
+  @GET(path: 'headers')
   Future<String> getHeaders({
     @Header('x-string') required String stringHeader,
     @Header('x-boolean') bool? boolHeader,

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -397,7 +397,7 @@ final class ChopperGenerator
           'Use @Body() annotation on your method parameter to provide a body to your request\n'
           '   e.g.: Future<Response> postRequest(@Body() Map body);\n'
           'Or explicitly suppress this warning by setting the optionalBody property\n'
-          '   e.g.: @Post(optionalBody: true)',
+          '   e.g.: @POST(optionalBody: true)',
         );
       }
 

--- a/chopper_generator/test/test_service.dart
+++ b/chopper_generator/test/test_service.dart
@@ -12,158 +12,158 @@ abstract class HttpTestService extends ChopperService {
   static HttpTestService create([ChopperClient? client]) =>
       _$HttpTestService(client);
 
-  @Get(path: 'get/{id}')
+  @GET(path: 'get/{id}')
   Future<Response<String>> getTest(
     @Path() String id, {
     @Header('test') required String dynamicHeader,
   });
 
-  @Head(path: 'head')
+  @HEAD(path: 'head')
   Future<Response> headTest();
 
-  @Options(path: 'options')
+  @OPTIONS(path: 'options')
   Future<Response> optionsTest();
 
-  @Get(path: 'get')
+  @GET(path: 'get')
   Future<Response<Stream<List<int>>>> getStreamTest();
 
-  @Get(path: '')
+  @GET(path: '')
   Future<Response> getAll();
 
-  @Get(path: '/')
+  @GET(path: '/')
   Future<Response> getAllWithTrailingSlash();
 
-  @Get(path: 'query')
+  @GET(path: 'query')
   Future<Response> getQueryTest({
     @Query('name') String name = '',
     @Query('int') int? number,
     @Query('default_value') int? def = 42,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest(@QueryMap() Map<String, dynamic> query);
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest2(
     @QueryMap() Map<String, dynamic> query, {
     @Query('test') bool? test,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest3({
     @Query('name') String name = '',
     @Query('number') int? number,
     @QueryMap() Map<String, dynamic> filters = const {},
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest4({
     @Query('name') String name = '',
     @Query('number') int? number,
     @QueryMap() Map<String, dynamic>? filters,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest5({
     @QueryMap() Map<String, dynamic>? filters,
   });
 
-  @Get(path: 'get_body')
+  @GET(path: 'get_body')
   Future<Response> getBody(@Body() dynamic body);
 
-  @Post(path: 'post')
+  @POST(path: 'post')
   Future<Response> postTest(@Body() String data);
 
-  @Post(path: 'post')
+  @POST(path: 'post')
   Future<Response> postStreamTest(@Body() Stream<List<int>> byteStream);
 
-  @Put(path: 'put/{id}')
+  @PUT(path: 'put/{id}')
   Future<Response> putTest(@Path('id') String test, @Body() String data);
 
-  @Delete(path: 'delete/{id}', headers: {'foo': 'bar'})
+  @DELETE(path: 'delete/{id}', headers: {'foo': 'bar'})
   Future<Response> deleteTest(@Path() String id);
 
-  @Patch(path: 'patch/{id}')
+  @PATCH(path: 'patch/{id}')
   Future<Response> patchTest(@Path() String id, @Body() String data);
 
-  @Post(path: 'map')
+  @POST(path: 'map')
   Future<Response> mapTest(@Body() Map<String, String> map);
 
   @FactoryConverter(request: convertForm)
-  @Post(path: 'form/body')
+  @POST(path: 'form/body')
   Future<Response> postForm(@Body() Map<String, String> fields);
 
-  @Post(path: 'form/body', headers: {contentTypeKey: formEncodedHeaders})
+  @POST(path: 'form/body', headers: {contentTypeKey: formEncodedHeaders})
   Future<Response> postFormUsingHeaders(@Body() Map<String, String> fields);
 
   @FactoryConverter(request: convertForm)
-  @Post(path: 'form/body/fields')
+  @POST(path: 'form/body/fields')
   Future<Response> postFormFields(@Field() String foo, @Field() int bar);
 
-  @Post(path: 'map/json')
+  @POST(path: 'map/json')
   @FactoryConverter(
     request: customConvertRequest,
     response: customConvertResponse,
   )
   Future<Response> forceJsonTest(@Body() Map map);
 
-  @Post(path: 'multi')
+  @POST(path: 'multi')
   @multipart
   Future<Response> postResources(
     @Part('1') Map a,
     @Part('2') Map b,
   );
 
-  @Post(path: 'formUrlEncoded')
+  @POST(path: 'formUrlEncoded')
   @FormUrlEncoded()
   Future<Response> postFormUrlEncodeBody(
     @Body() HashMap hashMapBody,
     @FieldMap() Map<String, String> map,
   );
 
-  @Post(path: 'formUrlEncoded')
+  @POST(path: 'formUrlEncoded')
   @FormUrlEncoded()
   Future<Response> postFormUrlEncodeField(
     @Field('a') String a,
     @Field('a1') String a2,
   );
 
-  @Post(path: 'formUrlEncoded')
+  @POST(path: 'formUrlEncoded')
   @FormUrlEncoded()
   Future<Response> postFormUrlEncodeFieldMap(
     @FieldMap() Map<String, String> c,
   );
 
-  @Post(path: 'formUrlEncoded')
+  @POST(path: 'formUrlEncoded')
   @FormUrlEncoded()
   Future<Response> postFormUrlEncodeFieldDynamicMap(
     @FieldMap() Map<String, dynamic> c,
   );
 
-  @Post(path: 'file')
+  @POST(path: 'file')
   @multipart
   Future<Response> postFile(
     @PartFile('file') List<int> bytes,
   );
 
-  @Post(path: 'image')
+  @POST(path: 'image')
   @multipart
   Future<Response> postImage(
     @PartFile('image') List<int> imageData,
   );
 
-  @Post(path: 'file')
+  @POST(path: 'file')
   @multipart
   Future<Response> postMultipartFile(
     @PartFile() MultipartFile file, {
     @Part() String? id,
   });
 
-  @Post(path: 'files')
+  @POST(path: 'files')
   @multipart
   Future<Response> postListFiles(@PartFile() List<MultipartFile> files);
 
-  @Post(path: 'multipart_list')
+  @POST(path: 'multipart_list')
   @multipart
   Future<Response> postMultipartList({
     @Part('ints') required List<int> ints,
@@ -172,58 +172,58 @@ abstract class HttpTestService extends ChopperService {
     @Part('strings') required List<String> strings,
   });
 
-  @Get(path: 'https://test.com')
+  @GET(path: 'https://test.com')
   Future<Response> fullUrl();
 
-  @Get(path: '/list/string')
+  @GET(path: '/list/string')
   Future<Response<List<String>>> listString();
 
-  @Post(path: 'no-body')
+  @POST(path: 'no-body')
   Future<Response> noBody();
 
-  @Get(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
+  @GET(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
   Future<Response<String>> getUsingQueryParamIncludeNullQueryVars({
     @Query('foo') String? foo,
     @Query('bar') String? bar,
     @Query('baz') String? baz,
   });
 
-  @Get(path: '/list_query_param')
+  @GET(path: '/list_query_param')
   Future<Response<String>> getUsingListQueryParam(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_brackets_legacy', useBrackets: true)
+  @GET(path: '/list_query_param_with_brackets_legacy', useBrackets: true)
   Future<Response<String>> getUsingListQueryParamWithBracketsLegacy(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_brackets', listFormat: ListFormat.brackets)
+  @GET(path: '/list_query_param_with_brackets', listFormat: ListFormat.brackets)
   Future<Response<String>> getUsingListQueryParamWithBrackets(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_indices', listFormat: ListFormat.indices)
+  @GET(path: '/list_query_param_with_indices', listFormat: ListFormat.indices)
   Future<Response<String>> getUsingListQueryParamWithIndices(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_repeat', listFormat: ListFormat.repeat)
+  @GET(path: '/list_query_param_with_repeat', listFormat: ListFormat.repeat)
   Future<Response<String>> getUsingListQueryParamWithRepeat(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_comma', listFormat: ListFormat.comma)
+  @GET(path: '/list_query_param_with_comma', listFormat: ListFormat.comma)
   Future<Response<String>> getUsingListQueryParamWithComma(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/map_query_param')
+  @GET(path: '/map_query_param')
   Future<Response<String>> getUsingMapQueryParam(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(
+  @GET(
     path: '/map_query_param_include_null_query_vars',
     includeNullQueryVars: true,
   )
@@ -231,32 +231,32 @@ abstract class HttpTestService extends ChopperService {
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_brackets_legacy', useBrackets: true)
+  @GET(path: '/map_query_param_with_brackets_legacy', useBrackets: true)
   Future<Response<String>> getUsingMapQueryParamWithBracketsLegacy(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_brackets', listFormat: ListFormat.brackets)
+  @GET(path: '/map_query_param_with_brackets', listFormat: ListFormat.brackets)
   Future<Response<String>> getUsingMapQueryParamWithBrackets(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_indices', listFormat: ListFormat.indices)
+  @GET(path: '/map_query_param_with_indices', listFormat: ListFormat.indices)
   Future<Response<String>> getUsingMapQueryParamWithIndices(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_repeat', listFormat: ListFormat.repeat)
+  @GET(path: '/map_query_param_with_repeat', listFormat: ListFormat.repeat)
   Future<Response<String>> getUsingMapQueryParamWithRepeat(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_comma', listFormat: ListFormat.comma)
+  @GET(path: '/map_query_param_with_comma', listFormat: ListFormat.comma)
   Future<Response<String>> getUsingMapQueryParamWithComma(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: 'headers')
+  @GET(path: 'headers')
   Future<Response<String>> getHeaders({
     @Header('x-string') required String stringHeader,
     @Header('x-boolean') bool? boolHeader,
@@ -265,7 +265,7 @@ abstract class HttpTestService extends ChopperService {
     @Header('x-enum') ExampleEnum? enumHeader,
   });
 
-  @Post(path: 'publish')
+  @POST(path: 'publish')
   @FactoryConverter(request: FormUrlEncodedConverter.requestFactory)
   Future<Response<void>> publish(
     @Field('review_id') final String reviewId,
@@ -274,19 +274,19 @@ abstract class HttpTestService extends ChopperService {
     @Field() final String? signature,
   ]);
 
-  @Post(path: 'tag')
+  @POST(path: 'tag')
   Future<Response<void>> tag(
     @Field('fool') final String foo,
     @Tag() Object? t1,
   );
 
-  @Get(path: 'get_timeout', timeout: Duration(seconds: 42))
+  @GET(path: 'get_timeout', timeout: Duration(seconds: 42))
   Future<Response<String>> getTimeoutTest();
 
-  @Get(path: 'get_timeout_zero', timeout: Duration(seconds: 0))
+  @GET(path: 'get_timeout_zero', timeout: Duration(seconds: 0))
   Future<Response<String>> getTimeoutTestZero();
 
-  @Get(path: 'get_timeout_neg', timeout: Duration(seconds: -1))
+  @GET(path: 'get_timeout_neg', timeout: Duration(seconds: -1))
   Future<Response<String>> getTimeoutTestNeg();
 }
 

--- a/chopper_generator/test/test_service_variable.dart
+++ b/chopper_generator/test/test_service_variable.dart
@@ -13,132 +13,132 @@ abstract class HttpTestServiceVariable extends ChopperService {
   static HttpTestServiceVariable create([ChopperClient? client]) =>
       _$HttpTestServiceVariable(client);
 
-  @Get(path: 'get/{id}')
+  @GET(path: 'get/{id}')
   Future<Response<String>> getTest(
     @Path() String id, {
     @Header('test') required String dynamicHeader,
   });
 
-  @Head(path: 'head')
+  @HEAD(path: 'head')
   Future<Response> headTest();
 
-  @Options(path: 'options')
+  @OPTIONS(path: 'options')
   Future<Response> optionsTest();
 
-  @Get(path: 'get')
+  @GET(path: 'get')
   Future<Response<Stream<List<int>>>> getStreamTest();
 
-  @Get(path: '')
+  @GET(path: '')
   Future<Response> getAll();
 
-  @Get(path: '/')
+  @GET(path: '/')
   Future<Response> getAllWithTrailingSlash();
 
-  @Get(path: 'query')
+  @GET(path: 'query')
   Future<Response> getQueryTest({
     @Query('name') String name = '',
     @Query('int') int? number,
     @Query('default_value') int? def = 42,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest(@QueryMap() Map<String, dynamic> query);
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest2(
     @QueryMap() Map<String, dynamic> query, {
     @Query('test') bool? test,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest3({
     @Query('name') String name = '',
     @Query('number') int? number,
     @QueryMap() Map<String, dynamic> filters = const {},
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest4({
     @Query('name') String name = '',
     @Query('number') int? number,
     @QueryMap() Map<String, dynamic>? filters,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest5({
     @QueryMap() Map<String, dynamic>? filters,
   });
 
-  @Get(path: 'get_body')
+  @GET(path: 'get_body')
   Future<Response> getBody(@Body() dynamic body);
 
-  @Post(path: 'post')
+  @POST(path: 'post')
   Future<Response> postTest(@Body() String data);
 
-  @Post(path: 'post')
+  @POST(path: 'post')
   Future<Response> postStreamTest(@Body() Stream<List<int>> byteStream);
 
-  @Put(path: 'put/{id}')
+  @PUT(path: 'put/{id}')
   Future<Response> putTest(@Path('id') String test, @Body() String data);
 
-  @Delete(path: 'delete/{id}', headers: {'foo': 'bar'})
+  @DELETE(path: 'delete/{id}', headers: {'foo': 'bar'})
   Future<Response> deleteTest(@Path() String id);
 
-  @Patch(path: 'patch/{id}')
+  @PATCH(path: 'patch/{id}')
   Future<Response> patchTest(@Path() String id, @Body() String data);
 
-  @Post(path: 'map')
+  @POST(path: 'map')
   Future<Response> mapTest(@Body() Map<String, String> map);
 
   @FactoryConverter(request: convertForm)
-  @Post(path: 'form/body')
+  @POST(path: 'form/body')
   Future<Response> postForm(@Body() Map<String, String> fields);
 
-  @Post(path: 'form/body', headers: {contentTypeKey: formEncodedHeaders})
+  @POST(path: 'form/body', headers: {contentTypeKey: formEncodedHeaders})
   Future<Response> postFormUsingHeaders(@Body() Map<String, String> fields);
 
   @FactoryConverter(request: convertForm)
-  @Post(path: 'form/body/fields')
+  @POST(path: 'form/body/fields')
   Future<Response> postFormFields(@Field() String foo, @Field() int bar);
 
-  @Post(path: 'map/json')
+  @POST(path: 'map/json')
   @FactoryConverter(
     request: customConvertRequest,
     response: customConvertResponse,
   )
   Future<Response> forceJsonTest(@Body() Map map);
 
-  @Post(path: 'multi')
+  @POST(path: 'multi')
   @multipart
   Future<Response> postResources(
     @Part('1') Map a,
     @Part('2') Map b,
   );
 
-  @Post(path: 'file')
+  @POST(path: 'file')
   @multipart
   Future<Response> postFile(
     @PartFile('file') List<int> bytes,
   );
 
-  @Post(path: 'image')
+  @POST(path: 'image')
   @multipart
   Future<Response> postImage(
     @PartFile('image') List<int> imageData,
   );
 
-  @Post(path: 'file')
+  @POST(path: 'file')
   @multipart
   Future<Response> postMultipartFile(
     @PartFile() MultipartFile file, {
     @Part() String? id,
   });
 
-  @Post(path: 'files')
+  @POST(path: 'files')
   @multipart
   Future<Response> postListFiles(@PartFile() List<MultipartFile> files);
 
-  @Post(path: 'multipart_list')
+  @POST(path: 'multipart_list')
   @multipart
   Future<Response> postMultipartList({
     @Part('ints') required List<int> ints,
@@ -147,58 +147,58 @@ abstract class HttpTestServiceVariable extends ChopperService {
     @Part('strings') required List<String> strings,
   });
 
-  @Get(path: 'https://test.com')
+  @GET(path: 'https://test.com')
   Future<Response> fullUrl();
 
-  @Get(path: '/list/string')
+  @GET(path: '/list/string')
   Future<Response<List<String>>> listString();
 
-  @Post(path: 'no-body')
+  @POST(path: 'no-body')
   Future<Response> noBody();
 
-  @Get(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
+  @GET(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
   Future<Response<String>> getUsingQueryParamIncludeNullQueryVars({
     @Query('foo') String? foo,
     @Query('bar') String? bar,
     @Query('baz') String? baz,
   });
 
-  @Get(path: '/list_query_param')
+  @GET(path: '/list_query_param')
   Future<Response<String>> getUsingListQueryParam(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_brackets_legacy', useBrackets: true)
+  @GET(path: '/list_query_param_with_brackets_legacy', useBrackets: true)
   Future<Response<String>> getUsingListQueryParamWithBracketsLegacy(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_brackets', listFormat: ListFormat.brackets)
+  @GET(path: '/list_query_param_with_brackets', listFormat: ListFormat.brackets)
   Future<Response<String>> getUsingListQueryParamWithBrackets(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_indices', listFormat: ListFormat.indices)
+  @GET(path: '/list_query_param_with_indices', listFormat: ListFormat.indices)
   Future<Response<String>> getUsingListQueryParamWithIndices(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_repeat', listFormat: ListFormat.repeat)
+  @GET(path: '/list_query_param_with_repeat', listFormat: ListFormat.repeat)
   Future<Response<String>> getUsingListQueryParamWithRepeat(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_comma', listFormat: ListFormat.comma)
+  @GET(path: '/list_query_param_with_comma', listFormat: ListFormat.comma)
   Future<Response<String>> getUsingListQueryParamWithComma(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/map_query_param')
+  @GET(path: '/map_query_param')
   Future<Response<String>> getUsingMapQueryParam(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(
+  @GET(
     path: '/map_query_param_include_null_query_vars',
     includeNullQueryVars: true,
   )
@@ -206,27 +206,27 @@ abstract class HttpTestServiceVariable extends ChopperService {
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_brackets_legacy', useBrackets: true)
+  @GET(path: '/map_query_param_with_brackets_legacy', useBrackets: true)
   Future<Response<String>> getUsingMapQueryParamWithBracketsLegacy(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_brackets', listFormat: ListFormat.brackets)
+  @GET(path: '/map_query_param_with_brackets', listFormat: ListFormat.brackets)
   Future<Response<String>> getUsingMapQueryParamWithBrackets(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_indices', listFormat: ListFormat.indices)
+  @GET(path: '/map_query_param_with_indices', listFormat: ListFormat.indices)
   Future<Response<String>> getUsingMapQueryParamWithIndices(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_repeat', listFormat: ListFormat.repeat)
+  @GET(path: '/map_query_param_with_repeat', listFormat: ListFormat.repeat)
   Future<Response<String>> getUsingMapQueryParamWithRepeat(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_comma', listFormat: ListFormat.comma)
+  @GET(path: '/map_query_param_with_comma', listFormat: ListFormat.comma)
   Future<Response<String>> getUsingMapQueryParamWithComma(
     @Query('value') Map<String, dynamic> value,
   );

--- a/chopper_generator/test/test_without_response_service.dart
+++ b/chopper_generator/test/test_without_response_service.dart
@@ -11,132 +11,132 @@ abstract class HttpTestService extends ChopperService {
   static HttpTestService create([ChopperClient? client]) =>
       _$HttpTestService(client);
 
-  @Get(path: 'get/{id}')
+  @GET(path: 'get/{id}')
   Future<String> getTest(
     @Path() String id, {
     @Header('test') required String dynamicHeader,
   });
 
-  @Head(path: 'head')
+  @HEAD(path: 'head')
   Future headTest();
 
-  @Options(path: 'options')
+  @OPTIONS(path: 'options')
   Future optionsTest();
 
-  @Get(path: 'get')
+  @GET(path: 'get')
   Future<Stream<List<int>>> getStreamTest();
 
-  @Get(path: '')
+  @GET(path: '')
   Future getAll();
 
-  @Get(path: '/')
+  @GET(path: '/')
   Future getAllWithTrailingSlash();
 
-  @Get(path: 'query')
+  @GET(path: 'query')
   Future getQueryTest({
     @Query('name') String name = '',
     @Query('int') int? number,
     @Query('default_value') int? def = 42,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future getQueryMapTest(@QueryMap() Map<String, dynamic> query);
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future getQueryMapTest2(
     @QueryMap() Map<String, dynamic> query, {
     @Query('test') bool? test,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future getQueryMapTest3({
     @Query('name') String name = '',
     @Query('number') int? number,
     @QueryMap() Map<String, dynamic> filters = const {},
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future getQueryMapTest4({
     @Query('name') String name = '',
     @Query('number') int? number,
     @QueryMap() Map<String, dynamic>? filters,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future getQueryMapTest5({
     @QueryMap() Map<String, dynamic>? filters,
   });
 
-  @Get(path: 'get_body')
+  @GET(path: 'get_body')
   Future getBody(@Body() dynamic body);
 
-  @Post(path: 'post')
+  @POST(path: 'post')
   Future postTest(@Body() String data);
 
-  @Post(path: 'post')
+  @POST(path: 'post')
   Future postStreamTest(@Body() Stream<List<int>> byteStream);
 
-  @Put(path: 'put/{id}')
+  @PUT(path: 'put/{id}')
   Future putTest(@Path('id') String test, @Body() String data);
 
-  @Delete(path: 'delete/{id}', headers: {'foo': 'bar'})
+  @DELETE(path: 'delete/{id}', headers: {'foo': 'bar'})
   Future<void> deleteTest(@Path() String id);
 
-  @Patch(path: 'patch/{id}')
+  @PATCH(path: 'patch/{id}')
   Future patchTest(@Path() String id, @Body() String data);
 
-  @Post(path: 'map')
+  @POST(path: 'map')
   Future mapTest(@Body() Map<String, String> map);
 
   @FactoryConverter(request: convertForm)
-  @Post(path: 'form/body')
+  @POST(path: 'form/body')
   Future postForm(@Body() Map<String, String> fields);
 
-  @Post(path: 'form/body', headers: {contentTypeKey: formEncodedHeaders})
+  @POST(path: 'form/body', headers: {contentTypeKey: formEncodedHeaders})
   Future postFormUsingHeaders(@Body() Map<String, String> fields);
 
   @FactoryConverter(request: convertForm)
-  @Post(path: 'form/body/fields')
+  @POST(path: 'form/body/fields')
   Future postFormFields(@Field() String foo, @Field() int bar);
 
-  @Post(path: 'map/json')
+  @POST(path: 'map/json')
   @FactoryConverter(
     request: customConvertRequest,
     response: customConvertResponse,
   )
   Future forceJsonTest(@Body() Map map);
 
-  @Post(path: 'multi')
+  @POST(path: 'multi')
   @multipart
   Future postResources(
     @Part('1') Map a,
     @Part('2') Map b,
   );
 
-  @Post(path: 'file')
+  @POST(path: 'file')
   @multipart
   Future postFile(
     @PartFile('file') List<int> bytes,
   );
 
-  @Post(path: 'image')
+  @POST(path: 'image')
   @multipart
   Future postImage(
     @PartFile('image') List<int> imageData,
   );
 
-  @Post(path: 'file')
+  @POST(path: 'file')
   @multipart
   Future postMultipartFile(
     @PartFile() MultipartFile file, {
     @Part() String? id,
   });
 
-  @Post(path: 'files')
+  @POST(path: 'files')
   @multipart
   Future postListFiles(@PartFile() List<MultipartFile> files);
 
-  @Post(path: 'multipart_list')
+  @POST(path: 'multipart_list')
   @multipart
   Future postMultipartList({
     @Part('ints') required List<int> ints,
@@ -145,58 +145,58 @@ abstract class HttpTestService extends ChopperService {
     @Part('strings') required List<String> strings,
   });
 
-  @Get(path: 'https://test.com')
+  @GET(path: 'https://test.com')
   Future fullUrl();
 
-  @Get(path: '/list/string')
+  @GET(path: '/list/string')
   Future<List<String>> listString();
 
-  @Post(path: 'no-body')
+  @POST(path: 'no-body')
   Future noBody();
 
-  @Get(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
+  @GET(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
   Future<String> getUsingQueryParamIncludeNullQueryVars({
     @Query('foo') String? foo,
     @Query('bar') String? bar,
     @Query('baz') String? baz,
   });
 
-  @Get(path: '/list_query_param')
+  @GET(path: '/list_query_param')
   Future<String> getUsingListQueryParam(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_brackets_legacy', useBrackets: true)
+  @GET(path: '/list_query_param_with_brackets_legacy', useBrackets: true)
   Future<String> getUsingListQueryParamWithBracketsLegacy(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_brackets', listFormat: ListFormat.brackets)
+  @GET(path: '/list_query_param_with_brackets', listFormat: ListFormat.brackets)
   Future<String> getUsingListQueryParamWithBrackets(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_indices', listFormat: ListFormat.indices)
+  @GET(path: '/list_query_param_with_indices', listFormat: ListFormat.indices)
   Future<String> getUsingListQueryParamWithIndices(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_repeat', listFormat: ListFormat.repeat)
+  @GET(path: '/list_query_param_with_repeat', listFormat: ListFormat.repeat)
   Future<String> getUsingListQueryParamWithRepeat(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_comma', listFormat: ListFormat.comma)
+  @GET(path: '/list_query_param_with_comma', listFormat: ListFormat.comma)
   Future<String> getUsingListQueryParamWithComma(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/map_query_param')
+  @GET(path: '/map_query_param')
   Future<String> getUsingMapQueryParam(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(
+  @GET(
     path: '/map_query_param_include_null_query_vars',
     includeNullQueryVars: true,
   )
@@ -204,32 +204,32 @@ abstract class HttpTestService extends ChopperService {
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_brackets_legacy', useBrackets: true)
+  @GET(path: '/map_query_param_with_brackets_legacy', useBrackets: true)
   Future<String> getUsingMapQueryParamWithBracketsLegacy(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_brackets', listFormat: ListFormat.brackets)
+  @GET(path: '/map_query_param_with_brackets', listFormat: ListFormat.brackets)
   Future<String> getUsingMapQueryParamWithBrackets(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_indices', listFormat: ListFormat.indices)
+  @GET(path: '/map_query_param_with_indices', listFormat: ListFormat.indices)
   Future<String> getUsingMapQueryParamWithIndices(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_repeat', listFormat: ListFormat.repeat)
+  @GET(path: '/map_query_param_with_repeat', listFormat: ListFormat.repeat)
   Future<String> getUsingMapQueryParamWithRepeat(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_comma', listFormat: ListFormat.comma)
+  @GET(path: '/map_query_param_with_comma', listFormat: ListFormat.comma)
   Future<String> getUsingMapQueryParamWithComma(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: 'headers')
+  @GET(path: 'headers')
   Future<String> getHeaders({
     @Header('x-string') required String stringHeader,
     @Header('x-boolean') bool? boolHeader,

--- a/example/lib/built_value_resource.dart
+++ b/example/lib/built_value_resource.dart
@@ -40,16 +40,16 @@ abstract class ResourceError
 abstract class MyService extends ChopperService {
   static MyService create([ChopperClient? client]) => _$MyService(client);
 
-  @Get(path: '/{id}/')
+  @GET(path: '/{id}/')
   Future<Response> getResource(@Path() String id);
 
-  @Get(path: '/list')
+  @GET(path: '/list')
   Future<Response<BuiltList<Resource>>> getBuiltListResources();
 
-  @Get(path: '/', headers: {'foo': 'bar'})
+  @GET(path: '/', headers: {'foo': 'bar'})
   Future<Response<Resource>> getTypedResource();
 
-  @Post()
+  @POST()
   Future<Response<Resource>> newResource(
     @Body() Resource resource, {
     @Header() String? name,

--- a/example/lib/json_serializable.dart
+++ b/example/lib/json_serializable.dart
@@ -37,19 +37,19 @@ class ResourceError {
 abstract class MyService extends ChopperService {
   static MyService create([ChopperClient? client]) => _$MyService(client);
 
-  @Get(path: '/{id}/')
+  @GET(path: '/{id}/')
   Future<Response> getResource(@Path() String id);
 
-  @Get(path: '/all', headers: {'test': 'list'})
+  @GET(path: '/all', headers: {'test': 'list'})
   Future<Response<List<Resource>>> getResources();
 
-  @Get(path: '/')
+  @GET(path: '/')
   Future<Response<Map>> getMapResource(@Query() String id);
 
-  @Get(path: '/', headers: {'foo': 'bar'})
+  @GET(path: '/', headers: {'foo': 'bar'})
   Future<Response<Resource>> getTypedResource();
 
-  @Post()
+  @POST()
   Future<Response<Resource>> newResource(
     @Body() Resource resource, {
     @Header() String? name,


### PR DESCRIPTION
This pull request includes changes to the `chopper` library to standardize HTTP method annotations by replacing the old annotations with new uppercase versions and marking the old ones as deprecated. Additionally, it updates the test service to use the new annotations.

Standardization of HTTP method annotations:

* [`chopper/lib/src/annotations.dart`](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6R254-R278): Introduced new uppercase HTTP method annotations (`GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD`, `OPTIONS`) and marked the old ones as deprecated. [[1]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6R254-R278) [[2]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6L269-R308) [[3]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6L279-R319) [[4]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6L289-R356) [[5]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6L307-R386) [[6]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6L317-R397) [[7]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6L327-R426) [[8]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6L336-R436) [[9]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6L346-R473) [[10]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6L364-R510) [[11]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6L382-R520)

* [`chopper/lib/src/annotations.dart`](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6L629-R786): Updated constant definitions to use the new uppercase HTTP method annotations.

Updates to test service:

* [`chopper/test/test_service.dart`](diffhunk://#diff-d0e4b11813c8876585f5c621bbc9167d82deb2d336556232ff7944ceb5a58ebfL16-R141): Replaced all instances of the old HTTP method annotations with the new uppercase versions in the `HttpTestService` class. [[1]](diffhunk://#diff-d0e4b11813c8876585f5c621bbc9167d82deb2d336556232ff7944ceb5a58ebfL16-R141) [[2]](diffhunk://#diff-d0e4b11813c8876585f5c621bbc9167d82deb2d336556232ff7944ceb5a58ebfL150-R239) [[3]](diffhunk://#diff-d0e4b11813c8876585f5c621bbc9167d82deb2d336556232ff7944ceb5a58ebfL248-R248) [[4]](diffhunk://#diff-d0e4b11813c8876585f5c621bbc9167d82deb2d336556232ff7944ceb5a58ebfL257-R263)

--- 

Fixes #632 based on https://github.com/lejard-h/chopper/issues/632#issuecomment-2318857293