### PR TITLE
:bookmark: release v8.2.0

### DIFF
--- a/chopper/CHANGELOG.md
+++ b/chopper/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 8.2.0
+
+- Add `DateFormat` to enhance date serialization options ([#668](https://github.com/lejard-h/chopper/pull/668))
+
 ## 8.1.0
 
 - Deprecate all lower-case method annotations ([#651](https://github.com/lejard-h/chopper/pull/651))

--- a/chopper/lib/chopper.dart
+++ b/chopper/lib/chopper.dart
@@ -4,17 +4,19 @@
 library;
 
 export 'package:qs_dart/qs_dart.dart' show ListFormat;
+
 export 'src/annotations.dart';
 export 'src/authenticator.dart';
 export 'src/base.dart';
-export 'src/chopper_http_exception.dart';
+export 'src/chain/chain.dart';
 export 'src/chopper_exception.dart';
+export 'src/chopper_http_exception.dart';
 export 'src/chopper_log_record.dart';
 export 'src/constants.dart';
-export 'src/extensions.dart';
-export 'src/chain/chain.dart';
-export 'src/interceptors/interceptor.dart';
 export 'src/converters.dart';
+export 'src/date_format.dart';
+export 'src/extensions.dart';
+export 'src/interceptors/interceptor.dart';
 export 'src/request.dart';
 export 'src/response.dart';
 export 'src/utils.dart' hide mapToQuery;

--- a/chopper/lib/src/annotations.dart
+++ b/chopper/lib/src/annotations.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:chopper/src/constants.dart';
+import 'package:chopper/src/date_format.dart';
 import 'package:chopper/src/request.dart';
 import 'package:chopper/src/response.dart';
 import 'package:meta/meta.dart';
@@ -209,6 +210,21 @@ sealed class Method {
   @Deprecated('Use listFormat instead')
   final bool? useBrackets;
 
+  /// Date format to use when encoding dates
+  ///
+  ///  - [DateFormat.iso8601] `hxxp://path/to/script?dt=2023-10-01T12:00:00.000`
+  ///  - [DateFormat.utcIso8601] `hxxp://path/to/script?dt=2023-10-01T12:00:00Z` (default)
+  ///  - [DateFormat.localIso8601] `hxxp://path/to/script?dt=2023-10-01T12:00:00`
+  ///  - [DateFormat.seconds] `hxxp://path/to/script?dt=1234567890`
+  ///  - [DateFormat.unix] `hxxp://path/to/script?dt=1234567890`
+  ///  - [DateFormat.milliseconds] `hxxp://path/to/script?dt=1234567890000`
+  ///  - [DateFormat.microseconds] `hxxp://path/to/script?dt=1234567890000000`
+  ///  - [DateFormat.rfc2822] `hxxp://path/to/script?dt=Sun, 01 Oct 2023 12:00:00 GMT`
+  ///  - [DateFormat.date] `hxxp://path/to/script?dt=2023-10-01`
+  ///  - [DateFormat.time] `hxxp://path/to/script?dt=12:00:00`
+  ///  - [DateFormat.string] `hxxp://path/to/script?dt=2023-10-01 12:00:00.000`
+  final DateFormat? dateFormat;
+
   /// Set to [true] to include query variables with null values. This includes nested maps.
   /// The default is to exclude them.
   ///
@@ -246,6 +262,7 @@ sealed class Method {
     this.headers = const {},
     this.listFormat,
     @Deprecated('Use listFormat instead') this.useBrackets,
+    this.dateFormat,
     this.includeNullQueryVars,
     this.timeout,
   });
@@ -264,9 +281,13 @@ final class GET extends Method {
     super.headers,
     super.listFormat,
     super.useBrackets,
+    super.dateFormat,
     super.includeNullQueryVars,
     super.timeout,
-  }) : super(HttpMethod.Get);
+  })
+// coverage:ignore-start
+  : super(HttpMethod.Get);
+// coverage:ignore-end
 }
 
 /// {@template Get}
@@ -283,6 +304,7 @@ final class Get extends GET {
     super.headers,
     super.listFormat,
     super.useBrackets,
+    super.dateFormat,
     super.includeNullQueryVars,
     super.timeout,
   });
@@ -303,9 +325,13 @@ final class POST extends Method {
     super.headers,
     super.listFormat,
     super.useBrackets,
+    super.dateFormat,
     super.includeNullQueryVars,
     super.timeout,
-  }) : super(HttpMethod.Post);
+  })
+// coverage:ignore-start
+  : super(HttpMethod.Post);
+// coverage:ignore-end
 }
 
 /// {@template Post}
@@ -324,6 +350,7 @@ final class Post extends POST {
     super.headers,
     super.listFormat,
     super.useBrackets,
+    super.dateFormat,
     super.includeNullQueryVars,
     super.timeout,
   });
@@ -342,9 +369,13 @@ final class DELETE extends Method {
     super.headers,
     super.listFormat,
     super.useBrackets,
+    super.dateFormat,
     super.includeNullQueryVars,
     super.timeout,
-  }) : super(HttpMethod.Delete);
+  })
+// coverage:ignore-start
+  : super(HttpMethod.Delete);
+// coverage:ignore-end
 }
 
 /// {@template Delete}
@@ -361,6 +392,7 @@ final class Delete extends DELETE {
     super.headers,
     super.listFormat,
     super.useBrackets,
+    super.dateFormat,
     super.includeNullQueryVars,
     super.timeout,
   });
@@ -381,9 +413,13 @@ final class PUT extends Method {
     super.headers,
     super.listFormat,
     super.useBrackets,
+    super.dateFormat,
     super.includeNullQueryVars,
     super.timeout,
-  }) : super(HttpMethod.Put);
+  })
+// coverage:ignore-start
+  : super(HttpMethod.Put);
+// coverage:ignore-end
 }
 
 /// {@template Put}
@@ -402,6 +438,7 @@ final class Put extends PUT {
     super.headers,
     super.listFormat,
     super.useBrackets,
+    super.dateFormat,
     super.includeNullQueryVars,
     super.timeout,
   });
@@ -421,9 +458,13 @@ final class PATCH extends Method {
     super.headers,
     super.listFormat,
     super.useBrackets,
+    super.dateFormat,
     super.includeNullQueryVars,
     super.timeout,
-  }) : super(HttpMethod.Patch);
+  })
+// coverage:ignore-start
+  : super(HttpMethod.Patch);
+// coverage:ignore-end
 }
 
 /// {@template Patch}
@@ -441,6 +482,7 @@ final class Patch extends PATCH {
     super.headers,
     super.listFormat,
     super.useBrackets,
+    super.dateFormat,
     super.includeNullQueryVars,
     super.timeout,
   });
@@ -459,9 +501,13 @@ final class HEAD extends Method {
     super.headers,
     super.listFormat,
     super.useBrackets,
+    super.dateFormat,
     super.includeNullQueryVars,
     super.timeout,
-  }) : super(HttpMethod.Head);
+  })
+// coverage:ignore-start
+  : super(HttpMethod.Head);
+// coverage:ignore-end
 }
 
 /// {@template Head}
@@ -478,6 +524,7 @@ final class Head extends HEAD {
     super.headers,
     super.listFormat,
     super.useBrackets,
+    super.dateFormat,
     super.includeNullQueryVars,
     super.timeout,
   });
@@ -496,9 +543,13 @@ final class OPTIONS extends Method {
     super.headers,
     super.listFormat,
     super.useBrackets,
+    super.dateFormat,
     super.includeNullQueryVars,
     super.timeout,
-  }) : super(HttpMethod.Options);
+  })
+// coverage:ignore-start
+  : super(HttpMethod.Options);
+// coverage:ignore-end
 }
 
 /// {@template Options}
@@ -515,6 +566,7 @@ final class Options extends OPTIONS {
     super.headers,
     super.listFormat,
     super.useBrackets,
+    super.dateFormat,
     super.includeNullQueryVars,
     super.timeout,
   });

