### PR TITLE
:memo: update HTTP verb capitalization in documentation

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -67,7 +67,7 @@ Request compressRequest(Request request) {
 ...
 
 @FactoryConverter(request: compressRequest)
-@Post()
+@POST()
 Future<Response> postRequest(@Body() Map<String, String> data);
 ```
 
@@ -131,7 +131,7 @@ abstract class ApiService extends ChopperService {
     return _$ApiService(client);
   }
 
-  @Get(path: "/get")
+  @GET(path: "/get")
   Future<Response> get(@Query() String url);
 }
 ```
@@ -487,7 +487,7 @@ abstract class TodosListService extends ChopperService {
   @factoryMethod
   static TodosListService create(ChopperClient client) => _$TodosListService(client);
 
-  @Get()
+  @GET()
   Future<Response<List<Todo>>> getTodos();
 }
 ```

--- a/getting-started.md
+++ b/getting-started.md
@@ -53,17 +53,17 @@ The `@ChopperApi` annotation takes one optional parameter - the `baseUrl` - that
 
 Use one of the following annotations on abstract methods of a service class to define requests:
 
-* `@Get` 
+* `@GET` 
 
-* `@Post` 
+* `@POST` 
 
-* `@Put`
+* `@PUT`
 
-* `@Patch`
+* `@PATCH`
 
-* `@Delete`
+* `@DELETE`
 
-* `@Head`
+* `@HEAD`
 
 Request methods must return with values of the type `Future<Response>`, `Future<Response<SomeType>>` or `Future<SomeType>`.
 The `Response` class is a wrapper around the HTTP response that contains the response body, the status code and the error (if any) of the request.
@@ -72,21 +72,21 @@ This class can be omitted if only the response body is needed. When omitting the
 To define a `GET` request to the endpoint `/todos` in the service class above, add one of the following method declarations to the class:
 
 ```dart
-@Get()
+@GET()
 Future<Response> getTodos();
 ```
 
 or
 
 ```dart
-@Get()
+@GET()
 Future<Response<List<Todo>>> getTodos();
 ```
 
 or
 
 ```dart
-@Get()
+@GET()
 Future<List<Todo>> getTodos();
 ```
 

--- a/requests.md
+++ b/requests.md
@@ -4,12 +4,12 @@
 
 | Annotation                                 | HTTP verb | Description                                            |
 |--------------------------------------------|-----------|--------------------------------------------------------|
-| `@Get()`, `@get`                           | `GET`     | Defines a `GET` request.                               |
-| `@Post()`, `@post`                         | `POST`    | Defines a `POST` request.                              |
-| `@Put()`, `@put`                           | `PUT`     | Defines a `PUT` request.                               |
-| `@Patch()`, `@patch`                       | `PATCH`   | Defines a `PATCH` request.                             |
-| `@Delete()`, `@delete`                     | `DELETE`  | Defines a `DELETE` request.                            |
-| `@Head()`, `@head`                         | `HEAD`    | Defines a `HEAD` request.                              |
+| `@GET()`, `@get`                           | `GET`     | Defines a `GET` request.                               |
+| `@POST()`, `@post`                         | `POST`    | Defines a `POST` request.                              |
+| `@PUT()`, `@put`                           | `PUT`     | Defines a `PUT` request.                               |
+| `@PATCH()`, `@patch`                       | `PATCH`   | Defines a `PATCH` request.                             |
+| `@DELETE()`, `@delete`                     | `DELETE`  | Defines a `DELETE` request.                            |
+| `@HEAD()`, `@head`                         | `HEAD`    | Defines a `HEAD` request.                              |
 | `@Body()`, `@body`                         | -         | Defines the request's body.                            |
 | `@FormUrlEncoded`, `@formUrlEncoded`       | -         | Defines a `application/x-www-form-urlencoded` request. |
 | `@Multipart()`, `@multipart`               | -         | Defines a `multipart/form-data` request.               |         
@@ -90,14 +90,14 @@ Dynamic path parameters can be defined in the URL with replacement blocks. A rep
 substring of the path surrounded by `{` and `}`. In the following example `{id}` is a replacement block.
 
 ```dart
-@Get(path: "/{id}")
+@GET(path: "/{id}")
 ```
 
 Use the `@Path()` annotation to bind a parameter to a replacement block. This way the parameter's name must match a
 replacement block's string.
 
 ```dart
-@Get(path: "/{id}")
+@GET(path: "/{id}")
 Future<Response> getItemById(@Path() String id);
 ```
 
@@ -105,7 +105,7 @@ As an alternative, you can set the `@Path` annotation's `name` parameter to matc
 using a different parameter name, like in the following example:
 
 ```dart
-@Get(path: "/{id}")
+@GET(path: "/{id}")
 Future<Response> getItemById(@Path("id") int itemId);
 ```
 
@@ -137,7 +137,7 @@ Future<Response> search(@QueryMap() Map<String, dynamic> query);
 Use the `@Body` annotation on a request method parameter to specify data that will be sent as the request's body.
 
 ```dart
-@Post(path: "todo/create")
+@POST(path: "todo/create")
 Future<Response> postData(@Body() String data);
 ```
 
@@ -154,22 +154,22 @@ Request headers can be set by providing a `Map<String, String>` object to the `h
 annotations have.
 
 ```dart
-@Get(path: "/", headers: {"foo": "bar"})
+@GET(path: "/", headers: {"foo": "bar"})
 Future<Response> fetch();
 ```
 
-The `@Header` annotation can be used on method parameters to set headers dynamically for each request call.
+The `@HEADer` annotation can be used on method parameters to set headers dynamically for each request call.
 
 ```dart
-@Get(path: "/")
-Future<Response> fetch(@Header("foo") String bar);
+@GET(path: "/")
+Future<Response> fetch(@HEADer("foo") String bar);
 ```
 
 > Setting request headers dynamically is also supported by [Interceptors](interceptors.md)
 > and [Converters](converters/converters.md).
 >
 > As Chopper invokes Interceptors and Converter(s) *after* creating a Request, Interceptors and Converters *can*
-> override headers set with the `headers` parameter or `@Header` annotations.
+> override headers set with the `headers` parameter or `@HEADer` annotations.
 
 ## Sending `application/x-www-form-urlencoded` data
 
@@ -184,7 +184,7 @@ We recommend annotation `@formUrlEncoded` on method that will add the correct `c
 into `Map<String, String>` for requests.
 
 ```dart
-@Post(
+@POST(
   path: "form",
 )
 @formUrlEncoded
@@ -208,7 +208,7 @@ To do only a single type of request with form encoding in a service, use the pro
 s `requestFactory` method with the `@FactoryConverter` annotation.
 
 ```dart
-@Post(
+@POST(
   path: "form",
   headers: {contentTypeKey: formEncodedHeaders},
 )
@@ -224,7 +224,7 @@ To specify fields individually, use the `@Field` annotation on method parameters
 the parameter's name is used as the field's name.
 
 ```dart
-@Post(path: "form")
+@POST(path: "form")
 @formUrlEncoded
 Future<Response> post(@Field() String foo, @Field("b") int bar);
 ```
@@ -234,7 +234,7 @@ Future<Response> post(@Field() String foo, @Field("b") int bar);
 ### Sending a file in bytes as `List<int>` using `@PartFile`
 
 ```dart
-@Post(path: 'file')
+@POST(path: 'file')
 @multipart
 Future<Response> postFile(@PartFile('file') List<int> bytes,);
 ```
@@ -242,7 +242,7 @@ Future<Response> postFile(@PartFile('file') List<int> bytes,);
 ### Sending a file as `MultipartFile` using `@PartFile` with extra parameters via `@Part`
 
 ```dart
-@Post(path: 'file')
+@POST(path: 'file')
 @multipart
 Future<Response> postMultipartFile(@PartFile() MultipartFile file, {
   @Part() String? id,
@@ -252,7 +252,7 @@ Future<Response> postMultipartFile(@PartFile() MultipartFile file, {
 ### Sending multiple files as `List<MultipartFile>` using `@PartFile`
 
 ```dart
-@Post(path: 'files')
+@POST(path: 'files')
 @multipart
 Future<Response> postListFiles(@PartFile() List<MultipartFile> files);
 ```
@@ -266,15 +266,15 @@ Chopper will generate a client which will return the specified return type. When
 
 ```dart
 // Returns a Response<dynamic>
-@Get(path: "/")
+@GET(path: "/")
 Future<Response> fetch();
 
 // Returns a Response<MyClass>
-@Get(path: "/")
+@GET(path: "/")
 Future<Response<MyClass>> fetch();
 
 // Returns a MyClass
-@Get(path: "/")
+@GET(path: "/")
 Future<MyClass> fetch();
 ```
 


### PR DESCRIPTION
This pull request includes several changes to update HTTP method annotations in the documentation files to use uppercase versions. The changes ensure consistency and improve readability across the documentation.

### Documentation updates:

* [`faq.md`](diffhunk://#diff-08c93eef774739f8dd6832484cc3801ccbb881da56ff2237df2ad1088048b1dbL70-R70): Updated HTTP method annotations from lowercase to uppercase in `compressRequest`, `ApiService`, and `TodosListService` classes. [[1]](diffhunk://#diff-08c93eef774739f8dd6832484cc3801ccbb881da56ff2237df2ad1088048b1dbL70-R70) [[2]](diffhunk://#diff-08c93eef774739f8dd6832484cc3801ccbb881da56ff2237df2ad1088048b1dbL134-R134) [[3]](diffhunk://#diff-08c93eef774739f8dd6832484cc3801ccbb881da56ff2237df2ad1088048b1dbL490-R490)
* [`getting-started.md`](diffhunk://#diff-f007f6cb65740b71d33ebd4511fa8727d48a472d135ffd1bbef978237f9e6fa7L56-R66): Changed HTTP method annotations to uppercase in the list of annotations and provided examples. [[1]](diffhunk://#diff-f007f6cb65740b71d33ebd4511fa8727d48a472d135ffd1bbef978237f9e6fa7L56-R66) [[2]](diffhunk://#diff-f007f6cb65740b71d33ebd4511fa8727d48a472d135ffd1bbef978237f9e6fa7L75-R89)
* [`requests.md`](diffhunk://#diff-d19ad4421cde71e6f17c885788058c5d20450adb0e96a927a9ddaa0dfc74c019L7-R12): Updated HTTP method annotations to uppercase in various examples and descriptions, including `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, and `HEAD`. [[1]](diffhunk://#diff-d19ad4421cde71e6f17c885788058c5d20450adb0e96a927a9ddaa0dfc74c019L7-R12) [[2]](diffhunk://#diff-d19ad4421cde71e6f17c885788058c5d20450adb0e96a927a9ddaa0dfc74c019L93-R108) [[3]](diffhunk://#diff-d19ad4421cde71e6f17c885788058c5d20450adb0e96a927a9ddaa0dfc74c019L140-R140) [[4]](diffhunk://#diff-d19ad4421cde71e6f17c885788058c5d20450adb0e96a927a9ddaa0dfc74c019L157-R172) [[5]](diffhunk://#diff-d19ad4421cde71e6f17c885788058c5d20450adb0e96a927a9ddaa0dfc74c019L187-R187) [[6]](diffhunk://#diff-d19ad4421cde71e6f17c885788058c5d20450adb0e96a927a9ddaa0dfc74c019L211-R211) [[7]](diffhunk://#diff-d19ad4421cde71e6f17c885788058c5d20450adb0e96a927a9ddaa0dfc74c019L227-R227) [[8]](diffhunk://#diff-d19ad4421cde71e6f17c885788058c5d20450adb0e96a927a9ddaa0dfc74c019L237-R245) [[9]](diffhunk://#diff-d19ad4421cde71e6f17c885788058c5d20450adb0e96a927a9ddaa0dfc74c019L255-R255) [[10]](diffhunk://#diff-d19ad4421cde71e6f17c885788058c5d20450adb0e96a927a9ddaa0dfc74c019L269-R277)