### PR TITLE
:bookmark: release v8.1.0

### DIFF
--- a/chopper/CHANGELOG.md
+++ b/chopper/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 8.1.0
+
+- Deprecate all lower-case method annotations ([#651](https://github.com/lejard-h/chopper/pull/651))
+
 ## 8.0.4
 
 - Update dependencies

--- a/chopper/lib/src/annotations.dart
+++ b/chopper/lib/src/annotations.dart
@@ -115,10 +115,10 @@ final class QueryMap {
 }
 
 /// {@template Body}
-/// Declares the Body of [Post], [Put], and [Patch] requests
+/// Declares the Body of [POST], [PUT], and [PATCH] requests
 ///
 /// ```dart
-/// @Post()
+/// @POST()
 /// Future<Response> post(@Body() Map<String, dynamic> body);
 /// ```
 ///
@@ -163,7 +163,7 @@ final class Header {
 /// Must be used inside a [ChopperApi] definition.
 ///
 /// Recommended:
-/// [Get], [Post], [Put], [Delete], [Patch], or [Head] should be used instead.
+/// [GET], [POST], [PUT], [DELETE], [PATCH], or [HEAD] should be used instead.
 ///
 /// ```dart
 /// @Get(headers: const {'foo': 'bar' })
@@ -251,14 +251,14 @@ sealed class Method {
   });
 }
 
-/// {@template Get}
+/// {@template GET}
 /// Defines a method as an HTTP GET request.
 /// {@endtemplate}
 @immutable
 @Target({TargetKind.method})
-final class Get extends Method {
-  /// {@macro Get}
-  const Get({
+final class GET extends Method {
+  /// {@macro GET}
+  const GET({
     super.optionalBody = true,
     super.path,
     super.headers,
@@ -269,16 +269,35 @@ final class Get extends Method {
   }) : super(HttpMethod.Get);
 }
 
-/// {@template Post}
+/// {@template Get}
+/// Defines a method as an HTTP GET request.
+/// {@endtemplate}
+@immutable
+@Target({TargetKind.method})
+@Deprecated('Use GET instead')
+final class Get extends GET {
+  /// {@macro Get}
+  const Get({
+    super.optionalBody = true,
+    super.path,
+    super.headers,
+    super.listFormat,
+    super.useBrackets,
+    super.includeNullQueryVars,
+    super.timeout,
+  });
+}
+
+/// {@template POST}
 /// Defines a method as an HTTP POST request.
 ///
 /// Use the [Body] annotation to pass data to send.
 /// {@endtemplate}
 @immutable
 @Target({TargetKind.method})
-final class Post extends Method {
-  /// {@macro Post}
-  const Post({
+final class POST extends Method {
+  /// {@macro POST}
+  const POST({
     super.optionalBody,
     super.path,
     super.headers,
@@ -289,14 +308,35 @@ final class Post extends Method {
   }) : super(HttpMethod.Post);
 }
 
-/// {@template Delete}
+/// {@template Post}
+/// Defines a method as an HTTP POST request.
+///
+/// Use the [Body] annotation to pass data to send.
+/// {@endtemplate}
+@immutable
+@Target({TargetKind.method})
+@Deprecated('Use POST instead')
+final class Post extends POST {
+  /// {@macro Post}
+  const Post({
+    super.optionalBody,
+    super.path,
+    super.headers,
+    super.listFormat,
+    super.useBrackets,
+    super.includeNullQueryVars,
+    super.timeout,
+  });
+}
+
+/// {@template DELETE}
 /// Defines a method as an HTTP DELETE request.
 /// {@endtemplate}
 @immutable
 @Target({TargetKind.method})
-final class Delete extends Method {
-  /// {@macro Delete}
-  const Delete({
+final class DELETE extends Method {
+  /// {@macro DELETE}
+  const DELETE({
     super.optionalBody = true,
     super.path,
     super.headers,
@@ -307,16 +347,35 @@ final class Delete extends Method {
   }) : super(HttpMethod.Delete);
 }
 
-/// {@template Put}
+/// {@template Delete}
+/// Defines a method as an HTTP DELETE request.
+/// {@endtemplate}
+@immutable
+@Target({TargetKind.method})
+@Deprecated('Use DELETE instead')
+final class Delete extends DELETE {
+  /// {@macro Delete}
+  const Delete({
+    super.optionalBody = true,
+    super.path,
+    super.headers,
+    super.listFormat,
+    super.useBrackets,
+    super.includeNullQueryVars,
+    super.timeout,
+  });
+}
+
+/// {@template PUT}
 /// Defines a method as an HTTP PUT request.
 ///
 /// Use the [Body] annotation to pass data to send.
 /// {@endtemplate}
 @immutable
 @Target({TargetKind.method})
-final class Put extends Method {
-  /// {@macro Put}
-  const Put({
+final class PUT extends Method {
+  /// {@macro PUT}
+  const PUT({
     super.optionalBody,
     super.path,
     super.headers,
@@ -327,15 +386,36 @@ final class Put extends Method {
   }) : super(HttpMethod.Put);
 }
 
-/// {@template Patch}
+/// {@template Put}
+/// Defines a method as an HTTP PUT request.
+///
+/// Use the [Body] annotation to pass data to send.
+/// {@endtemplate}
+@immutable
+@Target({TargetKind.method})
+@Deprecated('Use PUT instead')
+final class Put extends PUT {
+  /// {@macro Put}
+  const Put({
+    super.optionalBody,
+    super.path,
+    super.headers,
+    super.listFormat,
+    super.useBrackets,
+    super.includeNullQueryVars,
+    super.timeout,
+  });
+}
+
+/// {@template PATCH}
 /// Defines a method as an HTTP PATCH request.
 /// Use the [Body] annotation to pass data to send.
 /// {@endtemplate}
 @immutable
 @Target({TargetKind.method})
-final class Patch extends Method {
-  /// {@macro Patch}
-  const Patch({
+final class PATCH extends Method {
+  /// {@macro PATCH}
+  const PATCH({
     super.optionalBody,
     super.path,
     super.headers,
@@ -346,14 +426,34 @@ final class Patch extends Method {
   }) : super(HttpMethod.Patch);
 }
 
-/// {@template Head}
+/// {@template Patch}
+/// Defines a method as an HTTP PATCH request.
+/// Use the [Body] annotation to pass data to send.
+/// {@endtemplate}
+@immutable
+@Target({TargetKind.method})
+@Deprecated('Use PATCH instead')
+final class Patch extends PATCH {
+  /// {@macro Patch}
+  const Patch({
+    super.optionalBody,
+    super.path,
+    super.headers,
+    super.listFormat,
+    super.useBrackets,
+    super.includeNullQueryVars,
+    super.timeout,
+  });
+}
+
+/// {@template HEAD}
 /// Defines a method as an HTTP HEAD request.
 /// {@endtemplate}
 @immutable
 @Target({TargetKind.method})
-final class Head extends Method {
-  /// {@macro Head}
-  const Head({
+final class HEAD extends Method {
+  /// {@macro HEAD}
+  const HEAD({
     super.optionalBody = true,
     super.path,
     super.headers,
@@ -364,12 +464,50 @@ final class Head extends Method {
   }) : super(HttpMethod.Head);
 }
 
+/// {@template Head}
+/// Defines a method as an HTTP HEAD request.
+/// {@endtemplate}
+@immutable
+@Target({TargetKind.method})
+@Deprecated('Use HEAD instead')
+final class Head extends HEAD {
+  /// {@macro Head}
+  const Head({
+    super.optionalBody = true,
+    super.path,
+    super.headers,
+    super.listFormat,
+    super.useBrackets,
+    super.includeNullQueryVars,
+    super.timeout,
+  });
+}
+
+/// {@template OPTIONS}
+/// Defines a method as an HTTP OPTIONS request.
+/// {@endtemplate}
+@immutable
+@Target({TargetKind.method})
+final class OPTIONS extends Method {
+  /// {@macro OPTIONS}
+  const OPTIONS({
+    super.optionalBody = true,
+    super.path,
+    super.headers,
+    super.listFormat,
+    super.useBrackets,
+    super.includeNullQueryVars,
+    super.timeout,
+  }) : super(HttpMethod.Options);
+}
+
 /// {@template Options}
 /// Defines a method as an HTTP OPTIONS request.
 /// {@endtemplate}
 @immutable
 @Target({TargetKind.method})
-final class Options extends Method {
+@Deprecated('Use OPTIONS instead')
+final class Options extends OPTIONS {
   /// {@macro Options}
   const Options({
     super.optionalBody = true,
@@ -379,7 +517,7 @@ final class Options extends Method {
     super.useBrackets,
     super.includeNullQueryVars,
     super.timeout,
-  }) : super(HttpMethod.Options);
+  });
 }
 
 /// A function that should convert the body of a [Request] to the HTTP representation.
@@ -626,26 +764,26 @@ const queryMap = QueryMap();
 /// {@macro Header}
 const header = Header();
 
-/// {@macro Get}
-const get = Get();
+/// {@macro GET}
+const get = GET();
 
-/// {@macro Post}
-const post = Post();
+/// {@macro POST}
+const post = POST();
 
-/// {@macro Delete}
-const delete = Delete();
+/// {@macro DELETE}
+const delete = DELETE();
 
-/// {@macro Put}
-const put = Put();
+/// {@macro PUT}
+const put = PUT();
 
-/// {@macro Patch}
-const patch = Patch();
+/// {@macro PATCH}
+const patch = PATCH();
 
-/// {@macro Head}
-const head = Head();
+/// {@macro HEAD}
+const head = HEAD();
 
-/// {@macro Options}
-const options = Options();
+/// {@macro OPTIONS}
+const options = OPTIONS();
 
 /// {@macro FactoryConverter}
 const factoryConverter = FactoryConverter();

--- a/chopper/lib/src/annotations.dart
+++ b/chopper/lib/src/annotations.dart
@@ -42,12 +42,12 @@ final class ChopperApi {
 ///
 /// Declared as follows inside the path String:
 /// ```dart
-/// @Get(path: '/{param}')
+/// @GET(path: '/{param}')
 /// ```
 ///
 /// Available inside method declaration:
 /// ```dart
-/// @Get(path: '/{param}')
+/// @GET(path: '/{param}')
 /// Future<Response> fetch(@Path() String param);
 /// ```
 /// {@endtemplate}
@@ -57,7 +57,7 @@ final class Path {
   /// Name is used to bind a method parameter to
   /// a URL path parameter.
   /// ```dart
-  /// @Get(path: '/{param}')
+  /// @GET(path: '/{param}')
   /// Future<Response> fetch(@Path('param') String hello);
   /// ```
   final String? name;
@@ -72,7 +72,7 @@ final class Path {
 /// [Query] is used to add query parameters after the request url.
 /// Example: /something?id=42
 /// ```dart
-/// @Get(path: '/something')
+/// @GET(path: '/something')
 /// Future<Response> fetch({@Query() String id});
 /// ```
 ///
@@ -84,7 +84,7 @@ final class Query {
   /// Name is used to bind a method parameter to
   /// the query parameter.
   /// ```dart
-  /// @Get(path: '/something')
+  /// @GET(path: '/something')
   /// Future<Response> fetch({@Query('id') String mySuperId});
   /// ```
   final String? name;
@@ -97,7 +97,7 @@ final class Query {
 /// Provides query parameters of a request as [Map<String, dynamic>].
 ///
 /// ```dart
-/// @Get(path: '/something')
+/// @GET(path: '/something')
 /// Future<Response> fetch(@QueryMap() Map<String, dynamic> query);
 /// ```
 ///
@@ -138,7 +138,7 @@ final class Body {
 /// Use the name of the method parameter or the name specified in the annotation.
 ///
 /// ```dart
-/// @Get()
+/// @GET()
 /// Future<Response> fetch(@Header() String foo);
 /// ```
 /// {@endtemplate}
@@ -148,7 +148,7 @@ final class Header {
   /// Name is used to bind a method parameter to
   /// a header name.
   /// ```dart
-  /// @Get()
+  /// @GET()
   /// Future<Response> fetch(@Header('foo') String headerFoo);
   /// ```
   final String? name;
@@ -166,7 +166,7 @@ final class Header {
 /// [GET], [POST], [PUT], [DELETE], [PATCH], or [HEAD] should be used instead.
 ///
 /// ```dart
-/// @Get(headers: const {'foo': 'bar' })
+/// @GET(headers: const {'foo': 'bar' })
 /// Future<Response> myGetRequest();
 /// ```
 ///
@@ -215,7 +215,7 @@ sealed class Method {
   /// NOTE: Empty strings are always included.
   ///
   /// ```dart
-  /// @Get(
+  /// @GET(
   ///   path: '/script',
   ///   includeNullQueryVars: true,
   /// )
@@ -549,7 +549,7 @@ typedef ConvertResponse<T> = FutureOr<Response<T>> Function(Response response);
 ///     );
 ///   }
 ///
-///   @Get(path: "/{id}")
+///   @GET(path: "/{id}")
 ///   @FactoryConverter(
 ///     request: customRequestConverter,
 ///     response: customResponseConverter
@@ -576,7 +576,7 @@ final class FactoryConverter {
 /// Automatically binds to the name of the method parameter.
 ///
 /// ```dart
-/// @Post(path: '/')
+/// @POST(path: '/')
 /// Future<Response> create(@Field() String name);
 /// ```
 /// Will be converted to `{ 'name': value }`.
@@ -586,7 +586,7 @@ final class FactoryConverter {
 final class Field {
   /// Name can be use to specify the name of the field
   /// ```dart
-  /// @Post(path: '/')
+  /// @POST(path: '/')
   /// Future<Response> create(@Field('id') String myId);
   /// ```
   final String? name;
@@ -599,7 +599,7 @@ final class Field {
 /// Provides field parameters of a request as [Map<String, dynamic>].
 ///
 /// ```dart
-/// @Post(path: '/something')
+/// @POST(path: '/something')
 /// Future<Response> fetch(@FieldMap Map<String, dynamic> query);
 /// ```
 /// {@endtemplate}
@@ -614,7 +614,7 @@ final class FieldMap {
 /// Defines a multipart request.
 ///
 /// ```dart
-/// @Post(path: '/')
+/// @POST(path: '/')
 /// @Multipart()
 /// Future<Response> create(@Part() String name);
 /// ```
@@ -649,7 +649,7 @@ final class Part {
 /// Provides part parameters of a request as [PartValue].
 ///
 /// ```dart
-/// @Post(path: '/something')
+/// @POST(path: '/something')
 /// @Multipart
 /// Future<Response> fetch(@PartMap() List<PartValue> query);
 /// ```
@@ -665,7 +665,7 @@ final class PartMap {
 /// Use [PartFile] to define a file field for a [Multipart] request.
 ///
 /// ```dart
-/// @Post(path: 'file')
+/// @POST(path: 'file')
 /// @multipart
 /// Future<Response> postFile(@PartFile('file') List<int> bytes);
 /// ```
@@ -688,7 +688,7 @@ final class PartFile {
 /// Provides partFile parameters of a request as [PartValueFile].
 ///
 /// ```dart
-/// @Post(path: '/something')
+/// @POST(path: '/something')
 /// @Multipart
 /// Future<Response> fetch(@PartFileMap() List<PartValueFile> query);
 /// ```
@@ -712,7 +712,7 @@ final class PartFileMap {
 ///
 ///
 /// ```dart
-/// @Post(path: '/something')
+/// @POST(path: '/something')
 /// @FormUrlEncoded
 /// Future<Response> fetch(@Field("param") String? param);
 /// ```

--- a/chopper/lib/src/converters.dart
+++ b/chopper/lib/src/converters.dart
@@ -58,7 +58,7 @@ abstract interface class ErrorConverter {
 /// This `Converter` also adds the `content-type: application/json` header to each request.
 ///
 /// If content type header is modified (for example by using
-/// `@Post(headers: {'content-type': '...'})`), `JsonConverter` won't add the
+/// `@POST(headers: {'content-type': '...'})`), `JsonConverter` won't add the
 /// header and it won't call json.encode if content type is not JSON.
 /// {@endtemplate}
 @immutable

--- a/chopper/lib/src/response.dart
+++ b/chopper/lib/src/response.dart
@@ -9,12 +9,12 @@ import 'package:meta/meta.dart';
 /// A [http.BaseResponse] wrapper representing a response of a Chopper network call.
 ///
 /// ```dart
-/// @Get(path: '/something')
+/// @GET(path: '/something')
 /// Future<Response> fetchSomething();
 /// ```
 ///
 /// ```dart
-/// @Get(path: '/items/{id}')
+/// @GET(path: '/items/{id}')
 /// Future<Response<Item>> fetchItem();
 /// ```
 /// {@endtemplate}

--- a/chopper/pubspec.yaml
+++ b/chopper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chopper
 description: Chopper is an http client generator using source_gen, inspired by Retrofit
-version: 8.0.4
+version: 8.1.0
 documentation: https://hadrien-lejard.gitbook.io/chopper
 repository: https://github.com/lejard-h/chopper
 

--- a/chopper/test/test_service.dart
+++ b/chopper/test/test_service.dart
@@ -13,132 +13,132 @@ abstract class HttpTestService extends ChopperService {
   static HttpTestService create([ChopperClient? client]) =>
       _$HttpTestService(client);
 
-  @Get(path: 'get/{id}')
+  @GET(path: 'get/{id}')
   Future<Response<String>> getTest(
     @Path() String id, {
     @Header('test') required String dynamicHeader,
   });
 
-  @Head(path: 'head')
+  @HEAD(path: 'head')
   Future<Response> headTest();
 
-  @Options(path: 'options')
+  @OPTIONS(path: 'options')
   Future<Response> optionsTest();
 
-  @Get(path: 'get')
+  @GET(path: 'get')
   Future<Response<Stream<List<int>>>> getStreamTest();
 
-  @Get(path: '')
+  @GET(path: '')
   Future<Response> getAll();
 
-  @Get(path: '/')
+  @GET(path: '/')
   Future<Response> getAllWithTrailingSlash();
 
-  @Get(path: 'query')
+  @GET(path: 'query')
   Future<Response> getQueryTest({
     @Query('name') String name = '',
     @Query('int') int? number,
     @Query('default_value') int? def = 42,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest(@QueryMap() Map<String, dynamic> query);
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest2(
     @QueryMap() Map<String, dynamic> query, {
     @Query('test') bool? test,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest3({
     @Query('name') String name = '',
     @Query('number') int? number,
     @QueryMap() Map<String, dynamic> filters = const {},
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest4({
     @Query('name') String name = '',
     @Query('number') int? number,
     @QueryMap() Map<String, dynamic>? filters,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest5({
     @QueryMap() Map<String, dynamic>? filters,
   });
 
-  @Get(path: 'get_body')
+  @GET(path: 'get_body')
   Future<Response> getBody(@Body() dynamic body);
 
-  @Post(path: 'post')
+  @POST(path: 'post')
   Future<Response> postTest(@Body() String data);
 
-  @Post(path: 'post')
+  @POST(path: 'post')
   Future<Response> postStreamTest(@Body() Stream<List<int>> byteStream);
 
-  @Put(path: 'put/{id}')
+  @PUT(path: 'put/{id}')
   Future<Response> putTest(@Path('id') String test, @Body() String data);
 
-  @Delete(path: 'delete/{id}', headers: {'foo': 'bar'})
+  @DELETE(path: 'delete/{id}', headers: {'foo': 'bar'})
   Future<Response> deleteTest(@Path() String id);
 
-  @Patch(path: 'patch/{id}')
+  @PATCH(path: 'patch/{id}')
   Future<Response> patchTest(@Path() String id, @Body() String data);
 
-  @Post(path: 'map')
+  @POST(path: 'map')
   Future<Response> mapTest(@Body() Map<String, String> map);
 
   @FactoryConverter(request: convertForm)
-  @Post(path: 'form/body')
+  @POST(path: 'form/body')
   Future<Response> postForm(@Body() Map<String, String> fields);
 
-  @Post(path: 'form/body', headers: {contentTypeKey: formEncodedHeaders})
+  @POST(path: 'form/body', headers: {contentTypeKey: formEncodedHeaders})
   Future<Response> postFormUsingHeaders(@Body() Map<String, String> fields);
 
   @FactoryConverter(request: convertForm)
-  @Post(path: 'form/body/fields')
+  @POST(path: 'form/body/fields')
   Future<Response> postFormFields(@Field() String foo, @Field() int bar);
 
-  @Post(path: 'map/json')
+  @POST(path: 'map/json')
   @FactoryConverter(
     request: customConvertRequest,
     response: customConvertResponse,
   )
   Future<Response> forceJsonTest(@Body() Map map);
 
-  @Post(path: 'multi')
+  @POST(path: 'multi')
   @multipart
   Future<Response> postResources(
     @Part('1') Map a,
     @Part('2') Map b,
   );
 
-  @Post(path: 'file')
+  @POST(path: 'file')
   @multipart
   Future<Response> postFile(
     @PartFile('file') List<int> bytes,
   );
 
-  @Post(path: 'image')
+  @POST(path: 'image')
   @multipart
   Future<Response> postImage(
     @PartFile('image') List<int> imageData,
   );
 
-  @Post(path: 'file')
+  @POST(path: 'file')
   @multipart
   Future<Response> postMultipartFile(
     @PartFile() MultipartFile file, {
     @Part() String? id,
   });
 
-  @Post(path: 'files')
+  @POST(path: 'files')
   @multipart
   Future<Response> postListFiles(@PartFile() List<MultipartFile> files);
 
-  @Post(path: 'multipart_list')
+  @POST(path: 'multipart_list')
   @multipart
   Future<Response> postMultipartList({
     @Part('ints') required List<int> ints,
@@ -147,58 +147,58 @@ abstract class HttpTestService extends ChopperService {
     @Part('strings') required List<String> strings,
   });
 
-  @Get(path: 'https://test.com')
+  @GET(path: 'https://test.com')
   Future<Response> fullUrl();
 
-  @Get(path: '/list/string')
+  @GET(path: '/list/string')
   Future<Response<List<String>>> listString();
 
-  @Post(path: 'no-body')
+  @POST(path: 'no-body')
   Future<Response> noBody();
 
-  @Get(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
+  @GET(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
   Future<Response<String>> getUsingQueryParamIncludeNullQueryVars({
     @Query('foo') String? foo,
     @Query('bar') String? bar,
     @Query('baz') String? baz,
   });
 
-  @Get(path: '/list_query_param')
+  @GET(path: '/list_query_param')
   Future<Response<String>> getUsingListQueryParam(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_brackets_legacy', useBrackets: true)
+  @GET(path: '/list_query_param_with_brackets_legacy', useBrackets: true)
   Future<Response<String>> getUsingListQueryParamWithBracketsLegacy(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_brackets', listFormat: ListFormat.brackets)
+  @GET(path: '/list_query_param_with_brackets', listFormat: ListFormat.brackets)
   Future<Response<String>> getUsingListQueryParamWithBrackets(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_indices', listFormat: ListFormat.indices)
+  @GET(path: '/list_query_param_with_indices', listFormat: ListFormat.indices)
   Future<Response<String>> getUsingListQueryParamWithIndices(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_repeat', listFormat: ListFormat.repeat)
+  @GET(path: '/list_query_param_with_repeat', listFormat: ListFormat.repeat)
   Future<Response<String>> getUsingListQueryParamWithRepeat(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_comma', listFormat: ListFormat.comma)
+  @GET(path: '/list_query_param_with_comma', listFormat: ListFormat.comma)
   Future<Response<String>> getUsingListQueryParamWithComma(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/map_query_param')
+  @GET(path: '/map_query_param')
   Future<Response<String>> getUsingMapQueryParam(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(
+  @GET(
     path: '/map_query_param_include_null_query_vars',
     includeNullQueryVars: true,
   )
@@ -206,37 +206,37 @@ abstract class HttpTestService extends ChopperService {
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_brackets_legacy', useBrackets: true)
+  @GET(path: '/map_query_param_with_brackets_legacy', useBrackets: true)
   Future<Response<String>> getUsingMapQueryParamWithBracketsLegacy(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_brackets', listFormat: ListFormat.brackets)
+  @GET(path: '/map_query_param_with_brackets', listFormat: ListFormat.brackets)
   Future<Response<String>> getUsingMapQueryParamWithBrackets(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_indices', listFormat: ListFormat.indices)
+  @GET(path: '/map_query_param_with_indices', listFormat: ListFormat.indices)
   Future<Response<String>> getUsingMapQueryParamWithIndices(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_repeat', listFormat: ListFormat.repeat)
+  @GET(path: '/map_query_param_with_repeat', listFormat: ListFormat.repeat)
   Future<Response<String>> getUsingMapQueryParamWithRepeat(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_comma', listFormat: ListFormat.comma)
+  @GET(path: '/map_query_param_with_comma', listFormat: ListFormat.comma)
   Future<Response<String>> getUsingMapQueryParamWithComma(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/date_time')
+  @GET(path: '/date_time')
   Future<Response<String>> getDateTime(
     @Query('value') DateTime value,
   );
 
-  @Get(path: 'headers')
+  @GET(path: 'headers')
   Future<Response<String>> getHeaders({
     @Header('x-string') required String stringHeader,
     @Header('x-boolean') bool? boolHeader,
@@ -245,7 +245,7 @@ abstract class HttpTestService extends ChopperService {
     @Header('x-enum') ExampleEnum? enumHeader,
   });
 
-  @Post(path: 'publish')
+  @POST(path: 'publish')
   @FactoryConverter(request: FormUrlEncodedConverter.requestFactory)
   Future<Response<void>> publish(
     @Field('review_id') final String reviewId,
@@ -254,13 +254,13 @@ abstract class HttpTestService extends ChopperService {
     @Field() final String? signature,
   ]);
 
-  @Get(path: 'get_timeout', timeout: Duration(seconds: 42))
+  @GET(path: 'get_timeout', timeout: Duration(seconds: 42))
   Future<Response<String>> getTimeoutTest();
 
-  @Get(path: 'get_timeout_zero', timeout: Duration(seconds: 0))
+  @GET(path: 'get_timeout_zero', timeout: Duration(seconds: 0))
   Future<Response<String>> getTimeoutTestZero();
 
-  @Get(path: 'get_timeout_neg', timeout: Duration(seconds: -1))
+  @GET(path: 'get_timeout_neg', timeout: Duration(seconds: -1))
   Future<Response<String>> getTimeoutTestNeg();
 }
 

--- a/chopper/test/test_service_base_url.dart
+++ b/chopper/test/test_service_base_url.dart
@@ -10,58 +10,58 @@ abstract class HttpTestServiceBaseUrl extends ChopperService {
   static HttpTestServiceBaseUrl create([ChopperClient? client]) =>
       _$HttpTestServiceBaseUrl(client);
 
-  @Get(path: '')
+  @GET(path: '')
   Future<Response> getAll();
 
-  @Get(path: '/')
+  @GET(path: '/')
   Future<Response> getAllWithTrailingSlash();
 
-  @Get(path: '/list/string')
+  @GET(path: '/list/string')
   Future<Response<List<String>>> listString();
 
-  @Get(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
+  @GET(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
   Future<Response<String>> getUsingQueryParamIncludeNullQueryVars({
     @Query('foo') String? foo,
     @Query('bar') String? bar,
     @Query('baz') String? baz,
   });
 
-  @Get(path: '/list_query_param')
+  @GET(path: '/list_query_param')
   Future<Response<String>> getUsingListQueryParam(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_brackets_legacy', useBrackets: true)
+  @GET(path: '/list_query_param_with_brackets_legacy', useBrackets: true)
   Future<Response<String>> getUsingListQueryParamWithBracketsLegacy(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_brackets', listFormat: ListFormat.brackets)
+  @GET(path: '/list_query_param_with_brackets', listFormat: ListFormat.brackets)
   Future<Response<String>> getUsingListQueryParamWithBrackets(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_indices', listFormat: ListFormat.indices)
+  @GET(path: '/list_query_param_with_indices', listFormat: ListFormat.indices)
   Future<Response<String>> getUsingListQueryParamWithIndices(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_repeat', listFormat: ListFormat.repeat)
+  @GET(path: '/list_query_param_with_repeat', listFormat: ListFormat.repeat)
   Future<Response<String>> getUsingListQueryParamWithRepeat(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_comma', listFormat: ListFormat.comma)
+  @GET(path: '/list_query_param_with_comma', listFormat: ListFormat.comma)
   Future<Response<String>> getUsingListQueryParamWithComma(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/map_query_param')
+  @GET(path: '/map_query_param')
   Future<Response<String>> getUsingMapQueryParam(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(
+  @GET(
     path: '/map_query_param_include_null_query_vars',
     includeNullQueryVars: true,
   )
@@ -69,27 +69,27 @@ abstract class HttpTestServiceBaseUrl extends ChopperService {
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_brackets_legacy', useBrackets: true)
+  @GET(path: '/map_query_param_with_brackets_legacy', useBrackets: true)
   Future<Response<String>> getUsingMapQueryParamWithBracketsLegacy(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_brackets', listFormat: ListFormat.brackets)
+  @GET(path: '/map_query_param_with_brackets', listFormat: ListFormat.brackets)
   Future<Response<String>> getUsingMapQueryParamWithBrackets(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_indices', listFormat: ListFormat.indices)
+  @GET(path: '/map_query_param_with_indices', listFormat: ListFormat.indices)
   Future<Response<String>> getUsingMapQueryParamWithIndices(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_repeat', listFormat: ListFormat.repeat)
+  @GET(path: '/map_query_param_with_repeat', listFormat: ListFormat.repeat)
   Future<Response<String>> getUsingMapQueryParamWithRepeat(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_comma', listFormat: ListFormat.comma)
+  @GET(path: '/map_query_param_with_comma', listFormat: ListFormat.comma)
   Future<Response<String>> getUsingMapQueryParamWithComa(
     @Query('value') Map<String, dynamic> value,
   );

--- a/chopper/test/test_service_variable.dart
+++ b/chopper/test/test_service_variable.dart
@@ -13,132 +13,132 @@ abstract class HttpTestServiceVariable extends ChopperService {
   static HttpTestServiceVariable create([ChopperClient? client]) =>
       _$HttpTestServiceVariable(client);
 
-  @Get(path: 'get/{id}')
+  @GET(path: 'get/{id}')
   Future<Response<String>> getTest(
     @Path() String id, {
     @Header('test') required String dynamicHeader,
   });
 
-  @Head(path: 'head')
+  @HEAD(path: 'head')
   Future<Response> headTest();
 
-  @Options(path: 'options')
+  @OPTIONS(path: 'options')
   Future<Response> optionsTest();
 
-  @Get(path: 'get')
+  @GET(path: 'get')
   Future<Response<Stream<List<int>>>> getStreamTest();
 
-  @Get(path: '')
+  @GET(path: '')
   Future<Response> getAll();
 
-  @Get(path: '/')
+  @GET(path: '/')
   Future<Response> getAllWithTrailingSlash();
 
-  @Get(path: 'query')
+  @GET(path: 'query')
   Future<Response> getQueryTest({
     @Query('name') String name = '',
     @Query('int') int? number,
     @Query('default_value') int? def = 42,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest(@QueryMap() Map<String, dynamic> query);
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest2(
     @QueryMap() Map<String, dynamic> query, {
     @Query('test') bool? test,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest3({
     @Query('name') String name = '',
     @Query('number') int? number,
     @QueryMap() Map<String, dynamic> filters = const {},
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest4({
     @Query('name') String name = '',
     @Query('number') int? number,
     @QueryMap() Map<String, dynamic>? filters,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest5({
     @QueryMap() Map<String, dynamic>? filters,
   });
 
-  @Get(path: 'get_body')
+  @GET(path: 'get_body')
   Future<Response> getBody(@Body() dynamic body);
 
-  @Post(path: 'post')
+  @POST(path: 'post')
   Future<Response> postTest(@Body() String data);
 
-  @Post(path: 'post')
+  @POST(path: 'post')
   Future<Response> postStreamTest(@Body() Stream<List<int>> byteStream);
 
-  @Put(path: 'put/{id}')
+  @PUT(path: 'put/{id}')
   Future<Response> putTest(@Path('id') String test, @Body() String data);
 
-  @Delete(path: 'delete/{id}', headers: {'foo': 'bar'})
+  @DELETE(path: 'delete/{id}', headers: {'foo': 'bar'})
   Future<Response> deleteTest(@Path() String id);
 
-  @Patch(path: 'patch/{id}')
+  @PATCH(path: 'patch/{id}')
   Future<Response> patchTest(@Path() String id, @Body() String data);
 
-  @Post(path: 'map')
+  @POST(path: 'map')
   Future<Response> mapTest(@Body() Map<String, String> map);
 
   @FactoryConverter(request: convertForm)
-  @Post(path: 'form/body')
+  @POST(path: 'form/body')
   Future<Response> postForm(@Body() Map<String, String> fields);
 
-  @Post(path: 'form/body', headers: {contentTypeKey: formEncodedHeaders})
+  @POST(path: 'form/body', headers: {contentTypeKey: formEncodedHeaders})
   Future<Response> postFormUsingHeaders(@Body() Map<String, String> fields);
 
   @FactoryConverter(request: convertForm)
-  @Post(path: 'form/body/fields')
+  @POST(path: 'form/body/fields')
   Future<Response> postFormFields(@Field() String foo, @Field() int bar);
 
-  @Post(path: 'map/json')
+  @POST(path: 'map/json')
   @FactoryConverter(
     request: customConvertRequest,
     response: customConvertResponse,
   )
   Future<Response> forceJsonTest(@Body() Map map);
 
-  @Post(path: 'multi')
+  @POST(path: 'multi')
   @multipart
   Future<Response> postResources(
     @Part('1') Map a,
     @Part('2') Map b,
   );
 
-  @Post(path: 'file')
+  @POST(path: 'file')
   @multipart
   Future<Response> postFile(
     @PartFile('file') List<int> bytes,
   );
 
-  @Post(path: 'image')
+  @POST(path: 'image')
   @multipart
   Future<Response> postImage(
     @PartFile('image') List<int> imageData,
   );
 
-  @Post(path: 'file')
+  @POST(path: 'file')
   @multipart
   Future<Response> postMultipartFile(
     @PartFile() MultipartFile file, {
     @Part() String? id,
   });
 
-  @Post(path: 'files')
+  @POST(path: 'files')
   @multipart
   Future<Response> postListFiles(@PartFile() List<MultipartFile> files);
 
-  @Post(path: 'multipart_list')
+  @POST(path: 'multipart_list')
   @multipart
   Future<Response> postMultipartList({
     @Part('ints') required List<int> ints,
@@ -147,58 +147,58 @@ abstract class HttpTestServiceVariable extends ChopperService {
     @Part('strings') required List<String> strings,
   });
 
-  @Get(path: 'https://test.com')
+  @GET(path: 'https://test.com')
   Future<Response> fullUrl();
 
-  @Get(path: '/list/string')
+  @GET(path: '/list/string')
   Future<Response<List<String>>> listString();
 
-  @Post(path: 'no-body')
+  @POST(path: 'no-body')
   Future<Response> noBody();
 
-  @Get(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
+  @GET(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
   Future<Response<String>> getUsingQueryParamIncludeNullQueryVars({
     @Query('foo') String? foo,
     @Query('bar') String? bar,
     @Query('baz') String? baz,
   });
 
-  @Get(path: '/list_query_param')
+  @GET(path: '/list_query_param')
   Future<Response<String>> getUsingListQueryParam(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_brackets_legacy', useBrackets: true)
+  @GET(path: '/list_query_param_with_brackets_legacy', useBrackets: true)
   Future<Response<String>> getUsingListQueryParamWithBracketsLegacy(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_brackets', listFormat: ListFormat.brackets)
+  @GET(path: '/list_query_param_with_brackets', listFormat: ListFormat.brackets)
   Future<Response<String>> getUsingListQueryParamWithBrackets(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_indices', listFormat: ListFormat.indices)
+  @GET(path: '/list_query_param_with_indices', listFormat: ListFormat.indices)
   Future<Response<String>> getUsingListQueryParamWithIndices(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_repeat', listFormat: ListFormat.repeat)
+  @GET(path: '/list_query_param_with_repeat', listFormat: ListFormat.repeat)
   Future<Response<String>> getUsingListQueryParamWithRepeat(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_comma', listFormat: ListFormat.comma)
+  @GET(path: '/list_query_param_with_comma', listFormat: ListFormat.comma)
   Future<Response<String>> getUsingListQueryParamWithComma(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/map_query_param')
+  @GET(path: '/map_query_param')
   Future<Response<String>> getUsingMapQueryParam(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(
+  @GET(
     path: '/map_query_param_include_null_query_vars',
     includeNullQueryVars: true,
   )
@@ -206,27 +206,27 @@ abstract class HttpTestServiceVariable extends ChopperService {
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_brackets_legacy', useBrackets: true)
+  @GET(path: '/map_query_param_with_brackets_legacy', useBrackets: true)
   Future<Response<String>> getUsingMapQueryParamWithBracketsLegacy(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_brackets', listFormat: ListFormat.brackets)
+  @GET(path: '/map_query_param_with_brackets', listFormat: ListFormat.brackets)
   Future<Response<String>> getUsingMapQueryParamWithBrackets(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_indices', listFormat: ListFormat.indices)
+  @GET(path: '/map_query_param_with_indices', listFormat: ListFormat.indices)
   Future<Response<String>> getUsingMapQueryParamWithIndices(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_repeat', listFormat: ListFormat.repeat)
+  @GET(path: '/map_query_param_with_repeat', listFormat: ListFormat.repeat)
   Future<Response<String>> getUsingMapQueryParamWithRepeat(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_comma', listFormat: ListFormat.comma)
+  @GET(path: '/map_query_param_with_comma', listFormat: ListFormat.comma)
   Future<Response<String>> getUsingMapQueryParamWithComma(
     @Query('value') Map<String, dynamic> value,
   );

--- a/chopper/test/test_without_response_service.dart
+++ b/chopper/test/test_without_response_service.dart
@@ -11,132 +11,132 @@ abstract class HttpTestService extends ChopperService {
   static HttpTestService create([ChopperClient? client]) =>
       _$HttpTestService(client);
 
-  @Get(path: 'get/{id}')
+  @GET(path: 'get/{id}')
   Future<String> getTest(
     @Path() String id, {
     @Header('test') required String dynamicHeader,
   });
 
-  @Head(path: 'head')
+  @HEAD(path: 'head')
   Future headTest();
 
-  @Options(path: 'options')
+  @OPTIONS(path: 'options')
   Future optionsTest();
 
-  @Get(path: 'get')
+  @GET(path: 'get')
   Future<Stream<List<int>>> getStreamTest();
 
-  @Get(path: '')
+  @GET(path: '')
   Future getAll();
 
-  @Get(path: '/')
+  @GET(path: '/')
   Future getAllWithTrailingSlash();
 
-  @Get(path: 'query')
+  @GET(path: 'query')
   Future getQueryTest({
     @Query('name') String name = '',
     @Query('int') int? number,
     @Query('default_value') int? def = 42,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future getQueryMapTest(@QueryMap() Map<String, dynamic> query);
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future getQueryMapTest2(
     @QueryMap() Map<String, dynamic> query, {
     @Query('test') bool? test,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future getQueryMapTest3({
     @Query('name') String name = '',
     @Query('number') int? number,
     @QueryMap() Map<String, dynamic> filters = const {},
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future getQueryMapTest4({
     @Query('name') String name = '',
     @Query('number') int? number,
     @QueryMap() Map<String, dynamic>? filters,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future getQueryMapTest5({
     @QueryMap() Map<String, dynamic>? filters,
   });
 
-  @Get(path: 'get_body')
+  @GET(path: 'get_body')
   Future getBody(@Body() dynamic body);
 
-  @Post(path: 'post')
+  @POST(path: 'post')
   Future postTest(@Body() String data);
 
-  @Post(path: 'post')
+  @POST(path: 'post')
   Future postStreamTest(@Body() Stream<List<int>> byteStream);
 
-  @Put(path: 'put/{id}')
+  @PUT(path: 'put/{id}')
   Future putTest(@Path('id') String test, @Body() String data);
 
-  @Delete(path: 'delete/{id}', headers: {'foo': 'bar'})
+  @DELETE(path: 'delete/{id}', headers: {'foo': 'bar'})
   Future<void> deleteTest(@Path() String id);
 
-  @Patch(path: 'patch/{id}')
+  @PATCH(path: 'patch/{id}')
   Future patchTest(@Path() String id, @Body() String data);
 
-  @Post(path: 'map')
+  @POST(path: 'map')
   Future mapTest(@Body() Map<String, String> map);
 
   @FactoryConverter(request: convertForm)
-  @Post(path: 'form/body')
+  @POST(path: 'form/body')
   Future postForm(@Body() Map<String, String> fields);
 
-  @Post(path: 'form/body', headers: {contentTypeKey: formEncodedHeaders})
+  @POST(path: 'form/body', headers: {contentTypeKey: formEncodedHeaders})
   Future postFormUsingHeaders(@Body() Map<String, String> fields);
 
   @FactoryConverter(request: convertForm)
-  @Post(path: 'form/body/fields')
+  @POST(path: 'form/body/fields')
   Future postFormFields(@Field() String foo, @Field() int bar);
 
-  @Post(path: 'map/json')
+  @POST(path: 'map/json')
   @FactoryConverter(
     request: customConvertRequest,
     response: customConvertResponse,
   )
   Future forceJsonTest(@Body() Map map);
 
-  @Post(path: 'multi')
+  @POST(path: 'multi')
   @multipart
   Future postResources(
     @Part('1') Map a,
     @Part('2') Map b,
   );
 
-  @Post(path: 'file')
+  @POST(path: 'file')
   @multipart
   Future postFile(
     @PartFile('file') List<int> bytes,
   );
 
-  @Post(path: 'image')
+  @POST(path: 'image')
   @multipart
   Future postImage(
     @PartFile('image') List<int> imageData,
   );
 
-  @Post(path: 'file')
+  @POST(path: 'file')
   @multipart
   Future postMultipartFile(
     @PartFile() MultipartFile file, {
     @Part() String? id,
   });
 
-  @Post(path: 'files')
+  @POST(path: 'files')
   @multipart
   Future postListFiles(@PartFile() List<MultipartFile> files);
 
-  @Post(path: 'multipart_list')
+  @POST(path: 'multipart_list')
   @multipart
   Future postMultipartList({
     @Part('ints') required List<int> ints,
@@ -145,58 +145,58 @@ abstract class HttpTestService extends ChopperService {
     @Part('strings') required List<String> strings,
   });
 
-  @Get(path: 'https://test.com')
+  @GET(path: 'https://test.com')
   Future fullUrl();
 
-  @Get(path: '/list/string')
+  @GET(path: '/list/string')
   Future<List<String>> listString();
 
-  @Post(path: 'no-body')
+  @POST(path: 'no-body')
   Future noBody();
 
-  @Get(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
+  @GET(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
   Future<String> getUsingQueryParamIncludeNullQueryVars({
     @Query('foo') String? foo,
     @Query('bar') String? bar,
     @Query('baz') String? baz,
   });
 
-  @Get(path: '/list_query_param')
+  @GET(path: '/list_query_param')
   Future<String> getUsingListQueryParam(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_brackets_legacy', useBrackets: true)
+  @GET(path: '/list_query_param_with_brackets_legacy', useBrackets: true)
   Future<String> getUsingListQueryParamWithBracketsLegacy(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_brackets', listFormat: ListFormat.brackets)
+  @GET(path: '/list_query_param_with_brackets', listFormat: ListFormat.brackets)
   Future<String> getUsingListQueryParamWithBrackets(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_indices', listFormat: ListFormat.indices)
+  @GET(path: '/list_query_param_with_indices', listFormat: ListFormat.indices)
   Future<String> getUsingListQueryParamWithIndices(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_repeat', listFormat: ListFormat.repeat)
+  @GET(path: '/list_query_param_with_repeat', listFormat: ListFormat.repeat)
   Future<String> getUsingListQueryParamWithRepeat(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_comma', listFormat: ListFormat.comma)
+  @GET(path: '/list_query_param_with_comma', listFormat: ListFormat.comma)
   Future<String> getUsingListQueryParamWithComma(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/map_query_param')
+  @GET(path: '/map_query_param')
   Future<String> getUsingMapQueryParam(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(
+  @GET(
     path: '/map_query_param_include_null_query_vars',
     includeNullQueryVars: true,
   )
@@ -204,32 +204,32 @@ abstract class HttpTestService extends ChopperService {
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_brackets_legacy', useBrackets: true)
+  @GET(path: '/map_query_param_with_brackets_legacy', useBrackets: true)
   Future<String> getUsingMapQueryParamWithBracketsLegacy(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_brackets', listFormat: ListFormat.brackets)
+  @GET(path: '/map_query_param_with_brackets', listFormat: ListFormat.brackets)
   Future<String> getUsingMapQueryParamWithBrackets(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_indices', listFormat: ListFormat.indices)
+  @GET(path: '/map_query_param_with_indices', listFormat: ListFormat.indices)
   Future<String> getUsingMapQueryParamWithIndices(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_repeat', listFormat: ListFormat.repeat)
+  @GET(path: '/map_query_param_with_repeat', listFormat: ListFormat.repeat)
   Future<String> getUsingMapQueryParamWithRepeat(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_comma', listFormat: ListFormat.comma)
+  @GET(path: '/map_query_param_with_comma', listFormat: ListFormat.comma)
   Future<String> getUsingMapQueryParamWithComma(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: 'headers')
+  @GET(path: 'headers')
   Future<String> getHeaders({
     @Header('x-string') required String stringHeader,
     @Header('x-boolean') bool? boolHeader,

--- a/chopper_generator/CHANGELOG.md
+++ b/chopper_generator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 8.1.0
+
+- Deprecate all lower-case method annotations ([#651](https://github.com/lejard-h/chopper/pull/651))
+
 ## 8.0.4
 
 - Update dependencies

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -397,7 +397,7 @@ final class ChopperGenerator
           'Use @Body() annotation on your method parameter to provide a body to your request\n'
           '   e.g.: Future<Response> postRequest(@Body() Map body);\n'
           'Or explicitly suppress this warning by setting the optionalBody property\n'
-          '   e.g.: @Post(optionalBody: true)',
+          '   e.g.: @POST(optionalBody: true)',
         );
       }
 

--- a/chopper_generator/pubspec.yaml
+++ b/chopper_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chopper_generator
 description: Chopper is an http client generator using source_gen, inspired by Retrofit
-version: 8.0.4
+version: 8.1.0
 documentation: https://hadrien-lejard.gitbook.io/chopper
 repository: https://github.com/lejard-h/chopper
 
@@ -11,7 +11,7 @@ dependencies:
   analyzer: ">=6.9.0 <8.0.0"
   build: ^2.4.1
   built_collection: ^5.1.1
-  chopper: ^8.0.3
+  chopper: ^8.0.4
   code_builder: ^4.10.0
   logging: ^1.2.0
   meta: ^1.9.1

--- a/chopper_generator/test/test_service.dart
+++ b/chopper_generator/test/test_service.dart
@@ -12,158 +12,158 @@ abstract class HttpTestService extends ChopperService {
   static HttpTestService create([ChopperClient? client]) =>
       _$HttpTestService(client);
 
-  @Get(path: 'get/{id}')
+  @GET(path: 'get/{id}')
   Future<Response<String>> getTest(
     @Path() String id, {
     @Header('test') required String dynamicHeader,
   });
 
-  @Head(path: 'head')
+  @HEAD(path: 'head')
   Future<Response> headTest();
 
-  @Options(path: 'options')
+  @OPTIONS(path: 'options')
   Future<Response> optionsTest();
 
-  @Get(path: 'get')
+  @GET(path: 'get')
   Future<Response<Stream<List<int>>>> getStreamTest();
 
-  @Get(path: '')
+  @GET(path: '')
   Future<Response> getAll();
 
-  @Get(path: '/')
+  @GET(path: '/')
   Future<Response> getAllWithTrailingSlash();
 
-  @Get(path: 'query')
+  @GET(path: 'query')
   Future<Response> getQueryTest({
     @Query('name') String name = '',
     @Query('int') int? number,
     @Query('default_value') int? def = 42,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest(@QueryMap() Map<String, dynamic> query);
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest2(
     @QueryMap() Map<String, dynamic> query, {
     @Query('test') bool? test,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest3({
     @Query('name') String name = '',
     @Query('number') int? number,
     @QueryMap() Map<String, dynamic> filters = const {},
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest4({
     @Query('name') String name = '',
     @Query('number') int? number,
     @QueryMap() Map<String, dynamic>? filters,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest5({
     @QueryMap() Map<String, dynamic>? filters,
   });
 
-  @Get(path: 'get_body')
+  @GET(path: 'get_body')
   Future<Response> getBody(@Body() dynamic body);
 
-  @Post(path: 'post')
+  @POST(path: 'post')
   Future<Response> postTest(@Body() String data);
 
-  @Post(path: 'post')
+  @POST(path: 'post')
   Future<Response> postStreamTest(@Body() Stream<List<int>> byteStream);
 
-  @Put(path: 'put/{id}')
+  @PUT(path: 'put/{id}')
   Future<Response> putTest(@Path('id') String test, @Body() String data);
 
-  @Delete(path: 'delete/{id}', headers: {'foo': 'bar'})
+  @DELETE(path: 'delete/{id}', headers: {'foo': 'bar'})
   Future<Response> deleteTest(@Path() String id);
 
-  @Patch(path: 'patch/{id}')
+  @PATCH(path: 'patch/{id}')
   Future<Response> patchTest(@Path() String id, @Body() String data);
 
-  @Post(path: 'map')
+  @POST(path: 'map')
   Future<Response> mapTest(@Body() Map<String, String> map);
 
   @FactoryConverter(request: convertForm)
-  @Post(path: 'form/body')
+  @POST(path: 'form/body')
   Future<Response> postForm(@Body() Map<String, String> fields);
 
-  @Post(path: 'form/body', headers: {contentTypeKey: formEncodedHeaders})
+  @POST(path: 'form/body', headers: {contentTypeKey: formEncodedHeaders})
   Future<Response> postFormUsingHeaders(@Body() Map<String, String> fields);
 
   @FactoryConverter(request: convertForm)
-  @Post(path: 'form/body/fields')
+  @POST(path: 'form/body/fields')
   Future<Response> postFormFields(@Field() String foo, @Field() int bar);
 
-  @Post(path: 'map/json')
+  @POST(path: 'map/json')
   @FactoryConverter(
     request: customConvertRequest,
     response: customConvertResponse,
   )
   Future<Response> forceJsonTest(@Body() Map map);
 
-  @Post(path: 'multi')
+  @POST(path: 'multi')
   @multipart
   Future<Response> postResources(
     @Part('1') Map a,
     @Part('2') Map b,
   );
 
-  @Post(path: 'formUrlEncoded')
+  @POST(path: 'formUrlEncoded')
   @FormUrlEncoded()
   Future<Response> postFormUrlEncodeBody(
     @Body() HashMap hashMapBody,
     @FieldMap() Map<String, String> map,
   );
 
-  @Post(path: 'formUrlEncoded')
+  @POST(path: 'formUrlEncoded')
   @FormUrlEncoded()
   Future<Response> postFormUrlEncodeField(
     @Field('a') String a,
     @Field('a1') String a2,
   );
 
-  @Post(path: 'formUrlEncoded')
+  @POST(path: 'formUrlEncoded')
   @FormUrlEncoded()
   Future<Response> postFormUrlEncodeFieldMap(
     @FieldMap() Map<String, String> c,
   );
 
-  @Post(path: 'formUrlEncoded')
+  @POST(path: 'formUrlEncoded')
   @FormUrlEncoded()
   Future<Response> postFormUrlEncodeFieldDynamicMap(
     @FieldMap() Map<String, dynamic> c,
   );
 
-  @Post(path: 'file')
+  @POST(path: 'file')
   @multipart
   Future<Response> postFile(
     @PartFile('file') List<int> bytes,
   );
 
-  @Post(path: 'image')
+  @POST(path: 'image')
   @multipart
   Future<Response> postImage(
     @PartFile('image') List<int> imageData,
   );
 
-  @Post(path: 'file')
+  @POST(path: 'file')
   @multipart
   Future<Response> postMultipartFile(
     @PartFile() MultipartFile file, {
     @Part() String? id,
   });
 
-  @Post(path: 'files')
+  @POST(path: 'files')
   @multipart
   Future<Response> postListFiles(@PartFile() List<MultipartFile> files);
 
-  @Post(path: 'multipart_list')
+  @POST(path: 'multipart_list')
   @multipart
   Future<Response> postMultipartList({
     @Part('ints') required List<int> ints,
@@ -172,58 +172,58 @@ abstract class HttpTestService extends ChopperService {
     @Part('strings') required List<String> strings,
   });
 
-  @Get(path: 'https://test.com')
+  @GET(path: 'https://test.com')
   Future<Response> fullUrl();
 
-  @Get(path: '/list/string')
+  @GET(path: '/list/string')
   Future<Response<List<String>>> listString();
 
-  @Post(path: 'no-body')
+  @POST(path: 'no-body')
   Future<Response> noBody();
 
-  @Get(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
+  @GET(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
   Future<Response<String>> getUsingQueryParamIncludeNullQueryVars({
     @Query('foo') String? foo,
     @Query('bar') String? bar,
     @Query('baz') String? baz,
   });
 
-  @Get(path: '/list_query_param')
+  @GET(path: '/list_query_param')
   Future<Response<String>> getUsingListQueryParam(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_brackets_legacy', useBrackets: true)
+  @GET(path: '/list_query_param_with_brackets_legacy', useBrackets: true)
   Future<Response<String>> getUsingListQueryParamWithBracketsLegacy(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_brackets', listFormat: ListFormat.brackets)
+  @GET(path: '/list_query_param_with_brackets', listFormat: ListFormat.brackets)
   Future<Response<String>> getUsingListQueryParamWithBrackets(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_indices', listFormat: ListFormat.indices)
+  @GET(path: '/list_query_param_with_indices', listFormat: ListFormat.indices)
   Future<Response<String>> getUsingListQueryParamWithIndices(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_repeat', listFormat: ListFormat.repeat)
+  @GET(path: '/list_query_param_with_repeat', listFormat: ListFormat.repeat)
   Future<Response<String>> getUsingListQueryParamWithRepeat(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_comma', listFormat: ListFormat.comma)
+  @GET(path: '/list_query_param_with_comma', listFormat: ListFormat.comma)
   Future<Response<String>> getUsingListQueryParamWithComma(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/map_query_param')
+  @GET(path: '/map_query_param')
   Future<Response<String>> getUsingMapQueryParam(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(
+  @GET(
     path: '/map_query_param_include_null_query_vars',
     includeNullQueryVars: true,
   )
@@ -231,32 +231,32 @@ abstract class HttpTestService extends ChopperService {
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_brackets_legacy', useBrackets: true)
+  @GET(path: '/map_query_param_with_brackets_legacy', useBrackets: true)
   Future<Response<String>> getUsingMapQueryParamWithBracketsLegacy(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_brackets', listFormat: ListFormat.brackets)
+  @GET(path: '/map_query_param_with_brackets', listFormat: ListFormat.brackets)
   Future<Response<String>> getUsingMapQueryParamWithBrackets(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_indices', listFormat: ListFormat.indices)
+  @GET(path: '/map_query_param_with_indices', listFormat: ListFormat.indices)
   Future<Response<String>> getUsingMapQueryParamWithIndices(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_repeat', listFormat: ListFormat.repeat)
+  @GET(path: '/map_query_param_with_repeat', listFormat: ListFormat.repeat)
   Future<Response<String>> getUsingMapQueryParamWithRepeat(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_comma', listFormat: ListFormat.comma)
+  @GET(path: '/map_query_param_with_comma', listFormat: ListFormat.comma)
   Future<Response<String>> getUsingMapQueryParamWithComma(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: 'headers')
+  @GET(path: 'headers')
   Future<Response<String>> getHeaders({
     @Header('x-string') required String stringHeader,
     @Header('x-boolean') bool? boolHeader,
@@ -265,7 +265,7 @@ abstract class HttpTestService extends ChopperService {
     @Header('x-enum') ExampleEnum? enumHeader,
   });
 
-  @Post(path: 'publish')
+  @POST(path: 'publish')
   @FactoryConverter(request: FormUrlEncodedConverter.requestFactory)
   Future<Response<void>> publish(
     @Field('review_id') final String reviewId,
@@ -274,19 +274,19 @@ abstract class HttpTestService extends ChopperService {
     @Field() final String? signature,
   ]);
 
-  @Post(path: 'tag')
+  @POST(path: 'tag')
   Future<Response<void>> tag(
     @Field('fool') final String foo,
     @Tag() Object? t1,
   );
 
-  @Get(path: 'get_timeout', timeout: Duration(seconds: 42))
+  @GET(path: 'get_timeout', timeout: Duration(seconds: 42))
   Future<Response<String>> getTimeoutTest();
 
-  @Get(path: 'get_timeout_zero', timeout: Duration(seconds: 0))
+  @GET(path: 'get_timeout_zero', timeout: Duration(seconds: 0))
   Future<Response<String>> getTimeoutTestZero();
 
-  @Get(path: 'get_timeout_neg', timeout: Duration(seconds: -1))
+  @GET(path: 'get_timeout_neg', timeout: Duration(seconds: -1))
   Future<Response<String>> getTimeoutTestNeg();
 }
 

--- a/chopper_generator/test/test_service_variable.dart
+++ b/chopper_generator/test/test_service_variable.dart
@@ -13,132 +13,132 @@ abstract class HttpTestServiceVariable extends ChopperService {
   static HttpTestServiceVariable create([ChopperClient? client]) =>
       _$HttpTestServiceVariable(client);
 
-  @Get(path: 'get/{id}')
+  @GET(path: 'get/{id}')
   Future<Response<String>> getTest(
     @Path() String id, {
     @Header('test') required String dynamicHeader,
   });
 
-  @Head(path: 'head')
+  @HEAD(path: 'head')
   Future<Response> headTest();
 
-  @Options(path: 'options')
+  @OPTIONS(path: 'options')
   Future<Response> optionsTest();
 
-  @Get(path: 'get')
+  @GET(path: 'get')
   Future<Response<Stream<List<int>>>> getStreamTest();
 
-  @Get(path: '')
+  @GET(path: '')
   Future<Response> getAll();
 
-  @Get(path: '/')
+  @GET(path: '/')
   Future<Response> getAllWithTrailingSlash();
 
-  @Get(path: 'query')
+  @GET(path: 'query')
   Future<Response> getQueryTest({
     @Query('name') String name = '',
     @Query('int') int? number,
     @Query('default_value') int? def = 42,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest(@QueryMap() Map<String, dynamic> query);
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest2(
     @QueryMap() Map<String, dynamic> query, {
     @Query('test') bool? test,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest3({
     @Query('name') String name = '',
     @Query('number') int? number,
     @QueryMap() Map<String, dynamic> filters = const {},
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest4({
     @Query('name') String name = '',
     @Query('number') int? number,
     @QueryMap() Map<String, dynamic>? filters,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future<Response> getQueryMapTest5({
     @QueryMap() Map<String, dynamic>? filters,
   });
 
-  @Get(path: 'get_body')
+  @GET(path: 'get_body')
   Future<Response> getBody(@Body() dynamic body);
 
-  @Post(path: 'post')
+  @POST(path: 'post')
   Future<Response> postTest(@Body() String data);
 
-  @Post(path: 'post')
+  @POST(path: 'post')
   Future<Response> postStreamTest(@Body() Stream<List<int>> byteStream);
 
-  @Put(path: 'put/{id}')
+  @PUT(path: 'put/{id}')
   Future<Response> putTest(@Path('id') String test, @Body() String data);
 
-  @Delete(path: 'delete/{id}', headers: {'foo': 'bar'})
+  @DELETE(path: 'delete/{id}', headers: {'foo': 'bar'})
   Future<Response> deleteTest(@Path() String id);
 
-  @Patch(path: 'patch/{id}')
+  @PATCH(path: 'patch/{id}')
   Future<Response> patchTest(@Path() String id, @Body() String data);
 
-  @Post(path: 'map')
+  @POST(path: 'map')
   Future<Response> mapTest(@Body() Map<String, String> map);
 
   @FactoryConverter(request: convertForm)
-  @Post(path: 'form/body')
+  @POST(path: 'form/body')
   Future<Response> postForm(@Body() Map<String, String> fields);
 
-  @Post(path: 'form/body', headers: {contentTypeKey: formEncodedHeaders})
+  @POST(path: 'form/body', headers: {contentTypeKey: formEncodedHeaders})
   Future<Response> postFormUsingHeaders(@Body() Map<String, String> fields);
 
   @FactoryConverter(request: convertForm)
-  @Post(path: 'form/body/fields')
+  @POST(path: 'form/body/fields')
   Future<Response> postFormFields(@Field() String foo, @Field() int bar);
 
-  @Post(path: 'map/json')
+  @POST(path: 'map/json')
   @FactoryConverter(
     request: customConvertRequest,
     response: customConvertResponse,
   )
   Future<Response> forceJsonTest(@Body() Map map);
 
-  @Post(path: 'multi')
+  @POST(path: 'multi')
   @multipart
   Future<Response> postResources(
     @Part('1') Map a,
     @Part('2') Map b,
   );
 
-  @Post(path: 'file')
+  @POST(path: 'file')
   @multipart
   Future<Response> postFile(
     @PartFile('file') List<int> bytes,
   );
 
-  @Post(path: 'image')
+  @POST(path: 'image')
   @multipart
   Future<Response> postImage(
     @PartFile('image') List<int> imageData,
   );
 
-  @Post(path: 'file')
+  @POST(path: 'file')
   @multipart
   Future<Response> postMultipartFile(
     @PartFile() MultipartFile file, {
     @Part() String? id,
   });
 
-  @Post(path: 'files')
+  @POST(path: 'files')
   @multipart
   Future<Response> postListFiles(@PartFile() List<MultipartFile> files);
 
-  @Post(path: 'multipart_list')
+  @POST(path: 'multipart_list')
   @multipart
   Future<Response> postMultipartList({
     @Part('ints') required List<int> ints,
@@ -147,58 +147,58 @@ abstract class HttpTestServiceVariable extends ChopperService {
     @Part('strings') required List<String> strings,
   });
 
-  @Get(path: 'https://test.com')
+  @GET(path: 'https://test.com')
   Future<Response> fullUrl();
 
-  @Get(path: '/list/string')
+  @GET(path: '/list/string')
   Future<Response<List<String>>> listString();
 
-  @Post(path: 'no-body')
+  @POST(path: 'no-body')
   Future<Response> noBody();
 
-  @Get(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
+  @GET(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
   Future<Response<String>> getUsingQueryParamIncludeNullQueryVars({
     @Query('foo') String? foo,
     @Query('bar') String? bar,
     @Query('baz') String? baz,
   });
 
-  @Get(path: '/list_query_param')
+  @GET(path: '/list_query_param')
   Future<Response<String>> getUsingListQueryParam(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_brackets_legacy', useBrackets: true)
+  @GET(path: '/list_query_param_with_brackets_legacy', useBrackets: true)
   Future<Response<String>> getUsingListQueryParamWithBracketsLegacy(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_brackets', listFormat: ListFormat.brackets)
+  @GET(path: '/list_query_param_with_brackets', listFormat: ListFormat.brackets)
   Future<Response<String>> getUsingListQueryParamWithBrackets(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_indices', listFormat: ListFormat.indices)
+  @GET(path: '/list_query_param_with_indices', listFormat: ListFormat.indices)
   Future<Response<String>> getUsingListQueryParamWithIndices(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_repeat', listFormat: ListFormat.repeat)
+  @GET(path: '/list_query_param_with_repeat', listFormat: ListFormat.repeat)
   Future<Response<String>> getUsingListQueryParamWithRepeat(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_comma', listFormat: ListFormat.comma)
+  @GET(path: '/list_query_param_with_comma', listFormat: ListFormat.comma)
   Future<Response<String>> getUsingListQueryParamWithComma(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/map_query_param')
+  @GET(path: '/map_query_param')
   Future<Response<String>> getUsingMapQueryParam(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(
+  @GET(
     path: '/map_query_param_include_null_query_vars',
     includeNullQueryVars: true,
   )
@@ -206,27 +206,27 @@ abstract class HttpTestServiceVariable extends ChopperService {
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_brackets_legacy', useBrackets: true)
+  @GET(path: '/map_query_param_with_brackets_legacy', useBrackets: true)
   Future<Response<String>> getUsingMapQueryParamWithBracketsLegacy(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_brackets', listFormat: ListFormat.brackets)
+  @GET(path: '/map_query_param_with_brackets', listFormat: ListFormat.brackets)
   Future<Response<String>> getUsingMapQueryParamWithBrackets(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_indices', listFormat: ListFormat.indices)
+  @GET(path: '/map_query_param_with_indices', listFormat: ListFormat.indices)
   Future<Response<String>> getUsingMapQueryParamWithIndices(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_repeat', listFormat: ListFormat.repeat)
+  @GET(path: '/map_query_param_with_repeat', listFormat: ListFormat.repeat)
   Future<Response<String>> getUsingMapQueryParamWithRepeat(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_comma', listFormat: ListFormat.comma)
+  @GET(path: '/map_query_param_with_comma', listFormat: ListFormat.comma)
   Future<Response<String>> getUsingMapQueryParamWithComma(
     @Query('value') Map<String, dynamic> value,
   );

--- a/chopper_generator/test/test_without_response_service.dart
+++ b/chopper_generator/test/test_without_response_service.dart
@@ -11,132 +11,132 @@ abstract class HttpTestService extends ChopperService {
   static HttpTestService create([ChopperClient? client]) =>
       _$HttpTestService(client);
 
-  @Get(path: 'get/{id}')
+  @GET(path: 'get/{id}')
   Future<String> getTest(
     @Path() String id, {
     @Header('test') required String dynamicHeader,
   });
 
-  @Head(path: 'head')
+  @HEAD(path: 'head')
   Future headTest();
 
-  @Options(path: 'options')
+  @OPTIONS(path: 'options')
   Future optionsTest();
 
-  @Get(path: 'get')
+  @GET(path: 'get')
   Future<Stream<List<int>>> getStreamTest();
 
-  @Get(path: '')
+  @GET(path: '')
   Future getAll();
 
-  @Get(path: '/')
+  @GET(path: '/')
   Future getAllWithTrailingSlash();
 
-  @Get(path: 'query')
+  @GET(path: 'query')
   Future getQueryTest({
     @Query('name') String name = '',
     @Query('int') int? number,
     @Query('default_value') int? def = 42,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future getQueryMapTest(@QueryMap() Map<String, dynamic> query);
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future getQueryMapTest2(
     @QueryMap() Map<String, dynamic> query, {
     @Query('test') bool? test,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future getQueryMapTest3({
     @Query('name') String name = '',
     @Query('number') int? number,
     @QueryMap() Map<String, dynamic> filters = const {},
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future getQueryMapTest4({
     @Query('name') String name = '',
     @Query('number') int? number,
     @QueryMap() Map<String, dynamic>? filters,
   });
 
-  @Get(path: 'query_map')
+  @GET(path: 'query_map')
   Future getQueryMapTest5({
     @QueryMap() Map<String, dynamic>? filters,
   });
 
-  @Get(path: 'get_body')
+  @GET(path: 'get_body')
   Future getBody(@Body() dynamic body);
 
-  @Post(path: 'post')
+  @POST(path: 'post')
   Future postTest(@Body() String data);
 
-  @Post(path: 'post')
+  @POST(path: 'post')
   Future postStreamTest(@Body() Stream<List<int>> byteStream);
 
-  @Put(path: 'put/{id}')
+  @PUT(path: 'put/{id}')
   Future putTest(@Path('id') String test, @Body() String data);
 
-  @Delete(path: 'delete/{id}', headers: {'foo': 'bar'})
+  @DELETE(path: 'delete/{id}', headers: {'foo': 'bar'})
   Future<void> deleteTest(@Path() String id);
 
-  @Patch(path: 'patch/{id}')
+  @PATCH(path: 'patch/{id}')
   Future patchTest(@Path() String id, @Body() String data);
 
-  @Post(path: 'map')
+  @POST(path: 'map')
   Future mapTest(@Body() Map<String, String> map);
 
   @FactoryConverter(request: convertForm)
-  @Post(path: 'form/body')
+  @POST(path: 'form/body')
   Future postForm(@Body() Map<String, String> fields);
 
-  @Post(path: 'form/body', headers: {contentTypeKey: formEncodedHeaders})
+  @POST(path: 'form/body', headers: {contentTypeKey: formEncodedHeaders})
   Future postFormUsingHeaders(@Body() Map<String, String> fields);
 
   @FactoryConverter(request: convertForm)
-  @Post(path: 'form/body/fields')
+  @POST(path: 'form/body/fields')
   Future postFormFields(@Field() String foo, @Field() int bar);
 
-  @Post(path: 'map/json')
+  @POST(path: 'map/json')
   @FactoryConverter(
     request: customConvertRequest,
     response: customConvertResponse,
   )
   Future forceJsonTest(@Body() Map map);
 
-  @Post(path: 'multi')
+  @POST(path: 'multi')
   @multipart
   Future postResources(
     @Part('1') Map a,
     @Part('2') Map b,
   );
 
-  @Post(path: 'file')
+  @POST(path: 'file')
   @multipart
   Future postFile(
     @PartFile('file') List<int> bytes,
   );
 
-  @Post(path: 'image')
+  @POST(path: 'image')
   @multipart
   Future postImage(
     @PartFile('image') List<int> imageData,
   );
 
-  @Post(path: 'file')
+  @POST(path: 'file')
   @multipart
   Future postMultipartFile(
     @PartFile() MultipartFile file, {
     @Part() String? id,
   });
 
-  @Post(path: 'files')
+  @POST(path: 'files')
   @multipart
   Future postListFiles(@PartFile() List<MultipartFile> files);
 
-  @Post(path: 'multipart_list')
+  @POST(path: 'multipart_list')
   @multipart
   Future postMultipartList({
     @Part('ints') required List<int> ints,
@@ -145,58 +145,58 @@ abstract class HttpTestService extends ChopperService {
     @Part('strings') required List<String> strings,
   });
 
-  @Get(path: 'https://test.com')
+  @GET(path: 'https://test.com')
   Future fullUrl();
 
-  @Get(path: '/list/string')
+  @GET(path: '/list/string')
   Future<List<String>> listString();
 
-  @Post(path: 'no-body')
+  @POST(path: 'no-body')
   Future noBody();
 
-  @Get(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
+  @GET(path: '/query_param_include_null_query_vars', includeNullQueryVars: true)
   Future<String> getUsingQueryParamIncludeNullQueryVars({
     @Query('foo') String? foo,
     @Query('bar') String? bar,
     @Query('baz') String? baz,
   });
 
-  @Get(path: '/list_query_param')
+  @GET(path: '/list_query_param')
   Future<String> getUsingListQueryParam(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_brackets_legacy', useBrackets: true)
+  @GET(path: '/list_query_param_with_brackets_legacy', useBrackets: true)
   Future<String> getUsingListQueryParamWithBracketsLegacy(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_brackets', listFormat: ListFormat.brackets)
+  @GET(path: '/list_query_param_with_brackets', listFormat: ListFormat.brackets)
   Future<String> getUsingListQueryParamWithBrackets(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_indices', listFormat: ListFormat.indices)
+  @GET(path: '/list_query_param_with_indices', listFormat: ListFormat.indices)
   Future<String> getUsingListQueryParamWithIndices(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_repeat', listFormat: ListFormat.repeat)
+  @GET(path: '/list_query_param_with_repeat', listFormat: ListFormat.repeat)
   Future<String> getUsingListQueryParamWithRepeat(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/list_query_param_with_comma', listFormat: ListFormat.comma)
+  @GET(path: '/list_query_param_with_comma', listFormat: ListFormat.comma)
   Future<String> getUsingListQueryParamWithComma(
     @Query('value') List<String> value,
   );
 
-  @Get(path: '/map_query_param')
+  @GET(path: '/map_query_param')
   Future<String> getUsingMapQueryParam(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(
+  @GET(
     path: '/map_query_param_include_null_query_vars',
     includeNullQueryVars: true,
   )
@@ -204,32 +204,32 @@ abstract class HttpTestService extends ChopperService {
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_brackets_legacy', useBrackets: true)
+  @GET(path: '/map_query_param_with_brackets_legacy', useBrackets: true)
   Future<String> getUsingMapQueryParamWithBracketsLegacy(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_brackets', listFormat: ListFormat.brackets)
+  @GET(path: '/map_query_param_with_brackets', listFormat: ListFormat.brackets)
   Future<String> getUsingMapQueryParamWithBrackets(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_indices', listFormat: ListFormat.indices)
+  @GET(path: '/map_query_param_with_indices', listFormat: ListFormat.indices)
   Future<String> getUsingMapQueryParamWithIndices(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_repeat', listFormat: ListFormat.repeat)
+  @GET(path: '/map_query_param_with_repeat', listFormat: ListFormat.repeat)
   Future<String> getUsingMapQueryParamWithRepeat(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: '/map_query_param_with_comma', listFormat: ListFormat.comma)
+  @GET(path: '/map_query_param_with_comma', listFormat: ListFormat.comma)
   Future<String> getUsingMapQueryParamWithComma(
     @Query('value') Map<String, dynamic> value,
   );
 
-  @Get(path: 'headers')
+  @GET(path: 'headers')
   Future<String> getHeaders({
     @Header('x-string') required String stringHeader,
     @Header('x-boolean') bool? boolHeader,

--- a/example/lib/built_value_resource.dart
+++ b/example/lib/built_value_resource.dart
@@ -40,16 +40,16 @@ abstract class ResourceError
 abstract class MyService extends ChopperService {
   static MyService create([ChopperClient? client]) => _$MyService(client);
 
-  @Get(path: '/{id}/')
+  @GET(path: '/{id}/')
   Future<Response> getResource(@Path() String id);
 
-  @Get(path: '/list')
+  @GET(path: '/list')
   Future<Response<BuiltList<Resource>>> getBuiltListResources();
 
-  @Get(path: '/', headers: {'foo': 'bar'})
+  @GET(path: '/', headers: {'foo': 'bar'})
   Future<Response<Resource>> getTypedResource();
 
-  @Post()
+  @POST()
   Future<Response<Resource>> newResource(
     @Body() Resource resource, {
     @Header() String? name,

--- a/example/lib/json_serializable.dart
+++ b/example/lib/json_serializable.dart
@@ -37,19 +37,19 @@ class ResourceError {
 abstract class MyService extends ChopperService {
   static MyService create([ChopperClient? client]) => _$MyService(client);
 
-  @Get(path: '/{id}/')
+  @GET(path: '/{id}/')
   Future<Response> getResource(@Path() String id);
 
-  @Get(path: '/all', headers: {'test': 'list'})
+  @GET(path: '/all', headers: {'test': 'list'})
   Future<Response<List<Resource>>> getResources();
 
-  @Get(path: '/')
+  @GET(path: '/')
   Future<Response<Map>> getMapResource(@Query() String id);
 
-  @Get(path: '/', headers: {'foo': 'bar'})
+  @GET(path: '/', headers: {'foo': 'bar'})
   Future<Response<Resource>> getTypedResource();
 
-  @Post()
+  @POST()
   Future<Response<Resource>> newResource(
     @Body() Resource resource, {
     @Header() String? name,


### PR DESCRIPTION
This pull request introduces several changes to the `chopper` package, primarily focusing on deprecating lower-case method annotations and updating the documentation to use upper-case annotations. Additionally, several new upper-case method annotations have been added, and the library version has been incremented. Below are the most important changes:

Deprecation and Introduction of Upper-Case Annotations:
* Deprecated all lower-case method annotations and introduced new upper-case annotations such as `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD`, and `OPTIONS` in `chopper/lib/src/annotations.dart`. [[1]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6R254-R278) [[2]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6L269-R308) [[3]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6L279-R319) [[4]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6L289-R356) [[5]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6L307-R386) [[6]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6L317-R397) [[7]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6L327-R426) [[8]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6L336-R436) [[9]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6L346-R473) [[10]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6L364-R510) [[11]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6L382-R520)

Documentation and Example Updates:
* Updated the `chopper/test/test_service.dart` file to use the new upper-case method annotations in all examples. [[1]](diffhunk://#diff-d0e4b11813c8876585f5c621bbc9167d82deb2d336556232ff7944ceb5a58ebfL16-R141) [[2]](diffhunk://#diff-d0e4b11813c8876585f5c621bbc9167d82deb2d336556232ff7944ceb5a58ebfL150-R239) [[3]](diffhunk://#diff-d0e4b11813c8876585f5c621bbc9167d82deb2d336556232ff7944ceb5a58ebfL248-R248) [[4]](diffhunk://#diff-d0e4b11813c8876585f5c621bbc9167d82deb2d336556232ff7944ceb5a58ebfL257-R263)

Changelog and Version Update:
* Updated the `chopper/CHANGELOG.md` to document the deprecation of lower-case method annotations and added a new version entry for 8.1.0.
* Incremented the package version to 8.1.0 in `chopper/pubspec.yaml`.

These changes ensure consistency in the annotation naming conventions and prepare the library for future improvements.