--- a/chopper/lib/src/converters.dart
+++ b/chopper/lib/src/converters.dart
@@ -121,6 +121,7 @@ class JsonConverter implements Converter, ErrorConverter {
       (await decodeJson<BodyType, InnerType>(response)) as Response<BodyType>;
 
   @protected
+  @visibleForTesting
   FutureOr<dynamic> tryDecodeJson(String data) {
     try {
       return json.decode(data);

--- a/chopper/lib/src/date_format.dart
+++ b/chopper/lib/src/date_format.dart
@@ -1,0 +1,115 @@
+import 'package:qs_dart/qs_dart.dart' as qs show DateSerializer;
+
+/// Enum defining different serialization strategies for DateTime objects.
+///
+/// Each serializer converts a DateTime to a string representation suitable
+/// for different use cases (APIs, databases, etc.).
+enum DateFormat {
+  /// Converts DateTime to ISO8601 string in current timezone.
+  /// Example: DateTime(2023, 1, 1) -> "2023-01-01T00:00:00.000"
+  iso8601,
+
+  /// Converts DateTime to UTC ISO8601 string.
+  /// Example: DateTime(2023, 1, 1) -> "2023-01-01T00:00:00.000Z"
+  utcIso8601,
+
+  /// Converts DateTime to local ISO8601 string.
+  /// Example: DateTime(2023, 1, 1) -> "2023-01-01T00:00:00.000"
+  localIso8601,
+
+  /// Converts DateTime to seconds since epoch as a string.
+  /// Example: DateTime(2023, 1, 1) -> "1672531200"
+  seconds,
+  unix,
+
+  /// Converts DateTime to milliseconds since epoch as a string.
+  /// Example: DateTime(2023, 1, 1) -> "1672531200000"
+  milliseconds,
+
+  /// Converts DateTime to microseconds since epoch as a string.
+  /// Example: DateTime(2023, 1, 1) -> "1672531200000000"
+  microseconds,
+
+  /// Converts DateTime to RFC 2822 format (email/HTTP headers).
+  /// Example: DateTime(2023, 1, 1) -> "Sun, 01 Jan 2023 00:00:00 GMT"
+  rfc2822,
+
+  /// Converts DateTime to date-only format.
+  /// Example: DateTime(2023, 1, 1, 15, 30) -> "2023-01-01"
+  date,
+
+  /// Converts DateTime to time-only format.
+  /// Example: DateTime(2023, 1, 1, 15, 30, 45) -> "15:30:45"
+  time,
+
+  /// Converts DateTime to default string representation.
+  /// Example: DateTime(2023, 1, 1) -> "2023-01-01 00:00:00.000"
+  string;
+
+  /// Call the enum directly: e.g. `DateSerializer.date(dt)`.
+  String call(DateTime dt) => format(dt);
+
+  /// If you need to pass it as a [qs.DateSerializer]:
+  qs.DateSerializer get serializer => format;
+
+  /// Format a [DateTime] according to this strategy.
+  String format(DateTime dt) => switch (this) {
+        seconds || unix => (dt.millisecondsSinceEpoch ~/ 1000).toString(),
+        milliseconds => dt.millisecondsSinceEpoch.toString(),
+        microseconds => dt.microsecondsSinceEpoch.toString(),
+        utcIso8601 => dt.toUtc().toIso8601String(),
+        localIso8601 => dt.toLocal().toIso8601String(),
+        iso8601 => dt.toIso8601String(),
+        rfc2822 => _rfc2822(dt),
+        date => '${dt.year.toString().padLeft(4, '0')}-'
+            '${dt.month.toString().padLeft(2, '0')}-'
+            '${dt.day.toString().padLeft(2, '0')}',
+        time => '${dt.hour.toString().padLeft(2, '0')}:'
+            '${dt.minute.toString().padLeft(2, '0')}:'
+            '${dt.second.toString().padLeft(2, '0')}',
+        string => dt.toString(),
+      };
+
+  /// Format a [DateTime] to RFC 2822 format.
+  static String _rfc2822(DateTime datetime) {
+    final DateTime utc = datetime.toUtc();
+
+    final String wk = _weekdayNames[utc.weekday - 1];
+    final String m = _monthNames[utc.month - 1];
+    final String d = _twoDigits(utc.day);
+    final String hh = _twoDigits(utc.hour);
+    final String mm = _twoDigits(utc.minute);
+    final String ss = _twoDigits(utc.second);
+
+    return '$wk, $d $m ${utc.year} $hh:$mm:$ss GMT';
+  }
+
+  static const List<String> _weekdayNames = [
+    'Mon',
+    'Tue',
+    'Wed',
+    'Thu',
+    'Fri',
+    'Sat',
+    'Sun',
+  ];
+  static const List<String> _monthNames = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+
+  static String _twoDigits(int n) => n.toString().padLeft(2, '0');
+
+  @override
+  String toString() => name;
+}

--- a/chopper/lib/src/request.dart
+++ b/chopper/lib/src/request.dart
@@ -1,5 +1,6 @@
 import 'dart:async' show Stream;
 
+import 'package:chopper/src/date_format.dart';
 import 'package:chopper/src/extensions.dart';
 import 'package:chopper/src/utils.dart';
 import 'package:equatable/equatable.dart' show EquatableMixin;
@@ -20,6 +21,7 @@ base class Request extends http.BaseRequest with EquatableMixin {
   final bool multipart;
   final List<PartValue> parts;
   final ListFormat? listFormat;
+  final DateFormat? dateFormat;
   @Deprecated('Use listFormat instead')
   final bool? useBrackets;
   final bool? includeNullQueryVars;
@@ -37,6 +39,7 @@ base class Request extends http.BaseRequest with EquatableMixin {
     this.tag,
     this.listFormat,
     @Deprecated('Use listFormat instead') this.useBrackets,
+    this.dateFormat,
     this.includeNullQueryVars,
   })  : assert(
             !baseUri.hasQuery,
@@ -53,6 +56,7 @@ base class Request extends http.BaseRequest with EquatableMixin {
             listFormat: listFormat,
             // ignore: deprecated_member_use_from_same_package
             useBrackets: useBrackets,
+            dateFormat: dateFormat,
             includeNullQueryVars: includeNullQueryVars,
           ),
         ) {
@@ -71,6 +75,7 @@ base class Request extends http.BaseRequest with EquatableMixin {
     List<PartValue>? parts,
     ListFormat? listFormat,
     @Deprecated('Use listFormat instead') bool? useBrackets,
+    DateFormat? dateFormat,
     bool? includeNullQueryVars,
     Object? tag,
   }) =>
@@ -86,6 +91,7 @@ base class Request extends http.BaseRequest with EquatableMixin {
         listFormat: listFormat ?? this.listFormat,
         // ignore: deprecated_member_use_from_same_package
         useBrackets: useBrackets ?? this.useBrackets,
+        dateFormat: dateFormat ?? this.dateFormat,
         includeNullQueryVars: includeNullQueryVars ?? this.includeNullQueryVars,
         tag: tag ?? this.tag,
       );
@@ -100,6 +106,7 @@ base class Request extends http.BaseRequest with EquatableMixin {
     Map<String, dynamic> parameters, {
     ListFormat? listFormat,
     @Deprecated('Use listFormat instead') bool? useBrackets,
+    DateFormat? dateFormat,
     bool? includeNullQueryVars,
   }) {
     // If the request's url is already a fully qualified URL, we can use it
@@ -120,6 +127,7 @@ base class Request extends http.BaseRequest with EquatableMixin {
       listFormat: listFormat,
       // ignore: deprecated_member_use_from_same_package
       useBrackets: useBrackets,
+      dateSerializer: dateFormat,
       includeNullQueryVars: includeNullQueryVars,
     );
 
@@ -255,6 +263,7 @@ base class Request extends http.BaseRequest with EquatableMixin {
         listFormat,
         // ignore: deprecated_member_use_from_same_package
         useBrackets,
+        dateFormat,
         includeNullQueryVars,
       ];
 }

--- a/chopper/lib/src/utils.dart
+++ b/chopper/lib/src/utils.dart
@@ -1,5 +1,6 @@
 import 'dart:collection';
 
+import 'package:chopper/src/date_format.dart';
 import 'package:chopper/src/request.dart';
 import 'package:logging/logging.dart';
 import 'package:qs_dart/qs_dart.dart' show encode, EncodeOptions, ListFormat;
@@ -65,6 +66,7 @@ String mapToQuery(
   Map<String, dynamic> map, {
   ListFormat? listFormat,
   @Deprecated('Use listFormat instead') bool? useBrackets,
+  DateFormat? dateSerializer,
   bool? includeNullQueryVars,
 }) {
   listFormat ??= useBrackets == true ? ListFormat.brackets : ListFormat.repeat;
@@ -78,7 +80,7 @@ String mapToQuery(
       encodeValuesOnly: listFormat == ListFormat.repeat,
       skipNulls: includeNullQueryVars != true,
       strictNullHandling: false,
-      serializeDate: (DateTime date) => date.toUtc().toIso8601String(),
+      serializeDate: (dateSerializer ?? DateFormat.utcIso8601).serializer,
     ),
   );
 }

--- a/chopper/pubspec.yaml
+++ b/chopper/pubspec.yaml
@@ -12,18 +12,18 @@ dependencies:
   http: ^1.1.0
   logging: ^1.2.0
   meta: ^1.9.1
-  qs_dart: ^1.3.0
+  qs_dart: ^1.3.8
 
 dev_dependencies:
   build_runner: ^2.4.9
-  build_test: ^2.2.2
+  build_test: ^3.1.0
   build_verify: ^3.1.0
   collection: ^1.18.0
   coverage: ^1.8.0
-  data_fixture_dart: ^2.2.0
+  data_fixture_dart: ^3.0.0
   faker: ^2.1.0
   http_parser: ^4.0.2
-  lints: ">=4.0.0 <6.0.0"
+  lints: ">=4.0.0 <7.0.0"
   test: ^1.25.5
   transparent_image: ^2.0.1
   chopper_generator: ^8.0.3

--- a/chopper/pubspec.yaml
+++ b/chopper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chopper
 description: Chopper is an http client generator using source_gen, inspired by Retrofit
-version: 8.1.0
+version: 8.2.0
 documentation: https://hadrien-lejard.gitbook.io/chopper
 repository: https://github.com/lejard-h/chopper
 
@@ -26,7 +26,7 @@ dev_dependencies:
   lints: ">=4.0.0 <7.0.0"
   test: ^1.25.5
   transparent_image: ^2.0.1
-  chopper_generator: ^8.0.3
+  chopper_generator: ^8.1.0
 
 topics:
   - api

--- a/chopper/test/annotations_test.chopper.dart
+++ b/chopper/test/annotations_test.chopper.dart
@@ -1,0 +1,372 @@
+// dart format width=80
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'annotations_test.dart';
+
+// **************************************************************************
+// ChopperGenerator
+// **************************************************************************
+
+// coverage:ignore-file
+// ignore_for_file: type=lint
+final class _$DeprecatedAnnotationService extends DeprecatedAnnotationService {
+  _$DeprecatedAnnotationService([ChopperClient? client]) {
+    if (client == null) return;
+    this.client = client;
+  }
+
+  @override
+  final Type definitionType = DeprecatedAnnotationService;
+
+  @override
+  Future<Response<String>> testGet() {
+    final Uri $url = Uri.parse('/test/get');
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> testPost(dynamic body) {
+    final Uri $url = Uri.parse('/test/post');
+    final $body = body;
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> testPut(dynamic body) {
+    final Uri $url = Uri.parse('/test/put');
+    final $body = body;
+    final Request $request = Request(
+      'PUT',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> testPatch(dynamic body) {
+    final Uri $url = Uri.parse('/test/patch');
+    final $body = body;
+    final Request $request = Request(
+      'PATCH',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> testDelete() {
+    final Uri $url = Uri.parse('/test/delete');
+    final Request $request = Request(
+      'DELETE',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> testHead() {
+    final Uri $url = Uri.parse('/test/head');
+    final Request $request = Request(
+      'HEAD',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> testOptions() {
+    final Uri $url = Uri.parse('/test/options');
+    final Request $request = Request(
+      'OPTIONS',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+}
+
+// coverage:ignore-file
+// ignore_for_file: type=lint
+final class _$ShorthandAnnotationService extends ShorthandAnnotationService {
+  _$ShorthandAnnotationService([ChopperClient? client]) {
+    if (client == null) return;
+    this.client = client;
+  }
+
+  @override
+  final Type definitionType = ShorthandAnnotationService;
+
+  @override
+  Future<Response<dynamic>> testGetShorthand() {
+    final Uri $url = Uri.parse('/shorthand');
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> testPostShorthand(dynamic body) {
+    final Uri $url = Uri.parse('/shorthand');
+    final $body = body;
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> testPutShorthand(dynamic body) {
+    final Uri $url = Uri.parse('/shorthand');
+    final $body = body;
+    final Request $request = Request(
+      'PUT',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> testPatchShorthand(dynamic body) {
+    final Uri $url = Uri.parse('/shorthand');
+    final $body = body;
+    final Request $request = Request(
+      'PATCH',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> testDeleteShorthand() {
+    final Uri $url = Uri.parse('/shorthand');
+    final Request $request = Request(
+      'DELETE',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> testHeadShorthand() {
+    final Uri $url = Uri.parse('/shorthand');
+    final Request $request = Request(
+      'HEAD',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> testOptionsShorthand() {
+    final Uri $url = Uri.parse('/shorthand');
+    final Request $request = Request(
+      'OPTIONS',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> testPathShorthand(String id) {
+    final Uri $url = Uri.parse('/shorthand/${id}');
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> testQueryShorthand(String name) {
+    final Uri $url = Uri.parse('/shorthand/query');
+    final Map<String, dynamic> $params = <String, dynamic>{'name': name};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> testQueryMapShorthand(Map<String, dynamic> map) {
+    final Uri $url = Uri.parse('/shorthand/queryMap');
+    final Map<String, dynamic> $params = map;
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> testHeaderShorthand(String testHeader) {
+    final Uri $url = Uri.parse('/shorthand/header');
+    final Map<String, String> $headers = {
+      'testHeader': testHeader,
+    };
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      headers: $headers,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> testFieldShorthand(String data) {
+    final Uri $url = Uri.parse('/shorthand/field');
+    final Map<String, String> $headers = {
+      'content-type': 'application/x-www-form-urlencoded',
+    };
+    final $body = <String, String>{'data': data.toString()};
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      body: $body,
+      headers: $headers,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> testFieldMapShorthand(Map<String, dynamic> data) {
+    final Uri $url = Uri.parse('/shorthand/fieldMap');
+    final Map<String, String> $headers = {
+      'content-type': 'application/x-www-form-urlencoded',
+    };
+    final $body = data.map<String, String>((
+      key,
+      value,
+    ) {
+      return MapEntry(
+        key.toString(),
+        value.toString(),
+      );
+    });
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      body: $body,
+      headers: $headers,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> testPartShorthand(String data) {
+    final Uri $url = Uri.parse('/shorthand/multipart');
+    final List<PartValue> $parts = <PartValue>[
+      PartValue<String>(
+        'data',
+        data,
+      )
+    ];
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      parts: $parts,
+      multipart: true,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> testPartFileShorthand(List<int> data) {
+    final Uri $url = Uri.parse('/shorthand/partFile');
+    final List<PartValue> $parts = <PartValue>[
+      PartValueFile<List<int>>(
+        'data',
+        data,
+      )
+    ];
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      parts: $parts,
+      multipart: true,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> testPartMapShorthand(
+      List<PartValue<dynamic>> data) {
+    final Uri $url = Uri.parse('/shorthand/partMap');
+    final List<PartValue> $parts = data;
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      parts: $parts,
+      multipart: true,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> testPartFileMapShorthand(
+      List<PartValueFile<dynamic>> data) {
+    final Uri $url = Uri.parse('/shorthand/partFileMap');
+    final List<PartValue> $parts = data;
+    final Request $request = Request(
+      'POST',
+      $url,
+      client.baseUrl,
+      parts: $parts,
+      multipart: true,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<dynamic>> testTagShorthand(String myTag) {
+    final Uri $url = Uri.parse('/shorthand/tag');
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      tag: myTag,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+}

--- a/chopper/test/annotations_test.dart
+++ b/chopper/test/annotations_test.dart
@@ -1,0 +1,252 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+import 'dart:async';
+
+import 'package:chopper/chopper.dart';
+import 'package:test/test.dart';
+
+part 'annotations_test.chopper.dart';
+
+@ChopperApi(baseUrl: '/test')
+abstract class DeprecatedAnnotationService extends ChopperService {
+  @Get(path: '/get')
+  Future<Response<String>> testGet();
+
+  @Post(path: '/post')
+  Future<Response<dynamic>> testPost(@Body() dynamic body);
+
+  @Put(path: '/put')
+  Future<Response<dynamic>> testPut(@Body() dynamic body);
+
+  @Patch(path: '/patch')
+  Future<Response<dynamic>> testPatch(@Body() dynamic body);
+
+  @Delete(path: '/delete')
+  Future<Response<dynamic>> testDelete();
+
+  @Head(path: '/head')
+  Future<Response<dynamic>> testHead();
+
+  @Options(path: '/options')
+  Future<Response<dynamic>> testOptions();
+}
+
+@ChopperApi(baseUrl: '/shorthand')
+abstract class ShorthandAnnotationService extends ChopperService {
+  @get
+  Future<Response<dynamic>> testGetShorthand();
+
+  @post
+  Future<Response<dynamic>> testPostShorthand(@body dynamic body);
+
+  @put
+  Future<Response<dynamic>> testPutShorthand(@body dynamic body);
+
+  @patch
+  Future<Response<dynamic>> testPatchShorthand(@body dynamic body);
+
+  @delete
+  Future<Response<dynamic>> testDeleteShorthand();
+
+  @head
+  Future<Response<dynamic>> testHeadShorthand();
+
+  @options
+  Future<Response<dynamic>> testOptionsShorthand();
+
+  @Get(path: '/{id}')
+  Future<Response<dynamic>> testPathShorthand(@path String id);
+
+  @Get(path: '/query')
+  Future<Response<dynamic>> testQueryShorthand(@query String name);
+
+  @Get(path: '/queryMap')
+  Future<Response<dynamic>> testQueryMapShorthand(
+      @queryMap Map<String, dynamic> map);
+
+  @Get(path: '/header')
+  Future<Response<dynamic>> testHeaderShorthand(@header String testHeader);
+
+  @Post(path: '/field')
+  @formUrlEncoded
+  Future<Response<dynamic>> testFieldShorthand(@field String data);
+
+  @Post(path: '/fieldMap')
+  @formUrlEncoded
+  Future<Response<dynamic>> testFieldMapShorthand(
+      @fieldMap Map<String, dynamic> data);
+
+  @Post(path: '/multipart')
+  @multipart
+  Future<Response<dynamic>> testPartShorthand(@part String data);
+
+  @Post(path: '/partFile')
+  @multipart
+  Future<Response<dynamic>> testPartFileShorthand(@partFile List<int> data);
+
+  @Post(path: '/partMap')
+  @multipart
+  Future<Response<dynamic>> testPartMapShorthand(@partMap List<PartValue> data);
+
+  @Post(path: '/partFileMap')
+  @multipart
+  Future<Response<dynamic>> testPartFileMapShorthand(
+      @partFileMap List<PartValueFile> data);
+
+  @Get(path: '/tag')
+  Future<Response<dynamic>> testTagShorthand(@tag String myTag);
+}
+
+void main() {
+  group('Annotation Instantiation Tests', () {
+    test('Deprecated method annotations can be instantiated', () {
+      expect(const Get(), isA<Get>());
+      expect(const Post(), isA<Post>());
+      expect(const Put(), isA<Put>());
+      expect(const Patch(), isA<Patch>());
+      expect(const Delete(), isA<Delete>());
+      expect(const Head(), isA<Head>());
+      expect(const Options(), isA<Options>());
+    });
+
+    test('Shorthand method annotations can be instantiated', () {
+      expect(get, isA<GET>());
+      expect(post, isA<POST>());
+      expect(put, isA<PUT>());
+      expect(patch, isA<PATCH>());
+      expect(delete, isA<DELETE>());
+      expect(head, isA<HEAD>());
+      expect(options, isA<OPTIONS>());
+    });
+
+    test('Shorthand parameter annotations can be instantiated', () {
+      expect(body, isA<Body>());
+      expect(path, isA<Path>());
+      expect(query, isA<Query>());
+      expect(queryMap, isA<QueryMap>());
+      expect(header, isA<Header>());
+      expect(field, isA<Field>());
+      expect(fieldMap, isA<FieldMap>());
+      expect(part, isA<Part>());
+      expect(partMap, isA<PartMap>());
+      expect(partFile, isA<PartFile>());
+      expect(partFileMap, isA<PartFileMap>());
+      expect(tag, isA<Tag>());
+    });
+
+    test('Shorthand class/misc annotations can be instantiated', () {
+      expect(chopperApi, isA<ChopperApi>());
+      expect(multipart, isA<Multipart>());
+      expect(formUrlEncoded, isA<FormUrlEncoded>());
+      expect(factoryConverter, isA<FactoryConverter>());
+    });
+
+    // Test constructor argument passing for deprecated annotations
+    test('Deprecated GET with all arguments', () {
+      const annotation = GET(
+        path: '/all',
+        optionalBody: false,
+        headers: {'X-Test': 'true'},
+        listFormat: ListFormat.comma,
+        // Corrected from .csv
+        useBrackets: true,
+        includeNullQueryVars: true,
+        timeout: Duration(seconds: 10),
+      );
+      expect(annotation.path, '/all');
+      expect(annotation.optionalBody, false);
+      expect(annotation.headers['X-Test'], 'true');
+      expect(annotation.listFormat, ListFormat.comma); // Corrected from .csv
+      expect(annotation.useBrackets, true);
+      expect(annotation.includeNullQueryVars, true);
+      expect(annotation.timeout, const Duration(seconds: 10));
+    });
+
+    // Test constructor argument passing for main annotations (GET used as example)
+    // This also covers the base Method class constructor
+    test('Method (GET) with all arguments', () {
+      const annotation = GET(
+        path: '/allArgs',
+        optionalBody: false,
+        headers: {'X-Full-Test': 'yes'},
+        listFormat: ListFormat.indices,
+        useBrackets: false,
+        // Deliberately different from deprecated
+        includeNullQueryVars: false,
+        timeout: Duration(milliseconds: 500),
+      );
+      expect(annotation.path, '/allArgs');
+      expect(annotation.optionalBody, false);
+      expect(annotation.headers['X-Full-Test'], 'yes');
+      expect(annotation.listFormat, ListFormat.indices);
+      expect(annotation.useBrackets, false);
+      expect(annotation.includeNullQueryVars, false);
+      expect(annotation.timeout, const Duration(milliseconds: 500));
+    });
+
+    test('Method (GET) with default arguments', () {
+      const annotation = GET();
+      expect(annotation.path, '');
+      expect(annotation.optionalBody, true);
+      expect(annotation.headers, const {});
+      expect(annotation.listFormat, null);
+      expect(annotation.useBrackets, null); // Changed from false to null
+      expect(
+          annotation.includeNullQueryVars, null); // Changed from false to null
+      expect(annotation.timeout, null);
+    });
+
+    test('Path with name', () {
+      const p = Path('id');
+      expect(p.name, 'id');
+    });
+
+    test('Query with name', () {
+      const q = Query('name');
+      expect(q.name, 'name');
+    });
+
+    test('Header with name', () {
+      const h = Header('X-Custom-Header');
+      expect(h.name, 'X-Custom-Header');
+    });
+
+    test('Field with name', () {
+      const f = Field('dataField');
+      expect(f.name, 'dataField');
+    });
+
+    test('Field with default name', () {
+      const f = Field();
+      expect(f.name, null);
+    });
+
+    test('Part with name', () {
+      const p = Part('filePart');
+      expect(p.name, 'filePart');
+    });
+
+    test('Part with default name', () {
+      const p = Part();
+      expect(p.name, null);
+    });
+
+    test('PartFile with name', () {
+      const pf = PartFile('imageFile');
+      expect(pf.name, 'imageFile');
+    });
+
+    test('PartFile with default name', () {
+      const pf = PartFile();
+      expect(pf.name, null);
+    });
+
+    test('FactoryConverter with request and response', () {
+      FutureOr<Request> reqConv(Request r) => r;
+      FutureOr<Response> resConv(Response r) => r;
+      final fc = FactoryConverter(
+          request: reqConv, response: resConv); // Changed to final
+      expect(fc.request, reqConv);
+      expect(fc.response, resConv);
+    });
+  });
+}

--- a/chopper/test/chopper_client_extended_test.dart
+++ b/chopper/test/chopper_client_extended_test.dart
@@ -1,0 +1,519 @@
+import 'dart:async' show Future, TimeoutException;
+import 'dart:convert' show json;
+
+import 'package:chopper/chopper.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+import 'test_service.dart';
+
+void main() {
+  final defaultBaseUrl = Uri.parse('http://localhost:8000');
+
+  group('ChopperClient constructor', () {
+    test('throws AssertionError if baseUrl contains query parameters', () {
+      expect(
+        () =>
+            ChopperClient(baseUrl: Uri.parse('http://localhost:8000?foo=bar')),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('uses default Uri if baseUrl is null', () {
+      final client = ChopperClient();
+      expect(client.baseUrl, equals(Uri()));
+      client.dispose();
+    });
+
+    test('initializes with an internal http client if none is provided', () {
+      final client = ChopperClient();
+      expect(client.httpClient, isA<http.Client>());
+      client.dispose();
+    });
+
+    test('uses provided http client and does not close it on dispose', () {
+      final mockHttpClient =
+          ClosableMockClient((_) async => http.Response('', 200));
+      final client = ChopperClient(client: mockHttpClient);
+      expect(client.httpClient, same(mockHttpClient));
+      client.dispose();
+      expect(mockHttpClient.closeCalled, isFalse);
+      // It's good practice to close the client if it's not closed by Chopper
+      mockHttpClient.close();
+    });
+
+    test('initializes services and sets their client', () {
+      final service =
+          HttpTestService.create(); // Assumes HttpTestService.create() is valid
+      final client =
+          ChopperClient(services: [service], baseUrl: defaultBaseUrl);
+      expect(client.getService<HttpTestService>(), same(service));
+      expect(service.client, same(client));
+      client.dispose();
+    });
+  });
+
+  group('ChopperClient getService', () {
+    test('returns registered service', () {
+      final service = HttpTestService.create();
+      final client =
+          ChopperClient(services: [service], baseUrl: defaultBaseUrl);
+      expect(client.getService<HttpTestService>(), equals(service));
+      client.dispose();
+    });
+
+    test('throws Exception if service not found', () {
+      final client = ChopperClient(
+          services: [HttpTestService.create()], baseUrl: defaultBaseUrl);
+      expect(
+        () => client.getService<OtherTestService>(),
+        throwsA(isA<Exception>().having(
+          (e) => e.toString(),
+          'toString',
+          contains('Service of type \'OtherTestService\' not found.'),
+        )),
+      );
+      client.dispose();
+    });
+
+    test('throws Exception for dynamic service type', () {
+      final client = ChopperClient(baseUrl: defaultBaseUrl);
+      expect(
+        // Changed from <dynamic> to <ChopperService> to avoid compile error
+        // The runtime error message being checked is the same.
+        () => client.getService<ChopperService>(),
+        throwsA(isA<Exception>().having(
+          (e) => e.toString(),
+          'toString',
+          contains(
+              'Service type should be provided, `dynamic` is not allowed.'),
+        )),
+      );
+      client.dispose();
+    });
+
+    test('throws Exception for ChopperService service type', () {
+      final client = ChopperClient(baseUrl: defaultBaseUrl);
+      expect(
+        () => client.getService<ChopperService>(),
+        throwsA(isA<Exception>().having(
+          (e) => e.toString(),
+          'toString',
+          contains(
+              'Service type should be provided, `dynamic` is not allowed.'),
+        )),
+      );
+      client.dispose();
+    });
+  });
+
+  group('ChopperClient dispose', () {
+    test('closes internal http client, streams, and clears services', () {
+      final client = ChopperClient(
+          services: [HttpTestService.create()], baseUrl: defaultBaseUrl);
+      // To check if the internal client is closed, we'd ideally mock http.Client's close method
+      // or check a flag if ChopperClient exposed it.
+      // For now, we trust that dispose calls httpClient.close() when _clientIsInternal is true.
+      client.dispose();
+
+      expectLater(client.onRequest, emitsDone);
+      expectLater(client.onResponse, emitsDone);
+      expect(
+        () => client.getService<HttpTestService>(),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    test(
+      'does not close external http client but closes streams and clears services',
+      () {
+        final mockHttpClient =
+            ClosableMockClient((request) async => http.Response('', 200));
+        final client = ChopperClient(
+            client: mockHttpClient,
+            services: [HttpTestService.create()],
+            baseUrl: defaultBaseUrl);
+
+        client.dispose();
+
+        expect(mockHttpClient.closeCalled, isFalse);
+        expectLater(client.onRequest, emitsDone);
+        expectLater(client.onResponse, emitsDone);
+        expect(
+          () => client.getService<HttpTestService>(),
+          throwsA(isA<Exception>()),
+        );
+        mockHttpClient.close(); // Close the external client after the test
+      },
+    );
+  });
+
+  group('ChopperClient request/response streams', () {
+    late ChopperClient client;
+    late MockClient mockHttpClient;
+
+    setUp(() {
+      mockHttpClient = MockClient((request) async {
+        return http.Response(
+          '{"foo":"bar"}',
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+      client = ChopperClient(
+        client: mockHttpClient,
+        baseUrl: defaultBaseUrl,
+        converter: JsonConverter(),
+      );
+    });
+
+    tearDown(() {
+      client.dispose();
+      mockHttpClient.close();
+    });
+
+    test('onRequest stream emits request', () async {
+      final request =
+          Request(HttpMethod.Get, Uri.parse('/test'), client.baseUrl);
+
+      // Start listening before the action
+      final futureEmittedRequest = client.onRequest.first;
+
+      // Perform the action. If send fails, this will throw and fail the test.
+      // This is okay, as a failing send means the conditions for stream emission are not met.
+      try {
+        await client.send(request);
+      } catch (e) {
+        // Fail test if send() throws an error not caught by the test framework by default
+        return Future.error(e);
+      }
+
+      // Now check the stream emission.
+      final emittedRequest = await futureEmittedRequest.timeout(
+        Duration(seconds: 2),
+        // Short timeout, event should be immediate after send's internal add
+        onTimeout: () => throw TimeoutException(
+            'onRequest.first timed out after send completed'),
+      );
+      expect(emittedRequest.url.toString(), endsWith('/test'));
+    });
+
+    test('onResponse stream emits response', () async {
+      final request =
+          Request(HttpMethod.Get, Uri.parse('/test'), client.baseUrl);
+
+      // Start listening before the action
+      final futureEmittedResponse = client.onResponse.first;
+
+      // Perform the action and get the actual response
+      final Response<Map<String, dynamic>> actualResponse;
+      try {
+        actualResponse = await client
+            .send<Map<String, dynamic>, Map<String, dynamic>>(request);
+      } catch (e) {
+        // Fail test if send() throws an error
+        return Future.error(e);
+      }
+
+      // Check the stream emission
+      final emittedResponse = await futureEmittedResponse.timeout(
+        Duration(seconds: 2),
+        // Short timeout, event should be immediate after send completes
+        onTimeout: () => throw TimeoutException(
+            'onResponse.first timed out after send completed'),
+      );
+
+      expect(emittedResponse.base.statusCode, 200);
+      expect(emittedResponse.body,
+          actualResponse.body); // Compare with the response from send()
+    });
+  });
+
+  group('ChopperClient HTTP methods', () {
+    late ChopperClient client;
+    // Use MockClient for http.Client
+    late MockClient mockHttp;
+    final baseUrl = Uri.parse('http://localhost:8000');
+
+    void setupClientWithMock(
+        Future<http.Response> Function(http.Request) handler) {
+      // Dispose previous client instance before creating a new one.
+      // ChopperClient.dispose() handles whether to close the httpClient.
+      try {
+        client.dispose();
+      } catch (_) {
+        // Ignore if already disposed or other errors during cleanup of old client.
+      }
+
+      mockHttp = MockClient(handler);
+      client = ChopperClient(
+        client: mockHttp,
+        baseUrl: baseUrl,
+        converter: JsonConverter(),
+        errorConverter: JsonConverter(),
+      );
+    }
+
+    setUp(() {
+      // Initial client setup, can be overridden in tests needing specific mock logic
+      // For simplicity, we'll ensure each test sets up its own mock or uses a default one.
+      // Default setup for tests that might not call setupClientWithMock explicitly:
+      mockHttp = MockClient(
+        (request) async => http.Response(
+          '{}',
+          200,
+          headers: {'content-type': 'application/json'},
+        ),
+      );
+      client = ChopperClient(
+        client: mockHttp,
+        baseUrl: baseUrl,
+        converter: JsonConverter(),
+      );
+    });
+
+    tearDown(() {
+      client.dispose();
+      mockHttp.close();
+    });
+
+    test('GET request', () async {
+      setupClientWithMock((request) async {
+        expect(request.method, 'GET');
+        expect(request.url.path, '/resources/1');
+        return http.Response(
+          '{"id":1,"name":"test"}',
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+      final response =
+          await client.get<Map<String, dynamic>, Map<String, dynamic>>(
+        Uri.parse('/resources/1'),
+      );
+      expect(response.isSuccessful, isTrue);
+      expect(response.body, {'id': 1, 'name': 'test'});
+    });
+
+    test('GET request with headers and parameters', () async {
+      setupClientWithMock((request) async {
+        expect(
+          request.url.toString(),
+          'http://localhost:8000/resources/1?param1=value1&param2=value2',
+        );
+        expect(request.headers['X-Test-Header'], 'header_value');
+        return http.Response(
+          '{"id":1,"name":"test_params_headers"}',
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+
+      final response =
+          await client.get<Map<String, dynamic>, Map<String, dynamic>>(
+        Uri.parse('/resources/1'),
+        headers: {'X-Test-Header': 'header_value'},
+        parameters: {'param1': 'value1', 'param2': 'value2'},
+      );
+      expect(response.isSuccessful, isTrue);
+      expect(response.body, {'id': 1, 'name': 'test_params_headers'});
+    });
+
+    test('POST request with JSON body', () async {
+      final requestBody = {'name': 'new resource'};
+      setupClientWithMock((request) async {
+        expect(request.method, 'POST');
+        expect(request.url.path, '/resources');
+        expect(request.headers[contentTypeKey],
+            startsWith(jsonHeaders)); // Changed from jsonContentType
+        expect(json.decode(request.body), requestBody); // Compare decoded JSON
+        return http.Response(
+          json.encode({'id': 2, 'received_body': requestBody}),
+          201,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+
+      final response =
+          await client.post<Map<String, dynamic>, Map<String, dynamic>>(
+        Uri.parse('/resources'),
+        body: requestBody,
+      );
+      expect(response.isSuccessful, isTrue);
+      expect(response.statusCode, 201);
+      expect(response.body!['received_body'], equals(requestBody));
+    });
+
+    test('PUT request with JSON body', () async {
+      final requestBody = {'name': 'updated resource'};
+      setupClientWithMock((request) async {
+        expect(request.method, 'PUT');
+        expect(request.url.path, '/resources/1');
+        expect(request.headers[contentTypeKey],
+            startsWith(jsonHeaders)); // Changed from jsonContentType
+        expect(json.decode(request.body), requestBody);
+        return http.Response(
+          json.encode({'id': 1, 'received_body': requestBody}),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+
+      final response =
+          await client.put<Map<String, dynamic>, Map<String, dynamic>>(
+        Uri.parse('/resources/1'),
+        body: requestBody,
+      );
+      expect(response.isSuccessful, isTrue);
+      expect(response.body!['received_body'], equals(requestBody));
+    });
+
+    test('PATCH request with JSON body', () async {
+      final requestBody = {'name': 'patched resource'};
+      setupClientWithMock((request) async {
+        expect(request.method, 'PATCH');
+        expect(request.url.path, '/resources/1');
+        expect(request.headers[contentTypeKey],
+            startsWith(jsonHeaders)); // Changed from jsonContentType
+        expect(json.decode(request.body), requestBody);
+        return http.Response(
+          json.encode({'id': 1, 'received_body': requestBody}),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+
+      final response =
+          await client.patch<Map<String, dynamic>, Map<String, dynamic>>(
+        Uri.parse('/resources/1'),
+        body: requestBody,
+      );
+      expect(response.isSuccessful, isTrue);
+      expect(response.body!['received_body'], equals(requestBody));
+    });
+
+    test('DELETE request', () async {
+      setupClientWithMock((request) async {
+        expect(request.method, 'DELETE');
+        expect(request.url.path, '/resources/1');
+        return http.Response('', 204);
+      });
+      final response = await client.delete(Uri.parse('/resources/1'));
+      expect(response.isSuccessful, isTrue);
+      expect(response.statusCode, 204);
+    });
+
+    test('HEAD request', () async {
+      setupClientWithMock((request) async {
+        expect(request.method, 'HEAD');
+        return http.Response('', 200, headers: {'x-test-header': 'head_value'});
+      });
+      final response = await client.head(Uri.parse('/resources/1'));
+      expect(response.isSuccessful, isTrue);
+      expect(response.base.headers['x-test-header'], 'head_value');
+      expect(response.bodyString, isEmpty);
+    });
+
+    test('OPTIONS request', () async {
+      setupClientWithMock((request) async {
+        expect(request.method, 'OPTIONS');
+        return http.Response('', 200, headers: {'allow': 'GET, POST, OPTIONS'});
+      });
+      final response = await client.options(Uri.parse('/resources/1'));
+      expect(response.isSuccessful, isTrue);
+      expect(response.base.headers['allow'], 'GET, POST, OPTIONS');
+    });
+
+    test('request with overridden baseUrl', () async {
+      final newBaseUrl = Uri.parse('http://otherhost:9000');
+      setupClientWithMock((request) async {
+        expect(request.url.toString(), 'http://otherhost:9000/resources/1');
+        return http.Response(
+          '{"id":1,"name":"other_host_test"}',
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+
+      final response =
+          await client.get<Map<String, dynamic>, Map<String, dynamic>>(
+        Uri.parse('/resources/1'),
+        baseUrl: newBaseUrl,
+      );
+      expect(response.isSuccessful, isTrue);
+      expect(response.body, {'id': 1, 'name': 'other_host_test'});
+    });
+
+    test('POST request with multipart', () async {
+      setupClientWithMock((request) async {
+        expect(request.method, 'POST');
+        expect(
+          request.headers[contentTypeKey],
+          startsWith('multipart/form-data'), // Changed from multipartType
+        );
+        // More detailed multipart request body inspection would require casting 'request'
+        // to http.MultipartRequest and checking its fields/files.
+        // MockClient provides the raw request, so direct inspection of parts is complex here.
+        return http.Response(
+          '{"status":"multipart success"}',
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+
+      final parts = [
+        PartValue<String>('key1', 'value1'),
+      ];
+      final response =
+          await client.post<Map<String, dynamic>, Map<String, dynamic>>(
+        Uri.parse('/upload'),
+        parts: parts,
+        multipart: true,
+      );
+      expect(response.isSuccessful, isTrue);
+      expect(response.body, {'status': 'multipart success'});
+    });
+  });
+}
+
+// Helper class for testing ChopperClient.dispose with external clients
+class ClosableMockClient extends http.BaseClient {
+  bool closeCalled = false;
+  final Future<http.StreamedResponse> Function(http.BaseRequest request)
+      _handler;
+
+  ClosableMockClient(
+      Future<http.Response> Function(http.BaseRequest request) handler)
+      : _handler = ((req) async {
+          final response = await handler(req);
+          return http.StreamedResponse(
+            Stream.value(response.bodyBytes),
+            response.statusCode,
+            headers: response.headers,
+            reasonPhrase: response.reasonPhrase,
+            contentLength: response.contentLength,
+            request: req,
+            isRedirect: response.isRedirect,
+            persistentConnection: response.persistentConnection,
+          );
+        });
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    if (closeCalled) throw StateError('Client is already closed.');
+    return _handler(request);
+  }
+
+  @override
+  void close() {
+    closeCalled = true;
+    super.close();
+  }
+}
+
+// Dummy service for testing 'service not found' scenarios
+abstract class OtherTestService extends ChopperService {
+  @override
+  Type get definitionType => OtherTestService;
+}

--- a/chopper/test/chopper_exception_test.dart
+++ b/chopper/test/chopper_exception_test.dart
@@ -1,0 +1,117 @@
+import 'package:chopper/chopper.dart';
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+
+void main() {
+  group('ChopperException', () {
+    test('toString() with only message', () {
+      final exception = ChopperException('Test message');
+      expect(exception.toString(), 'ChopperException: Test message ');
+    });
+
+    test(
+      'toString() with message and response',
+      () {
+        final baseResponse = http.Response('Internal server error', 500);
+        final chopperResponse = Response(baseResponse, 'Error body');
+        final exception = ChopperException(
+          'Test message with response',
+          response: chopperResponse,
+        );
+        expect(
+          exception.toString(),
+          // ignore: lines_longer_than_80_chars
+          'ChopperException: Test message with response , \nResponse: Response<String>(Instance of \'Response\', Error body, null)',
+        );
+      },
+      testOn: 'vm',
+    );
+
+    test(
+      'toString() with message and response',
+      () {
+        final baseResponse = http.Response('Internal server error', 500);
+        final chopperResponse = Response(baseResponse, 'Error body');
+        final exception = ChopperException(
+          'Test message with response',
+          response: chopperResponse,
+        );
+        expect(
+          exception.toString(),
+          // ignore: lines_longer_than_80_chars
+          'ChopperException: Test message with response , \nResponse: Response<String>(Instance of \'Response0\', Error body, null)',
+        );
+      },
+      testOn: 'chrome',
+    );
+
+    test('toString() with message and request', () {
+      final chopperRequest = Request(
+        'GET',
+        Uri.parse('http://localhost/test'),
+        Uri.parse('http://baseurl'),
+      );
+      final exception = ChopperException(
+        'Test message with request',
+        request: chopperRequest,
+      );
+      expect(
+        exception.toString(),
+        // ignore: lines_longer_than_80_chars
+        'ChopperException: Test message with request , \nRequest: Request(GET, http://localhost/test, http://baseurl, null, {}, {}, false, [], null, null, null, null)',
+      );
+    });
+
+    test(
+      'toString() with message, response, and request',
+      () {
+        final baseResponse = http.Response('Not found', 404);
+        final chopperResponse = Response(baseResponse, null);
+        final chopperRequest = Request(
+          'POST',
+          Uri.parse('http://localhost/another/test'),
+          Uri.parse('http://baseurl'),
+          body: {'key': 'value'},
+          headers: {'foo': 'bar'},
+        );
+        final exception = ChopperException(
+          'Test message with response and request',
+          response: chopperResponse,
+          request: chopperRequest,
+        );
+        expect(
+          exception.toString(),
+          // ignore: lines_longer_than_80_chars
+          'ChopperException: Test message with response and request , \nResponse: Response<Null>(Instance of \'Response\', null, null), \nRequest: Request(POST, http://localhost/another/test, http://baseurl, {key: value}, {}, {foo: bar}, false, [], null, null, null, null)',
+        );
+      },
+      testOn: 'vm',
+    );
+
+    test(
+      'toString() with message, response, and request',
+      () {
+        final baseResponse = http.Response('Not found', 404);
+        final chopperResponse = Response(baseResponse, null);
+        final chopperRequest = Request(
+          'POST',
+          Uri.parse('http://localhost/another/test'),
+          Uri.parse('http://baseurl'),
+          body: {'key': 'value'},
+          headers: {'foo': 'bar'},
+        );
+        final exception = ChopperException(
+          'Test message with response and request',
+          response: chopperResponse,
+          request: chopperRequest,
+        );
+        expect(
+          exception.toString(),
+          // ignore: lines_longer_than_80_chars
+          'ChopperException: Test message with response and request , \nResponse: Response<Null>(Instance of \'Response0\', null, null), \nRequest: Request(POST, http://localhost/another/test, http://baseurl, {key: value}, {}, {foo: bar}, false, [], null, null, null, null)',
+        );
+      },
+      testOn: 'chrome',
+    );
+  });
+}

--- a/chopper/test/converter_test.dart
+++ b/chopper/test/converter_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert' as dart_convert;
 
 import 'package:chopper/src/base.dart';
+import 'package:chopper/src/constants.dart';
 import 'package:chopper/src/converters.dart';
 import 'package:chopper/src/request.dart';
 import 'package:chopper/src/response.dart';
@@ -115,6 +116,135 @@ void main() {
       expect(converted.body, equals({'foo': 'bar'}));
     });
 
+    test(
+      'decodeJson with bodyBytes and application/json content type',
+      () async {
+        final jsonData = {'key': 'value'};
+        final jsonString = dart_convert.jsonEncode(jsonData);
+        final bodyBytes = dart_convert.utf8.encode(jsonString);
+
+        final httpResponse = http.Response.bytes(
+          bodyBytes,
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+        // When using http.Response.bytes, Chopper's Response.body (String getter) might be empty or misinterpret bytes.
+        // We pass the original httpResponse so converter can access bodyBytes.
+        final chopperResponse = Response(
+            httpResponse, null /* httpResponse.body could be wrong here */);
+
+        final converted = await jsonConverter
+            .convertResponse<Map<String, dynamic>, dynamic>(chopperResponse);
+        expect(converted.body, equals(jsonData));
+      },
+    );
+
+    test('decodeJson with bodyBytes and application/vnd.api+json content type',
+        () async {
+      final jsonData = {'key': 'value'};
+      final jsonString = dart_convert.jsonEncode(jsonData);
+      final bodyBytes = dart_convert.utf8.encode(jsonString);
+
+      final httpResponse = http.Response.bytes(
+        bodyBytes,
+        200,
+        headers: {'content-type': 'application/vnd.api+json'},
+      );
+      final chopperResponse = Response(httpResponse, null);
+
+      final converted = await jsonConverter
+          .convertResponse<Map<String, dynamic>, dynamic>(chopperResponse);
+      expect(converted.body, equals(jsonData));
+    });
+
+    test('tryDecodeJson with invalid JSON returns original data', () async {
+      const invalidJsonString = 'this is not a valid {json string';
+      final response = Response(
+        http.Response(invalidJsonString, 200,
+            headers: {'content-type': 'application/json'}),
+        invalidJsonString,
+      );
+
+      final converted =
+          await jsonConverter.convertResponse<String, String>(response);
+      // Expect the original string because json.decode fails and tryDecodeJson returns the input data
+      expect(converted.body, invalidJsonString);
+    });
+
+    test('convertError decodes JSON error body', () async {
+      final errorJson = {'error': 'test error', 'code': 42};
+      final errorJsonString = dart_convert.jsonEncode(errorJson);
+      final response = Response(
+        http.Response(errorJsonString, 400,
+            headers: {'content-type': 'application/json'}),
+        errorJsonString,
+      );
+
+      final converted = await jsonConverter
+          .convertError<Map<String, dynamic>, dynamic>(response);
+      expect(converted.body, errorJson);
+    });
+
+    test('responseFactory decodes JSON response', () async {
+      final jsonData = {'id': 123, 'name': 'Test Item'};
+      final jsonString = dart_convert.jsonEncode(jsonData);
+      final response = Response(
+        http.Response(jsonString, 200,
+            headers: {'content-type': 'application/json'}),
+        jsonString,
+      );
+
+      final converted =
+          await JsonConverter.responseFactory<Map<String, dynamic>, dynamic>(
+              response);
+      expect(converted.body, jsonData);
+    });
+
+    test('requestFactory encodes JSON request if content-type is json', () {
+      final requestBody = {'item': 'test data'};
+      final request = Request(
+        'POST',
+        Uri.parse('/items'),
+        baseUrl,
+        body: requestBody,
+        headers: {'content-type': 'application/json'},
+      );
+
+      final converted = JsonConverter.requestFactory(request);
+      expect(converted.body, dart_convert.jsonEncode(requestBody));
+    });
+
+    test('requestFactory does not encode if content-type is not json', () {
+      final requestBody = {'item': 'test data'};
+      final request = Request(
+        'POST',
+        Uri.parse('/items'),
+        baseUrl,
+        body: requestBody,
+        headers: {'content-type': 'text/plain'},
+      );
+
+      final converted = JsonConverter.requestFactory(request);
+      expect(converted.body, requestBody); // Should not be json encoded
+    });
+
+    test(
+      'requestFactory does not double encode already JSON string with json header',
+      () {
+        final requestBodyJsonString = '{"item":"test data"}';
+        final request = Request(
+          'POST',
+          Uri.parse('/items'),
+          baseUrl,
+          body: requestBodyJsonString,
+          headers: {'content-type': 'application/json'},
+        );
+
+        final converted = JsonConverter.requestFactory(request);
+        expect(converted.body, requestBodyJsonString);
+      },
+    );
+
     test('JsonConverter.isJson', () {
       expect(JsonConverter.isJson('{"foo":"bar"}'), isTrue);
       expect(JsonConverter.isJson('foo'), isFalse);
@@ -131,6 +261,296 @@ void main() {
           'list': [1, 2, 3],
         }),
         isFalse,
+      );
+    });
+  });
+
+  group('FormUrlEncodedConverter', () {
+    final formConverter = FormUrlEncodedConverter();
+
+    test(
+        'convertRequest should return request as is if body is already Map<String, String>',
+        () {
+      final request = Request(
+        'POST',
+        Uri.parse('/test'),
+        baseUrl,
+        body: {'key': 'value'},
+        headers: {'content-type': 'application/x-www-form-urlencoded'},
+      );
+      final converted = formConverter.convertRequest(request);
+      expect(converted.body, equals({'key': 'value'}));
+      expect(converted.headers['content-type'],
+          'application/x-www-form-urlencoded');
+    });
+
+    test(
+        'convertRequest should convert Map<String, dynamic> body to Map<String, String>',
+        () {
+      final request = Request(
+        'POST',
+        Uri.parse('/test'),
+        baseUrl,
+        body: {'key': 'value', 'number': 123, 'bool': true, 'nullVal': null},
+        headers: {'content-type': 'application/x-www-form-urlencoded'},
+      );
+      final converted = formConverter.convertRequest(request);
+      expect(converted.body,
+          equals({'key': 'value', 'number': '123', 'bool': 'true'}));
+      expect(converted.headers['content-type'],
+          'application/x-www-form-urlencoded');
+    });
+
+    test('convertRequest should return request as is if body is not a Map', () {
+      final request = Request(
+        'POST',
+        Uri.parse('/test'),
+        baseUrl,
+        body: 'Just a string body',
+        headers: {'content-type': 'application/x-www-form-urlencoded'},
+      );
+      final converted = formConverter.convertRequest(request);
+      expect(converted.body, 'Just a string body');
+      expect(converted.headers['content-type'],
+          'application/x-www-form-urlencoded');
+    });
+
+    test('convertResponse returns response as is', () async {
+      final response = Response(http.Response('foo=bar', 200), 'foo=bar');
+      final converted =
+          await formConverter.convertResponse<String, String>(response);
+      expect(converted.body, 'foo=bar');
+      expect(converted.base.statusCode, 200);
+    });
+
+    test('convertError returns response as is', () async {
+      final response = Response(http.Response('error=true', 400), 'error=true');
+      final converted =
+          await formConverter.convertError<String, String>(response);
+      expect(converted.body, 'error=true');
+      expect(converted.base.statusCode, 400);
+    });
+  });
+
+  group('JsonConverter encodeJson specific tests', () {
+    final jsonConverter = JsonConverter();
+    test(
+      'encodeJson should not encode if content-type does not contain application/json',
+      () {
+        final request = Request(
+          'POST',
+          Uri.parse('/test'),
+          baseUrl,
+          body: {'key': 'value'},
+          headers: {'content-type': 'text/plain'},
+        );
+        final converted = jsonConverter.encodeJson(request);
+        expect(converted.body, equals({'key': 'value'})); // Not encoded
+      },
+    );
+
+    test(
+      'encodeJson should not encode if body is already a valid JSON string',
+      () {
+        final request = Request(
+          'POST',
+          Uri.parse('/test'),
+          baseUrl,
+          body: '{"key":"value"}',
+          headers: {'content-type': 'application/json'},
+        );
+        final converted = jsonConverter.encodeJson(request);
+        expect(converted.body, equals('{"key":"value"}')); // Not double encoded
+      },
+    );
+
+    test(
+      'encodeJson should encode if body is a string but not valid JSON and content type is JSON',
+      () {
+        final request = Request(
+          'POST',
+          Uri.parse('/test'),
+          baseUrl,
+          body: 'Just a string', // Not a valid JSON
+          headers: {'content-type': 'application/json'},
+        );
+        final converted = jsonConverter.encodeJson(request);
+        // It should be JSON encoded, meaning the string itself becomes a JSON string literal
+        expect(converted.body, equals('"Just a string"'));
+      },
+    );
+
+    test('encodeJson should encode non-string body if content type is JSON',
+        () {
+      final request = Request(
+        'POST',
+        Uri.parse('/test'),
+        baseUrl,
+        body: {'key': 'value', 'number': 123},
+        headers: {'content-type': 'application/json'},
+      );
+      final converted = jsonConverter.encodeJson(request);
+      expect(converted.body,
+          equals(dart_convert.jsonEncode({'key': 'value', 'number': 123})));
+    });
+
+    test(
+      'encodeJson should not encode if content-type is null, even if body could be JSON',
+      () {
+        final request = Request(
+          'POST',
+          Uri.parse('/test'),
+          baseUrl,
+          body: {'key': 'value'},
+          headers: {}, // No content-type header
+        );
+        final converted = jsonConverter.encodeJson(request);
+        expect(converted.body, equals({'key': 'value'})); // Not encoded
+      },
+    );
+
+    test(
+      'encodeJson should encode if content-type contains json and other params (e.g. charset)',
+      () {
+        final request = Request(
+          'POST',
+          Uri.parse('/test'),
+          baseUrl,
+          body: {'key': 'value'},
+          headers: {'content-type': 'application/json; charset=utf-8'},
+        );
+        final converted = jsonConverter.encodeJson(request);
+        expect(converted.body, dart_convert.jsonEncode({'key': 'value'}));
+      },
+    );
+  });
+
+  group('JsonConverter specific decodeJson tests', () {
+    final jsonConverter = JsonConverter();
+
+    test(
+        'decodeJson with Iterable<Map<String, dynamic>> and application/json content type',
+        () async {
+      final listMapData = [
+        {'id': 1, 'name': 'item1'},
+        {'id': 2, 'name': 'item2'}
+      ];
+      final jsonString = dart_convert.jsonEncode(listMapData);
+      final bodyBytes = dart_convert.utf8.encode(jsonString);
+      final httpResponse = http.Response.bytes(bodyBytes, 200,
+          headers: {'content-type': 'application/json'});
+      final chopperResponse = Response(httpResponse, null);
+
+      final converted = await jsonConverter.decodeJson<
+          Iterable<Map<String, dynamic>>,
+          Map<String, dynamic>>(chopperResponse);
+      expect(converted.body, isA<Iterable<Map<String, dynamic>>>());
+      expect(converted.body.first['name'], 'item1');
+    });
+
+    test(
+        'decodeJson with Map<String, Map<String, dynamic>> and application/json content type',
+        () async {
+      final mapMapData = {
+        'item1': {'value': 100},
+        'item2': {'value': 200}
+      };
+      final jsonString = dart_convert.jsonEncode(mapMapData);
+      final bodyBytes = dart_convert.utf8.encode(jsonString);
+      final httpResponse = http.Response.bytes(bodyBytes, 200,
+          headers: {'content-type': 'application/json'});
+      final chopperResponse = Response(httpResponse, null);
+
+      final converted = await jsonConverter.decodeJson<
+          Map<String, Map<String, dynamic>>,
+          Map<String, dynamic>>(chopperResponse);
+      expect(converted.body, isA<Map<String, Map<String, dynamic>>>());
+      expect(converted.body['item1']!['value'], 100);
+    });
+  });
+
+  group('JsonConverter specific tryDecodeJson tests', () {
+    final jsonConverter = JsonConverter();
+
+    test('tryDecodeJson with valid JSON string', () {
+      final data = '{"message":"success"}';
+      final decoded = jsonConverter.tryDecodeJson(data);
+      expect(decoded, equals({'message': 'success'}));
+    });
+
+    test('tryDecodeJson with array JSON string', () {
+      final data = '[1, 2, "test"]';
+      final decoded = jsonConverter.tryDecodeJson(data);
+      expect(decoded, equals([1, 2, 'test']));
+    });
+
+    test('tryDecodeJson with invalid JSON (truncated)', () {
+      final data =
+          r"""'{"message":"success''"""; // Missing closing brace and quote
+      // Logger test would go here if we could mock/intercept chopperLogger.warning
+      final result = jsonConverter.tryDecodeJson(data);
+      expect(result, equals(data)); // Returns original data on failure
+    });
+
+    test('tryDecodeJson with invalid JSON (syntax error)', () {
+      final data = '{"message":success}'; // Value not in quotes
+      final result = jsonConverter.tryDecodeJson(data);
+      expect(result, equals(data));
+    });
+
+    test('tryDecodeJson with empty string', () {
+      final data = '';
+      final result = jsonConverter.tryDecodeJson(data);
+      expect(result, equals(data)); // Returns original data on failure
+    });
+  });
+
+  group('FormUrlEncodedConverter specific tests', () {
+    final formConverter = FormUrlEncodedConverter();
+
+    test('requestFactory uses FormUrlEncodedConverter correctly', () {
+      final requestBody = {'param1': 'value1', 'param2': 'value2'};
+      final request = Request(
+        'POST',
+        Uri.parse('/submit'),
+        baseUrl,
+        body: requestBody,
+      );
+      // requestFactory in FormUrlEncodedConverter adds the header if not present
+      final converted = FormUrlEncodedConverter.requestFactory(request);
+      expect(converted.headers[contentTypeKey], formEncodedHeaders);
+      expect(
+        converted.body,
+        equals(requestBody), // Body type is Map<String, String>
+      );
+    });
+
+    test('convertRequest with empty map body', () {
+      final request = Request(
+        'POST',
+        Uri.parse('/test'),
+        baseUrl,
+        body: {},
+        headers: {'content-type': 'application/x-www-form-urlencoded'},
+      );
+      final converted = formConverter.convertRequest(request);
+      expect(converted.body, equals({}));
+    });
+
+    test('convertRequest with map containing null or empty string values', () {
+      final request = Request(
+        'POST',
+        Uri.parse('/test'),
+        baseUrl,
+        body: {'key1': 'value1', 'key2': null, 'key3': '', 'key4': 'value4'},
+        headers: {'content-type': 'application/x-www-form-urlencoded'},
+      );
+      final converted = formConverter.convertRequest(request);
+      // Null values are removed, empty strings are kept if that's the Map behavior (it is for Map<String,String>)
+      // The converter specifically filters out null values in its loop.
+      expect(
+        converted.body,
+        equals({'key1': 'value1', 'key3': '', 'key4': 'value4'}),
       );
     });
   });

--- a/chopper/test/curl_interceptor_test.dart
+++ b/chopper/test/curl_interceptor_test.dart
@@ -1,0 +1,193 @@
+import 'package:chopper/src/interceptors/curl_interceptor.dart';
+import 'package:chopper/src/request.dart';
+import 'package:chopper/src/response.dart';
+import 'package:chopper/src/utils.dart';
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+
+import 'helpers/fake_chain.dart';
+
+void main() {
+  group('CurlInterceptor', () {
+    late Request simpleRequest;
+    late Request requestWithHeaders;
+    late Request requestWithBody;
+    late Request requestWithQuery;
+
+    setUp(() {
+      simpleRequest = Request(
+        'GET',
+        Uri.parse('/resource'),
+        Uri.parse('https://api.example.com'),
+      );
+
+      requestWithHeaders = Request(
+        'GET',
+        Uri.parse('/resource'),
+        Uri.parse('https://api.example.com'),
+        headers: {
+          'Authorization': 'Bearer token123',
+          'Content-Type': 'application/json',
+        },
+      );
+
+      requestWithBody = Request(
+        'POST',
+        Uri.parse('/resource'),
+        Uri.parse('https://api.example.com'),
+        body: '{"name": "test", "value": 42}',
+        headers: {'Content-Type': 'application/json'},
+      );
+
+      requestWithQuery = Request(
+        'GET',
+        Uri.parse('/resource?param1=value1&param2=value2'),
+        Uri.parse('https://api.example.com'),
+      );
+    });
+
+    test('generates basic curl command for simple requests', () async {
+      final interceptor = CurlInterceptor();
+      final logs = [];
+      chopperLogger.onRecord.listen((r) => logs.add(r.message));
+
+      await interceptor.intercept(FakeChain(simpleRequest));
+
+      expect(logs, hasLength(1));
+      expect(logs[0],
+          contains("curl -v -X GET 'https://api.example.com/resource'"));
+    });
+
+    test('includes headers in curl command', () async {
+      final interceptor = CurlInterceptor();
+      final logs = [];
+      chopperLogger.onRecord.listen((r) => logs.add(r.message));
+
+      await interceptor.intercept(FakeChain(requestWithHeaders));
+
+      expect(logs, hasLength(1));
+      expect(logs[0], contains("-H 'Authorization: Bearer token123'"));
+      expect(logs[0], contains("-H 'Content-Type: application/json'"));
+    });
+
+    test('includes body in curl command for POST requests', () async {
+      final interceptor = CurlInterceptor();
+      final logs = [];
+      chopperLogger.onRecord.listen((r) => logs.add(r.message));
+
+      await interceptor.intercept(FakeChain(requestWithBody));
+
+      expect(logs, hasLength(1));
+      expect(logs[0], contains("-d '{\"name\": \"test\", \"value\": 42}'"));
+    });
+
+    test('handles query parameters in URL', () async {
+      final interceptor = CurlInterceptor();
+      final logs = [];
+      chopperLogger.onRecord.listen((r) => logs.add(r.message));
+
+      await interceptor.intercept(FakeChain(requestWithQuery));
+
+      expect(logs, hasLength(1));
+      expect(
+          logs[0],
+          contains(
+              "'https://api.example.com/resource?param1=value1&param2=value2'"));
+    });
+
+    test('escapes single quotes in body', () async {
+      final requestWithQuotes = Request(
+        'POST',
+        Uri.parse('/resource'),
+        Uri.parse('https://api.example.com'),
+        body: "{'name': 'John's data', 'value': 'test'}",
+        // Body with a single quote that needs escaping
+        headers: {'Content-Type': 'application/json'},
+      );
+
+      final interceptor = CurlInterceptor();
+      final logs = [];
+      chopperLogger.onRecord.listen((r) => logs.add(r.message));
+
+      await interceptor.intercept(FakeChain(requestWithQuotes));
+
+      expect(logs, hasLength(1));
+      // The CurlInterceptor replaces single quotes with '\'' according to the implementation
+      expect(logs[0], contains("John'\\''s data"));
+    });
+
+    test('proceeds with the chain without modifying request', () async {
+      final interceptor = CurlInterceptor();
+      final chain = FakeChain(requestWithBody);
+
+      final response = await interceptor.intercept(chain);
+
+      // FakeChain.proceed returns a Response with 'TestChain' content
+      expect(response, isA<Response>());
+      expect(response.base, isA<http.Response>());
+      expect((response.base as http.Response).body, equals('TestChain'));
+    });
+  });
+
+  group('CurlInterceptor with multipart requests', () {
+    test('handles multipart requests with fields and files', () async {
+      // Create a mock request that will return our multipart request
+      final request = MockMultipartRequest(
+        'POST',
+        Uri.parse('/upload'),
+        Uri.parse('https://api.example.com'),
+      );
+
+      // Add fields and files to the multipart request that will be returned
+      request.setupMultipart((multipart) {
+        multipart.fields['field1'] = 'value1';
+        multipart.fields['field2'] = 'value2';
+        multipart.files.add(http.MultipartFile.fromString(
+            'file', 'test content',
+            filename: 'test.txt'));
+      });
+
+      final interceptor = CurlInterceptor();
+      final logs = [];
+      chopperLogger.onRecord.listen((r) => logs.add(r.message));
+
+      await interceptor.intercept(FakeChain(request));
+
+      expect(logs, hasLength(1));
+      // Instead of checking for exact text that might change based on implementation,
+      // verify that it contains the field names and values
+      expect(logs[0], contains('curl -v -X POST'));
+      expect(logs[0], contains('field1'));
+      expect(logs[0], contains('value1'));
+      expect(logs[0], contains('field2'));
+      expect(logs[0], contains('value2'));
+      expect(logs[0], contains('file'));
+    });
+  });
+}
+
+/// A Request that returns a MultipartRequest when toBaseRequest is called
+// ignore: must_be_immutable
+final class MockMultipartRequest extends Request {
+  MockMultipartRequest(
+    super.method,
+    super.url,
+    super.baseUrl, {
+    super.body,
+    super.headers,
+  });
+
+  final http.MultipartRequest _multipartRequest = http.MultipartRequest(
+    'POST',
+    Uri.parse('https://api.example.com/upload'),
+  );
+
+  void setupMultipart(void Function(http.MultipartRequest) setup) {
+    setup(_multipartRequest);
+  }
+
+  @override
+  Future<http.BaseRequest> toBaseRequest() async {
+    return _multipartRequest;
+  }
+}

--- a/chopper/test/date_format_test.dart
+++ b/chopper/test/date_format_test.dart
@@ -1,0 +1,159 @@
+import 'package:chopper/chopper.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DateFormat', () {
+    final testDateTime = DateTime.utc(2023, 1, 1, 12, 30, 45, 500);
+
+    test('enum values have correct names', () {
+      expect(DateFormat.seconds.name, equals('seconds'));
+      expect(DateFormat.unix.name, equals('unix'));
+      expect(DateFormat.milliseconds.name, equals('milliseconds'));
+      expect(DateFormat.microseconds.name, equals('microseconds'));
+      expect(DateFormat.utcIso8601.name, equals('utcIso8601'));
+      expect(DateFormat.localIso8601.name, equals('localIso8601'));
+      expect(DateFormat.iso8601.name, equals('iso8601'));
+      expect(DateFormat.rfc2822.name, equals('rfc2822'));
+      expect(DateFormat.date.name, equals('date'));
+      expect(DateFormat.time.name, equals('time'));
+      expect(DateFormat.string.name, equals('string'));
+    });
+
+    test('toString returns the name of the enum value', () {
+      expect(DateFormat.seconds.toString(), equals('seconds'));
+      expect(DateFormat.unix.toString(), equals('unix'));
+      expect(DateFormat.milliseconds.toString(), equals('milliseconds'));
+      expect(DateFormat.microseconds.toString(), equals('microseconds'));
+      expect(DateFormat.utcIso8601.toString(), equals('utcIso8601'));
+      expect(DateFormat.localIso8601.toString(), equals('localIso8601'));
+      expect(DateFormat.iso8601.toString(), equals('iso8601'));
+      expect(DateFormat.rfc2822.toString(), equals('rfc2822'));
+      expect(DateFormat.date.toString(), equals('date'));
+      expect(DateFormat.time.toString(), equals('time'));
+      expect(DateFormat.string.toString(), equals('string'));
+    });
+
+    test('serializers produce expected format', () {
+      // Calculate expected values directly from testDateTime
+      final expectedSeconds =
+          (testDateTime.millisecondsSinceEpoch ~/ 1000).toString();
+      final expectedMilliseconds =
+          testDateTime.millisecondsSinceEpoch.toString();
+      final expectedMicroseconds =
+          testDateTime.microsecondsSinceEpoch.toString();
+
+      // Test seconds serializer
+      final secondsResult = DateFormat.seconds(testDateTime);
+      expect(secondsResult, equals(expectedSeconds));
+
+      // Test unix serializer (alias for seconds)
+      final unixResult = DateFormat.unix(testDateTime);
+      expect(unixResult, equals(expectedSeconds));
+
+      // Test that seconds and unix produce the same result
+      expect(secondsResult, equals(unixResult));
+
+      // Test milliseconds serializer
+      final msResult = DateFormat.milliseconds(testDateTime);
+      expect(msResult, equals(expectedMilliseconds));
+
+      // Test microseconds serializer
+      final usResult = DateFormat.microseconds(testDateTime);
+      expect(usResult, equals(expectedMicroseconds));
+
+      // Calculate expected values for ISO8601 formats
+      final expectedUtcIso8601 = testDateTime.toUtc().toIso8601String();
+      final expectedIso8601 = testDateTime.toIso8601String();
+
+      // Test utcIso8601 serializer
+      final utcResult = DateFormat.utcIso8601(testDateTime);
+      expect(utcResult, equals(expectedUtcIso8601));
+
+      // Test localIso8601 serializer
+      final localResult = DateFormat.localIso8601(testDateTime);
+      // Since this converts to local timezone, we can't test exact value
+      // but we can verify it follows the ISO8601 format without Z suffix
+      expect(
+        localResult,
+        matches(r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}$'),
+      );
+
+      // Test iso8601 serializer
+      final isoResult = DateFormat.iso8601(testDateTime);
+      expect(isoResult, equals(expectedIso8601));
+
+      // Test rfc2822 serializer
+      final rfc2822Result = DateFormat.rfc2822(testDateTime);
+      // Manually construct expected RFC 2822 format
+      final expectedRfc2822 = 'Sun, 01 Jan 2023 12:30:45 GMT';
+      expect(rfc2822Result, equals(expectedRfc2822));
+
+      // Test date serializer
+      final dateResult = DateFormat.date(testDateTime);
+      final expectedDate = '${testDateTime.year.toString().padLeft(4, '0')}-'
+          '${testDateTime.month.toString().padLeft(2, '0')}-'
+          '${testDateTime.day.toString().padLeft(2, '0')}';
+      expect(dateResult, equals(expectedDate));
+
+      // Test time serializer
+      final timeResult = DateFormat.time(testDateTime);
+      final expectedTime = '${testDateTime.hour.toString().padLeft(2, '0')}:'
+          '${testDateTime.minute.toString().padLeft(2, '0')}:'
+          '${testDateTime.second.toString().padLeft(2, '0')}';
+      expect(timeResult, equals(expectedTime));
+
+      // Test string serializer
+      final stringResult = DateFormat.string(testDateTime);
+      final expectedString = testDateTime.toString();
+      expect(stringResult, equals(expectedString));
+    });
+  });
+
+  group('Request with DateFormat', () {
+    final testDateTime = DateTime.utc(2023, 1, 1, 12, 30, 45, 500);
+
+    test('can be constructed with a DateFormat', () {
+      final request = Request(
+        'GET',
+        Uri.parse('/test'),
+        Uri.parse('https://example.com'),
+        parameters: {'date': testDateTime},
+        dateFormat: DateFormat.seconds,
+      );
+
+      expect(request.dateFormat, equals(DateFormat.seconds));
+    });
+
+    test('preserves DateFormat in copyWith', () {
+      final request = Request(
+        'GET',
+        Uri.parse('/test'),
+        Uri.parse('https://example.com'),
+        parameters: {'date': testDateTime},
+        dateFormat: DateFormat.seconds,
+      );
+
+      final copiedRequest = request.copyWith(
+        method: 'POST',
+      );
+
+      expect(copiedRequest.dateFormat, equals(DateFormat.seconds));
+    });
+
+    test('can override DateFormat in copyWith', () {
+      final request = Request(
+        'GET',
+        Uri.parse('/test'),
+        Uri.parse('https://example.com'),
+        parameters: {'date': testDateTime},
+        dateFormat: DateFormat.seconds,
+      );
+
+      final copiedRequest = request.copyWith(
+        dateFormat: DateFormat.milliseconds,
+      );
+
+      expect(copiedRequest.dateFormat, equals(DateFormat.milliseconds));
+    });
+  });
+}

--- a/chopper/test/fixtures/http_response_fixture.dart
+++ b/chopper/test/fixtures/http_response_fixture.dart
@@ -15,15 +15,17 @@ extension ResponseFixture on http.Response {
 final class ResponseFactory extends FixtureFactory<http.Response> {
   @override
   FixtureDefinition<http.Response> definition() => define(
-        (Faker faker) => http.Response(
+        (Faker faker, [int index = 0]) => http.Response(
           jsonEncode(PayloadFixture.factory.makeSingle().toJson()),
           200,
         ),
       );
 
   FixtureRedefinitionBuilder<http.Response> body(String? body) =>
-      (http.Response response) => response.copyWith(body: body);
+      (http.Response response, [int index = 0]) =>
+          response.copyWith(body: body);
 
   FixtureRedefinitionBuilder<http.Response> statusCode(int? statusCode) =>
-      (http.Response response) => response.copyWith(statusCode: statusCode);
+      (http.Response response, [int index = 0]) =>
+          response.copyWith(statusCode: statusCode);
 }

--- a/chopper/test/fixtures/payload_fixture.dart
+++ b/chopper/test/fixtures/payload_fixture.dart
@@ -11,7 +11,7 @@ extension PayloadFixture on Payload {
 final class PayloadFactory extends FixtureFactory<Payload> {
   @override
   FixtureDefinition<Payload> definition() => define(
-        (Faker faker) => Payload(
+        (Faker faker, [int index = 0]) => Payload(
           statusCode: 200,
           message: faker.lorem.sentence(),
         ),

--- a/chopper/test/fixtures/request_fixture.dart
+++ b/chopper/test/fixtures/request_fixture.dart
@@ -16,7 +16,7 @@ final class RequestFixtureFactory extends FixtureFactory<Request> {
         faker.randomGenerator.element(['GET', 'POST', 'PUT', 'DELETE']);
 
     return define(
-      (Faker faker) => Request(
+      (Faker faker, [int index = 0]) => Request(
         method,
         Uri.parse('/${faker.lorem.word()}'),
         Uri.https(faker.internet.domainName()),

--- a/chopper/test/fixtures/response_fixture.dart
+++ b/chopper/test/fixtures/response_fixture.dart
@@ -17,13 +17,14 @@ final class ResponseFixtureFactory<T> extends FixtureFactory<Response<T>> {
         http_fixture.ResponseFixture.factory.makeSingle();
 
     return define(
-      (Faker faker) => Response<T>(base, null),
+      (Faker faker, [int index = 0]) => Response<T>(base, null),
     );
   }
 
   FixtureRedefinitionBuilder<Response<T>> body(T? body) =>
-      (Response<T> response) => response.copyWith(body: body);
+      (Response<T> response, [int index = 0]) => response.copyWith(body: body);
 
   FixtureRedefinitionBuilder<Response<T>> error(Object? value) =>
-      (Response<T> response) => response.copyWith(bodyError: value);
+      (Response<T> response, [int index = 0]) =>
+          response.copyWith(bodyError: value);
 }

--- a/chopper/test/helpers/fake_chain.dart
+++ b/chopper/test/helpers/fake_chain.dart
@@ -5,16 +5,39 @@ import 'package:chopper/src/request.dart';
 import 'package:chopper/src/response.dart';
 import 'package:http/http.dart' as http;
 
-class FakeChain<BodyType> implements Chain {
-  FakeChain(this.request, {this.response});
+/// A fake implementation of [Chain] for testing purposes.
+class FakeChain<BodyType> implements Chain<BodyType> {
+  FakeChain(
+    this.request, {
+    this.response,
+    this.exception,
+  }) : assert(
+          response == null || exception == null,
+          'Either response or exception must be provided, not both.',
+        );
 
   @override
   final Request request;
-  final Response? response;
+
+  /// The fake response to be returned by the chain.
+  final Response<BodyType>? response;
+
+  /// The fake exception to be returned by the chain.
+  final Exception? exception;
 
   @override
   FutureOr<Response<BodyType>> proceed(Request request) {
-    return response as Response<BodyType>? ??
-        Response(http.Response('TestChain', 200), 'TestChain' as BodyType);
+    if (exception != null) {
+      throw exception!;
+    }
+
+    if (response != null) {
+      return response!;
+    }
+
+    return Response<BodyType>(
+      http.Response('TestChain', 200),
+      'TestChain' as BodyType,
+    );
   }
 }

--- a/chopper/test/http_call_interceptor_test.dart
+++ b/chopper/test/http_call_interceptor_test.dart
@@ -1,0 +1,56 @@
+import 'dart:async';
+
+import 'package:chopper/src/chopper_exception.dart';
+import 'package:chopper/src/interceptors/http_call_interceptor.dart';
+import 'package:chopper/src/request.dart';
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+
+import 'helpers/fake_chain.dart';
+
+void main() {
+  group('HttpCallInterceptor', () {
+    late http.Client mockClient;
+    late HttpCallInterceptor interceptor;
+
+    setUp(() {
+      mockClient = MockHttpClient();
+      interceptor = HttpCallInterceptor(mockClient);
+    });
+
+    test('throws ChopperException for unsupported response type', () async {
+      final request = Request(
+        'GET',
+        Uri.parse('/test'),
+        Uri.parse('https://example.com'),
+      );
+
+      final chain = UnsupportedTypeChain(request);
+
+      expect(
+        () => interceptor.intercept(chain),
+        throwsA(isA<ChopperException>()
+            .having((e) => e.message, 'message', 'Unsupported type')
+            .having((e) => e.request, 'request', equals(request))),
+      );
+    });
+  });
+}
+
+// A custom Chain implementation that forces the HttpCallInterceptor to handle
+// an unsupported response body type (int)
+class UnsupportedTypeChain extends FakeChain<int> {
+  UnsupportedTypeChain(super.request);
+}
+
+// Mock HTTP client that doesn't need to return anything for this test
+class MockHttpClient extends http.BaseClient {
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    // We won't reach this code because the exception is thrown before the actual HTTP call
+    return http.StreamedResponse(
+      Stream.empty(),
+      200,
+    );
+  }
+}

--- a/chopper/test/request_stream_interceptor_test.dart
+++ b/chopper/test/request_stream_interceptor_test.dart
@@ -1,0 +1,118 @@
+import 'dart:async';
+
+import 'package:chopper/chopper.dart';
+import 'package:chopper/src/interceptors/request_stream_interceptor.dart';
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+
+void main() {
+  group('RequestStreamInterceptor', () {
+    late List<Request> recordedRequests;
+    late RequestStreamInterceptor interceptor;
+
+    setUp(() {
+      recordedRequests = [];
+      interceptor = RequestStreamInterceptor((request) {
+        recordedRequests.add(request);
+      });
+    });
+
+    test('calls the callback with the request', () async {
+      final request = Request(
+        'POST',
+        Uri.parse('/resource'),
+        Uri.parse('https://api.example.com'),
+        body: 'test body',
+      );
+
+      final chain = CustomFakeChain(request);
+
+      await interceptor.intercept(chain);
+
+      // Verify the callback was called with the request
+      expect(recordedRequests, hasLength(1));
+      expect(recordedRequests.first, equals(request));
+
+      // Verify the request was passed through to the chain
+      expect(chain.processedRequest, equals(request));
+    });
+
+    test('handles requests with null body', () async {
+      final request = Request(
+        'GET',
+        Uri.parse('/resource'),
+        Uri.parse('https://api.example.com'),
+      );
+
+      final chain = CustomFakeChain(request);
+
+      await interceptor.intercept(chain);
+
+      // Verify the callback was called with the request
+      expect(recordedRequests, hasLength(1));
+      expect(recordedRequests.first, equals(request));
+    });
+
+    test(
+      'handles requests with stream body (passes through)',
+      () async {
+        final streamController = StreamController<String>();
+        final completer = Completer<void>();
+
+        // Create a request with a stream body
+        final request = Request(
+          'POST',
+          Uri.parse('/resource'),
+          Uri.parse('https://api.example.com'),
+          body: streamController.stream,
+        );
+
+        final chain = CustomFakeChain(request);
+
+        // Add data to the stream and close it immediately to avoid hanging
+        streamController.add('test data');
+        streamController.close();
+
+        // Properly handle the FutureOr return type
+        final result = interceptor.intercept(chain);
+        if (result is Future) {
+          await result;
+        }
+        completer.complete();
+
+        // Wait for the interceptor to complete
+        await completer.future;
+
+        // Verify the callback was called with the request
+        expect(recordedRequests, hasLength(1));
+        expect(recordedRequests.first, equals(request));
+
+        // The stream should be the same instance, but we can't directly compare streams
+        // Instead verify it's a Stream instance
+        expect(chain.processedRequest?.body, isA<Stream<String>>());
+      },
+      timeout: const Timeout(Duration(seconds: 5)),
+    );
+  });
+}
+
+/// Custom implementation of FakeChain to track processed requests
+class CustomFakeChain<T> implements Chain<T> {
+  CustomFakeChain(this.request, {this.response});
+
+  @override
+  final Request request;
+
+  final Response<T>? response;
+
+  Request? processedRequest;
+
+  @override
+  Future<Response<T>> proceed(Request request) async {
+    processedRequest = request;
+    return Response<T>(
+      http.Response('', 200),
+      null as T,
+    );
+  }
+}

--- a/chopper/test/response_test.dart
+++ b/chopper/test/response_test.dart
@@ -111,4 +111,105 @@ void main() {
       expect(() => response.bodyOrThrow, returnsNormally);
     });
   });
+
+  group('copyWith tests', () {
+    final baseResponse = http.Response('Base response body', 200);
+    final initialBody = {'key': 'value'};
+    final initialError = 'Initial Error';
+    final initialResponse = Response(
+      baseResponse,
+      initialBody,
+      error: initialError,
+    );
+
+    test('copyWith no parameters uses existing values', () {
+      final copiedResponse = initialResponse.copyWith();
+
+      expect(copiedResponse.base, baseResponse);
+      expect(copiedResponse.body, initialBody);
+      expect(copiedResponse.error, initialError);
+      expect(copiedResponse.statusCode, 200);
+    });
+
+    test('copyWith changes base response', () {
+      final newBaseResponse = http.Response('New base response body', 201);
+      final copiedResponse = initialResponse.copyWith(base: newBaseResponse);
+
+      expect(copiedResponse.base, newBaseResponse);
+      expect(copiedResponse.body, initialBody);
+      expect(copiedResponse.error, initialError);
+      expect(copiedResponse.statusCode, 201);
+    });
+
+    test('copyWith changes body', () {
+      final newBody = {'newKey': 'newValue'};
+      final copiedResponse = initialResponse.copyWith(body: newBody);
+
+      expect(copiedResponse.base, baseResponse);
+      expect(copiedResponse.body, newBody);
+      expect(copiedResponse.error, initialError);
+    });
+
+    test('copyWith changes error', () {
+      final newError = 'New Error';
+      final copiedResponse = initialResponse.copyWith(bodyError: newError);
+
+      expect(copiedResponse.base, baseResponse);
+      expect(copiedResponse.body, initialBody);
+      expect(copiedResponse.error, newError);
+    });
+
+    test('copyWith changes body type', () {
+      final newBody = 'New body string';
+      final Response<String> copiedResponse =
+          initialResponse.copyWith<String>(body: newBody);
+
+      expect(copiedResponse.base, baseResponse);
+      expect(copiedResponse.body, newBody);
+      expect(copiedResponse.error, initialError);
+      expect(copiedResponse.body, isA<String>());
+    });
+
+    test('copyWith with all parameters', () {
+      final newBaseResponse = http.Response('New base response body', 202);
+      final newBody = {'newKey': 'newValue'};
+      final newError = 'New Error';
+      final copiedResponse = initialResponse.copyWith(
+        base: newBaseResponse,
+        body: newBody,
+        bodyError: newError,
+      );
+
+      expect(copiedResponse.base, newBaseResponse);
+      expect(copiedResponse.body, newBody);
+      expect(copiedResponse.error, newError);
+      expect(copiedResponse.statusCode, 202);
+    });
+  });
+
+  group('bodyBytes and bodyString tests', () {
+    test('bodyBytes returns Uint8List(0) when base is not http.Response', () {
+      final base = http.StreamedResponse(Stream.fromIterable([]), 200);
+      final response = Response(base, null);
+      expect(response.bodyBytes, []);
+    });
+
+    test('bodyString returns empty string when base is not http.Response', () {
+      final base = http.StreamedResponse(Stream.fromIterable([]), 200);
+      final response = Response(base, null);
+      expect(response.bodyString, '');
+    });
+
+    test('bodyBytes returns correct bytes when base is http.Response', () {
+      final base = http.Response.bytes([1, 2, 3], 200);
+      final response = Response(base, null);
+      expect(response.bodyBytes, [1, 2, 3]);
+    });
+
+    test('bodyString returns correct string when base is http.Response', () {
+      final base = http.Response('test body', 200);
+      final response = Response(base, null);
+      expect(response.bodyString, 'test body');
+    });
+  });
 }

--- a/chopper/test/test_service.chopper.dart
+++ b/chopper/test/test_service.chopper.dart
@@ -772,6 +772,160 @@ final class _$HttpTestService extends HttpTestService {
   }
 
   @override
+  Future<Response<String>> getDateTimeFormatIso8601(DateTime value) {
+    final Uri $url = Uri.parse('/test/date_time_format_iso8601');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      dateFormat: DateFormat.iso8601,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getDateTimeFormatUtcIso8601(DateTime value) {
+    final Uri $url = Uri.parse('/test/date_time_format_utcIso8601');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      dateFormat: DateFormat.utcIso8601,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getDateTimeFormatLocalIso8601(DateTime value) {
+    final Uri $url = Uri.parse('/test/date_time_format_localIso8601');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      dateFormat: DateFormat.localIso8601,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getDateTimeFormatSeconds(DateTime value) {
+    final Uri $url = Uri.parse('/test/date_time_format_seconds');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      dateFormat: DateFormat.seconds,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getDateTimeFormatUnix(DateTime value) {
+    final Uri $url = Uri.parse('/test/date_time_format_unix');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      dateFormat: DateFormat.unix,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getDateTimeFormatMilliseconds(DateTime value) {
+    final Uri $url = Uri.parse('/test/date_time_format_milliseconds');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      dateFormat: DateFormat.milliseconds,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getDateTimeFormatMicroseconds(DateTime value) {
+    final Uri $url = Uri.parse('/test/date_time_format_microseconds');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      dateFormat: DateFormat.microseconds,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getDateTimeFormatRfc2822(DateTime value) {
+    final Uri $url = Uri.parse('/test/date_time_format_rfc2822');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      dateFormat: DateFormat.rfc2822,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getDateTimeFormatDate(DateTime value) {
+    final Uri $url = Uri.parse('/test/date_time_format_date');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      dateFormat: DateFormat.date,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getDateTimeFormatTime(DateTime value) {
+    final Uri $url = Uri.parse('/test/date_time_format_time');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      dateFormat: DateFormat.time,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getDateTimeFormatString(DateTime value) {
+    final Uri $url = Uri.parse('/test/date_time_format_string');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      dateFormat: DateFormat.string,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
   Future<Response<String>> getHeaders({
     required String stringHeader,
     bool? boolHeader,

--- a/chopper/test/test_service.dart
+++ b/chopper/test/test_service.dart
@@ -231,8 +231,84 @@ abstract class HttpTestService extends ChopperService {
     @Query('value') Map<String, dynamic> value,
   );
 
+  /// Default [DateFormat]
   @GET(path: '/date_time')
   Future<Response<String>> getDateTime(
+    @Query('value') DateTime value,
+  );
+
+  /// [DateFormat.iso8601]
+  @GET(path: '/date_time_format_iso8601', dateFormat: DateFormat.iso8601)
+  Future<Response<String>> getDateTimeFormatIso8601(
+    @Query('value') DateTime value,
+  );
+
+  /// [DateFormat.utcIso8601]
+  @GET(path: '/date_time_format_utcIso8601', dateFormat: DateFormat.utcIso8601)
+  Future<Response<String>> getDateTimeFormatUtcIso8601(
+    @Query('value') DateTime value,
+  );
+
+  /// [DateFormat.localIso8601]
+  @GET(
+    path: '/date_time_format_localIso8601',
+    dateFormat: DateFormat.localIso8601,
+  )
+  Future<Response<String>> getDateTimeFormatLocalIso8601(
+    @Query('value') DateTime value,
+  );
+
+  /// [DateFormat.seconds]
+  @GET(path: '/date_time_format_seconds', dateFormat: DateFormat.seconds)
+  Future<Response<String>> getDateTimeFormatSeconds(
+    @Query('value') DateTime value,
+  );
+
+  /// [DateFormat.unix]
+  @GET(path: '/date_time_format_unix', dateFormat: DateFormat.unix)
+  Future<Response<String>> getDateTimeFormatUnix(
+    @Query('value') DateTime value,
+  );
+
+  /// [DateFormat.milliseconds]
+  @GET(
+    path: '/date_time_format_milliseconds',
+    dateFormat: DateFormat.milliseconds,
+  )
+  Future<Response<String>> getDateTimeFormatMilliseconds(
+    @Query('value') DateTime value,
+  );
+
+  /// [DateFormat.microseconds]
+  @GET(
+    path: '/date_time_format_microseconds',
+    dateFormat: DateFormat.microseconds,
+  )
+  Future<Response<String>> getDateTimeFormatMicroseconds(
+    @Query('value') DateTime value,
+  );
+
+  /// [DateFormat.rfc2822]
+  @GET(path: '/date_time_format_rfc2822', dateFormat: DateFormat.rfc2822)
+  Future<Response<String>> getDateTimeFormatRfc2822(
+    @Query('value') DateTime value,
+  );
+
+  /// [DateFormat.date]
+  @GET(path: '/date_time_format_date', dateFormat: DateFormat.date)
+  Future<Response<String>> getDateTimeFormatDate(
+    @Query('value') DateTime value,
+  );
+
+  /// [DateFormat.time]
+  @GET(path: '/date_time_format_time', dateFormat: DateFormat.time)
+  Future<Response<String>> getDateTimeFormatTime(
+    @Query('value') DateTime value,
+  );
+
+  /// [DateFormat.string]
+  @GET(path: '/date_time_format_string', dateFormat: DateFormat.string)
+  Future<Response<String>> getDateTimeFormatString(
     @Query('value') DateTime value,
   );
 

--- a/chopper_built_value/lib/chopper_built_value.dart
+++ b/chopper_built_value/lib/chopper_built_value.dart
@@ -40,7 +40,7 @@ class BuiltValueConverter implements Converter, ErrorConverter {
     return BuiltList<InnerType>(deserialized.toList(growable: false));
   }
 
-  BodyType? deserialize<BodyType, InnerType>(entity) {
+  BodyType? deserialize<BodyType, InnerType>(dynamic entity) {
     if (entity is BodyType) return entity;
     if (entity is Iterable) {
       return _deserializeListOf<InnerType>(entity) as BodyType;

--- a/chopper_built_value/pubspec.yaml
+++ b/chopper_built_value/pubspec.yaml
@@ -16,9 +16,9 @@ dependencies:
 dev_dependencies:
   test: ^1.25.5
   build_runner: ^2.4.9
-  build_test: ^2.2.2
+  build_test: ^3.1.0
   built_value_generator: ^8.9.2
-  lints: ">=4.0.0 <6.0.0"
+  lints: ">=4.0.0 <7.0.0"
 
 topics:
   - codegen

--- a/chopper_built_value/test/converter_test.dart
+++ b/chopper_built_value/test/converter_test.dart
@@ -97,5 +97,25 @@ void main() {
 
       expect(convertedResponse.body.message, equals('Error message'));
     });
+
+    test('convert error falls back to raw body when deserialization fails',
+        () async {
+      // Create a converter without an errorType specified to trigger the fallback path
+      final converterWithoutErrorType = BuiltValueConverter(jsonSerializers);
+
+      // JSON object that doesn't match any model and has no wireName
+      final string =
+          '{"unknown":"structure", "that": "wont", "match": "any model"}';
+      final response = Response(http.Response(string, 400), string);
+
+      final convertedResponse =
+          await converterWithoutErrorType.convertError(response);
+
+      // Check that the body is the raw JSON object (fallback path was taken)
+      expect(convertedResponse.body, isA<Map<String, dynamic>>());
+      expect(convertedResponse.body['unknown'], equals('structure'));
+      expect(convertedResponse.body['that'], equals('wont'));
+      expect(convertedResponse.body['match'], equals('any model'));
+    });
   });
 }

--- a/chopper_generator/CHANGELOG.md
+++ b/chopper_generator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 8.2.0
+
+- Add `DateFormat` to enhance date serialization options ([#668](https://github.com/lejard-h/chopper/pull/668))
+
 ## 8.1.0
 
 - Deprecate all lower-case method annotations ([#651](https://github.com/lejard-h/chopper/pull/651))

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -405,6 +405,8 @@ final class ChopperGenerator
 
       final chopper.ListFormat? listFormat = Utils.getListFormat(method);
 
+      final chopper.DateFormat? dateFormat = Utils.getDateFormat(method);
+
       final bool? useBrackets = Utils.getUseBrackets(method);
 
       final bool? includeNullQueryVars = Utils.getIncludeNullQueryVars(method);
@@ -424,6 +426,7 @@ final class ChopperGenerator
                 listFormat: listFormat,
                 // ignore: deprecated_member_use_from_same_package
                 useBrackets: useBrackets,
+                dateFormat: dateFormat,
                 includeNullQueryVars: includeNullQueryVars,
               ),
             )
@@ -719,6 +722,7 @@ final class ChopperGenerator
     bool useHeaders = false,
     chopper.ListFormat? listFormat,
     @Deprecated('Use listFormat instead') bool? useBrackets,
+    chopper.DateFormat? dateFormat,
     bool? includeNullQueryVars,
     Reference? tagRefer,
   }) =>
@@ -740,6 +744,8 @@ final class ChopperGenerator
           if (listFormat != null)
             'listFormat': refer('ListFormat').type.property(listFormat.name),
           if (useBrackets != null) 'useBrackets': literalBool(useBrackets),
+          if (dateFormat != null)
+            'dateFormat': refer('DateFormat').type.property(dateFormat.name),
           if (includeNullQueryVars != null)
             'includeNullQueryVars': literalBool(includeNullQueryVars),
         },

--- a/chopper_generator/lib/src/utils.dart
+++ b/chopper_generator/lib/src/utils.dart
@@ -3,7 +3,7 @@
 import 'dart:math' show max;
 
 import 'package:analyzer/dart/element/element.dart';
-import 'package:chopper/chopper.dart' show ListFormat;
+import 'package:chopper/chopper.dart' show DateFormat, ListFormat;
 import 'package:chopper_generator/src/extensions.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:collection/collection.dart';
@@ -21,10 +21,22 @@ final class Utils {
 
   static ListFormat? getListFormat(ConstantReader method) {
     return ListFormat.values.firstWhereOrNull(
-      (listFormat) =>
+      (ListFormat listFormat) =>
           listFormat.name ==
           method
               .peek('listFormat')
+              ?.objectValue
+              .getField('_name')
+              ?.toStringValue(),
+    );
+  }
+
+  static DateFormat? getDateFormat(ConstantReader method) {
+    return DateFormat.values.firstWhereOrNull(
+      (DateFormat fmt) =>
+          fmt.name ==
+          method
+              .peek('dateFormat')
               ?.objectValue
               .getField('_name')
               ?.toStringValue(),

--- a/chopper_generator/pubspec.yaml
+++ b/chopper_generator/pubspec.yaml
@@ -23,7 +23,7 @@ dev_dependencies:
   build_runner: ^2.4.9
   build_verify: ^3.1.0
   http: ^1.1.0
-  lints: ">=4.0.0 <6.0.0"
+  lints: ">=4.0.0 <7.0.0"
   test: ^1.25.5
 
 topics:

--- a/chopper_generator/pubspec.yaml
+++ b/chopper_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chopper_generator
 description: Chopper is an http client generator using source_gen, inspired by Retrofit
-version: 8.1.0
+version: 8.2.0
 documentation: https://hadrien-lejard.gitbook.io/chopper
 repository: https://github.com/lejard-h/chopper
 
@@ -11,7 +11,7 @@ dependencies:
   analyzer: ">=6.9.0 <8.0.0"
   build: ^2.4.1
   built_collection: ^5.1.1
-  chopper: ^8.0.4
+  chopper: ^8.1.0
   code_builder: ^4.10.0
   logging: ^1.2.0
   meta: ^1.9.1

--- a/chopper_generator/test/test_service.chopper.dart
+++ b/chopper_generator/test/test_service.chopper.dart
@@ -854,6 +854,173 @@ final class _$HttpTestService extends HttpTestService {
   }
 
   @override
+  Future<Response<String>> getDateTime(DateTime value) {
+    final Uri $url = Uri.parse('/test/date_time');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getDateTimeFormatIso8601(DateTime value) {
+    final Uri $url = Uri.parse('/test/date_time_format_iso8601');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      dateFormat: DateFormat.iso8601,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getDateTimeFormatUtcIso8601(DateTime value) {
+    final Uri $url = Uri.parse('/test/date_time_format_utcIso8601');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      dateFormat: DateFormat.utcIso8601,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getDateTimeFormatLocalIso8601(DateTime value) {
+    final Uri $url = Uri.parse('/test/date_time_format_localIso8601');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      dateFormat: DateFormat.localIso8601,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getDateTimeFormatSeconds(DateTime value) {
+    final Uri $url = Uri.parse('/test/date_time_format_seconds');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      dateFormat: DateFormat.seconds,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getDateTimeFormatUnix(DateTime value) {
+    final Uri $url = Uri.parse('/test/date_time_format_unix');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      dateFormat: DateFormat.unix,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getDateTimeFormatMilliseconds(DateTime value) {
+    final Uri $url = Uri.parse('/test/date_time_format_milliseconds');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      dateFormat: DateFormat.milliseconds,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getDateTimeFormatMicroseconds(DateTime value) {
+    final Uri $url = Uri.parse('/test/date_time_format_microseconds');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      dateFormat: DateFormat.microseconds,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getDateTimeFormatRfc2822(DateTime value) {
+    final Uri $url = Uri.parse('/test/date_time_format_rfc2822');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      dateFormat: DateFormat.rfc2822,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getDateTimeFormatDate(DateTime value) {
+    final Uri $url = Uri.parse('/test/date_time_format_date');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      dateFormat: DateFormat.date,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getDateTimeFormatTime(DateTime value) {
+    final Uri $url = Uri.parse('/test/date_time_format_time');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      dateFormat: DateFormat.time,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
+  Future<Response<String>> getDateTimeFormatString(DateTime value) {
+    final Uri $url = Uri.parse('/test/date_time_format_string');
+    final Map<String, dynamic> $params = <String, dynamic>{'value': value};
+    final Request $request = Request(
+      'GET',
+      $url,
+      client.baseUrl,
+      parameters: $params,
+      dateFormat: DateFormat.string,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
   Future<Response<String>> getHeaders({
     required String stringHeader,
     bool? boolHeader,

--- a/chopper_generator/test/test_service.dart
+++ b/chopper_generator/test/test_service.dart
@@ -256,6 +256,87 @@ abstract class HttpTestService extends ChopperService {
     @Query('value') Map<String, dynamic> value,
   );
 
+  /// Default [DateFormat]
+  @GET(path: '/date_time')
+  Future<Response<String>> getDateTime(
+    @Query('value') DateTime value,
+  );
+
+  /// [DateFormat.iso8601]
+  @GET(path: '/date_time_format_iso8601', dateFormat: DateFormat.iso8601)
+  Future<Response<String>> getDateTimeFormatIso8601(
+    @Query('value') DateTime value,
+  );
+
+  /// [DateFormat.utcIso8601]
+  @GET(path: '/date_time_format_utcIso8601', dateFormat: DateFormat.utcIso8601)
+  Future<Response<String>> getDateTimeFormatUtcIso8601(
+    @Query('value') DateTime value,
+  );
+
+  /// [DateFormat.localIso8601]
+  @GET(
+    path: '/date_time_format_localIso8601',
+    dateFormat: DateFormat.localIso8601,
+  )
+  Future<Response<String>> getDateTimeFormatLocalIso8601(
+    @Query('value') DateTime value,
+  );
+
+  /// [DateFormat.seconds]
+  @GET(path: '/date_time_format_seconds', dateFormat: DateFormat.seconds)
+  Future<Response<String>> getDateTimeFormatSeconds(
+    @Query('value') DateTime value,
+  );
+
+  /// [DateFormat.unix]
+  @GET(path: '/date_time_format_unix', dateFormat: DateFormat.unix)
+  Future<Response<String>> getDateTimeFormatUnix(
+    @Query('value') DateTime value,
+  );
+
+  /// [DateFormat.milliseconds]
+  @GET(
+    path: '/date_time_format_milliseconds',
+    dateFormat: DateFormat.milliseconds,
+  )
+  Future<Response<String>> getDateTimeFormatMilliseconds(
+    @Query('value') DateTime value,
+  );
+
+  /// [DateFormat.microseconds]
+  @GET(
+    path: '/date_time_format_microseconds',
+    dateFormat: DateFormat.microseconds,
+  )
+  Future<Response<String>> getDateTimeFormatMicroseconds(
+    @Query('value') DateTime value,
+  );
+
+  /// [DateFormat.rfc2822]
+  @GET(path: '/date_time_format_rfc2822', dateFormat: DateFormat.rfc2822)
+  Future<Response<String>> getDateTimeFormatRfc2822(
+    @Query('value') DateTime value,
+  );
+
+  /// [DateFormat.date]
+  @GET(path: '/date_time_format_date', dateFormat: DateFormat.date)
+  Future<Response<String>> getDateTimeFormatDate(
+    @Query('value') DateTime value,
+  );
+
+  /// [DateFormat.time]
+  @GET(path: '/date_time_format_time', dateFormat: DateFormat.time)
+  Future<Response<String>> getDateTimeFormatTime(
+    @Query('value') DateTime value,
+  );
+
+  /// [DateFormat.string]
+  @GET(path: '/date_time_format_string', dateFormat: DateFormat.string)
+  Future<Response<String>> getDateTimeFormatString(
+    @Query('value') DateTime value,
+  );
+
   @GET(path: 'headers')
   Future<Response<String>> getHeaders({
     @Header('x-string') required String stringHeader,

--- a/faq.md
+++ b/faq.md
@@ -67,7 +67,7 @@ Request compressRequest(Request request) {
 ...
 
 @FactoryConverter(request: compressRequest)
-@Post()
+@POST()
 Future<Response> postRequest(@Body() Map<String, String> data);
 ```
 
@@ -131,7 +131,7 @@ abstract class ApiService extends ChopperService {
     return _$ApiService(client);
   }
 
-  @Get(path: "/get")
+  @GET(path: "/get")
   Future<Response> get(@Query() String url);
 }
 ```
@@ -487,7 +487,7 @@ abstract class TodosListService extends ChopperService {
   @factoryMethod
   static TodosListService create(ChopperClient client) => _$TodosListService(client);
 
-  @Get()
+  @GET()
   Future<Response<List<Todo>>> getTodos();
 }
 ```

--- a/getting-started.md
+++ b/getting-started.md
@@ -53,17 +53,17 @@ The `@ChopperApi` annotation takes one optional parameter - the `baseUrl` - that
 
 Use one of the following annotations on abstract methods of a service class to define requests:
 
-* `@Get` 
+* `@GET` 
 
-* `@Post` 
+* `@POST` 
 
-* `@Put`
+* `@PUT`
 
-* `@Patch`
+* `@PATCH`
 
-* `@Delete`
+* `@DELETE`
 
-* `@Head`
+* `@HEAD`
 
 Request methods must return with values of the type `Future<Response>`, `Future<Response<SomeType>>` or `Future<SomeType>`.
 The `Response` class is a wrapper around the HTTP response that contains the response body, the status code and the error (if any) of the request.
@@ -72,21 +72,21 @@ This class can be omitted if only the response body is needed. When omitting the
 To define a `GET` request to the endpoint `/todos` in the service class above, add one of the following method declarations to the class:
 
 ```dart
-@Get()
+@GET()
 Future<Response> getTodos();
 ```
 
 or
 
 ```dart
-@Get()
+@GET()
 Future<Response<List<Todo>>> getTodos();
 ```
 
 or
 
 ```dart
-@Get()
+@GET()
 Future<List<Todo>> getTodos();
 ```
 

--- a/requests.md
+++ b/requests.md
@@ -4,12 +4,12 @@
 
 | Annotation                                 | HTTP verb | Description                                            |
 |--------------------------------------------|-----------|--------------------------------------------------------|
-| `@Get()`, `@get`                           | `GET`     | Defines a `GET` request.                               |
-| `@Post()`, `@post`                         | `POST`    | Defines a `POST` request.                              |
-| `@Put()`, `@put`                           | `PUT`     | Defines a `PUT` request.                               |
-| `@Patch()`, `@patch`                       | `PATCH`   | Defines a `PATCH` request.                             |
-| `@Delete()`, `@delete`                     | `DELETE`  | Defines a `DELETE` request.                            |
-| `@Head()`, `@head`                         | `HEAD`    | Defines a `HEAD` request.                              |
+| `@GET()`, `@get`                           | `GET`     | Defines a `GET` request.                               |
+| `@POST()`, `@post`                         | `POST`    | Defines a `POST` request.                              |
+| `@PUT()`, `@put`                           | `PUT`     | Defines a `PUT` request.                               |
+| `@PATCH()`, `@patch`                       | `PATCH`   | Defines a `PATCH` request.                             |
+| `@DELETE()`, `@delete`                     | `DELETE`  | Defines a `DELETE` request.                            |
+| `@HEAD()`, `@head`                         | `HEAD`    | Defines a `HEAD` request.                              |
 | `@Body()`, `@body`                         | -         | Defines the request's body.                            |
 | `@FormUrlEncoded`, `@formUrlEncoded`       | -         | Defines a `application/x-www-form-urlencoded` request. |
 | `@Multipart()`, `@multipart`               | -         | Defines a `multipart/form-data` request.               |         
@@ -90,14 +90,14 @@ Dynamic path parameters can be defined in the URL with replacement blocks. A rep
 substring of the path surrounded by `{` and `}`. In the following example `{id}` is a replacement block.
 
 ```dart
-@Get(path: "/{id}")
+@GET(path: "/{id}")
 ```
 
 Use the `@Path()` annotation to bind a parameter to a replacement block. This way the parameter's name must match a
 replacement block's string.
 
 ```dart
-@Get(path: "/{id}")
+@GET(path: "/{id}")
 Future<Response> getItemById(@Path() String id);
 ```
 
@@ -105,7 +105,7 @@ As an alternative, you can set the `@Path` annotation's `name` parameter to matc
 using a different parameter name, like in the following example:
 
 ```dart
-@Get(path: "/{id}")
+@GET(path: "/{id}")
 Future<Response> getItemById(@Path("id") int itemId);
 ```
 
@@ -137,7 +137,7 @@ Future<Response> search(@QueryMap() Map<String, dynamic> query);
 Use the `@Body` annotation on a request method parameter to specify data that will be sent as the request's body.
 
 ```dart
-@Post(path: "todo/create")
+@POST(path: "todo/create")
 Future<Response> postData(@Body() String data);
 ```
 
@@ -154,22 +154,22 @@ Request headers can be set by providing a `Map<String, String>` object to the `h
 annotations have.
 
 ```dart
-@Get(path: "/", headers: {"foo": "bar"})
+@GET(path: "/", headers: {"foo": "bar"})
 Future<Response> fetch();
 ```
 
-The `@Header` annotation can be used on method parameters to set headers dynamically for each request call.
+The `@HEADer` annotation can be used on method parameters to set headers dynamically for each request call.
 
 ```dart
-@Get(path: "/")
-Future<Response> fetch(@Header("foo") String bar);
+@GET(path: "/")
+Future<Response> fetch(@HEADer("foo") String bar);
 ```
 
 > Setting request headers dynamically is also supported by [Interceptors](interceptors.md)
 > and [Converters](converters/converters.md).
 >
 > As Chopper invokes Interceptors and Converter(s) *after* creating a Request, Interceptors and Converters *can*
-> override headers set with the `headers` parameter or `@Header` annotations.
+> override headers set with the `headers` parameter or `@HEADer` annotations.
 
 ## Sending `application/x-www-form-urlencoded` data
 
@@ -184,7 +184,7 @@ We recommend annotation `@formUrlEncoded` on method that will add the correct `c
 into `Map<String, String>` for requests.
 
 ```dart
-@Post(
+@POST(
   path: "form",
 )
 @formUrlEncoded
@@ -208,7 +208,7 @@ To do only a single type of request with form encoding in a service, use the pro
 s `requestFactory` method with the `@FactoryConverter` annotation.
 
 ```dart
-@Post(
+@POST(
   path: "form",
   headers: {contentTypeKey: formEncodedHeaders},
 )
@@ -224,7 +224,7 @@ To specify fields individually, use the `@Field` annotation on method parameters
 the parameter's name is used as the field's name.
 
 ```dart
-@Post(path: "form")
+@POST(path: "form")
 @formUrlEncoded
 Future<Response> post(@Field() String foo, @Field("b") int bar);
 ```
@@ -234,7 +234,7 @@ Future<Response> post(@Field() String foo, @Field("b") int bar);
 ### Sending a file in bytes as `List<int>` using `@PartFile`
 
 ```dart
-@Post(path: 'file')
+@POST(path: 'file')
 @multipart
 Future<Response> postFile(@PartFile('file') List<int> bytes,);
 ```
@@ -242,7 +242,7 @@ Future<Response> postFile(@PartFile('file') List<int> bytes,);
 ### Sending a file as `MultipartFile` using `@PartFile` with extra parameters via `@Part`
 
 ```dart
-@Post(path: 'file')
+@POST(path: 'file')
 @multipart
 Future<Response> postMultipartFile(@PartFile() MultipartFile file, {
   @Part() String? id,
@@ -252,7 +252,7 @@ Future<Response> postMultipartFile(@PartFile() MultipartFile file, {
 ### Sending multiple files as `List<MultipartFile>` using `@PartFile`
 
 ```dart
-@Post(path: 'files')
+@POST(path: 'files')
 @multipart
 Future<Response> postListFiles(@PartFile() List<MultipartFile> files);
 ```
@@ -266,15 +266,15 @@ Chopper will generate a client which will return the specified return type. When
 
 ```dart
 // Returns a Response<dynamic>
-@Get(path: "/")
+@GET(path: "/")
 Future<Response> fetch();
 
 // Returns a Response<MyClass>
-@Get(path: "/")
+@GET(path: "/")
 Future<Response<MyClass>> fetch();
 
 // Returns a MyClass
-@Get(path: "/")
+@GET(path: "/")
 Future<MyClass> fetch();
 ```
 


### PR DESCRIPTION
This pull request introduces the `DateFormat` feature to enhance date serialization options in the `chopper` library. It also includes updates to support this feature across various classes and methods. Additionally, minor improvements were made to the codebase for clarity and maintainability.

### New Feature: Date Serialization Enhancements
* Added a new `DateFormat` enum in `chopper/lib/src/date_format.dart` to support multiple date serialization strategies, such as ISO8601, Unix timestamps, RFC2822, and more. Each strategy provides a specific way to format `DateTime` objects for query parameters.
* Updated `Request` class in `chopper/lib/src/request.dart` to include a new `dateFormat` parameter, allowing customization of date serialization for each request. [[1]](diffhunk://#diff-2dc27a5036ef0c21dd7610b955335660b980abb03efbe31bd900159aa2fb4f6aR24) [[2]](diffhunk://#diff-2dc27a5036ef0c21dd7610b955335660b980abb03efbe31bd900159aa2fb4f6aR42) [[3]](diffhunk://#diff-2dc27a5036ef0c21dd7610b955335660b980abb03efbe31bd900159aa2fb4f6aR59) [[4]](diffhunk://#diff-2dc27a5036ef0c21dd7610b955335660b980abb03efbe31bd900159aa2fb4f6aR78) [[5]](diffhunk://#diff-2dc27a5036ef0c21dd7610b955335660b980abb03efbe31bd900159aa2fb4f6aR94) [[6]](diffhunk://#diff-2dc27a5036ef0c21dd7610b955335660b980abb03efbe31bd900159aa2fb4f6aR109) [[7]](diffhunk://#diff-2dc27a5036ef0c21dd7610b955335660b980abb03efbe31bd900159aa2fb4f6aR130) [[8]](diffhunk://#diff-2dc27a5036ef0c21dd7610b955335660b980abb03efbe31bd900159aa2fb4f6aR266)
* Modified `mapToQuery` function in `chopper/lib/src/utils.dart` to accept an optional `dateSerializer` parameter, enabling date formatting during query parameter encoding.

### Updates to HTTP Method Annotations
* Extended all HTTP method annotations (`GET`, `POST`, `PUT`, etc.) in `chopper/lib/src/annotations.dart` to include the new `dateFormat` parameter, ensuring consistent date serialization across different HTTP methods. [[1]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6R213-R227) [[2]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6R265) [[3]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6R284-R290) [[4]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6R307) [[5]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6R328-R334) [[6]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6R353) [[7]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6R372-R378) [[8]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6R395) [[9]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6R416-R422) [[10]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6R441) [[11]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6R461-R467) [[12]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6R485) [[13]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6R504-R510) [[14]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6R527) [[15]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6R546-R552) [[16]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6R569)

### Codebase Improvements
* Marked the `tryDecodeJson` method in `JsonConverter` as `@visibleForTesting` to clarify its intended use for testing purposes.
* Updated exports in `chopper/lib/chopper.dart` to include the new `date_format.dart` file and reorganized the exports for better clarity.

### Documentation Updates
* Added a new entry for version `8.2.0` in the `CHANGELOG.md` file, documenting the addition of the `DateFormat` feature.