### PR TITLE
:bookmark: release v8.3.0

### DIFF
--- a/chopper/CHANGELOG.md
+++ b/chopper/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 8.3.0
+
+- Update analyzer and dependencies to use Element2 API ([#671](https://github.com/lejard-h/chopper/pull/671))
+
 ## 8.2.0
 
 - Add `DateFormat` to enhance date serialization options ([#668](https://github.com/lejard-h/chopper/pull/668))

--- a/chopper/README.md
+++ b/chopper/README.md
@@ -15,7 +15,7 @@ Chopper is an http client generator for Dart and Flutter using source_gen and in
 In your project's `pubspec.yaml` file, 
 
 * Add *chopper*'s latest version to your *dependencies*.
-* Add `build_runner: ^2.4.9` to your *dev_dependencies*.
+* Add `build_runner: ^2.6.0` to your *dev_dependencies*.
   * *build_runner* may already be in your *dev_dependencies* depending on your project setup and other dependencies.
 * Add *chopper_generator*'s latest version to your *dev_dependencies*.
 
@@ -26,7 +26,7 @@ dependencies:
   chopper: ^<latest version>
 
 dev_dependencies:
-  build_runner: ^2.4.9
+  build_runner: ^2.6.0
   chopper_generator: ^<latest version>
 ```
 

--- a/chopper/pubspec.yaml
+++ b/chopper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chopper
 description: Chopper is an http client generator using source_gen, inspired by Retrofit
-version: 8.2.0
+version: 8.3.0
 documentation: https://hadrien-lejard.gitbook.io/chopper
 repository: https://github.com/lejard-h/chopper
 

--- a/chopper/pubspec.yaml
+++ b/chopper/pubspec.yaml
@@ -8,25 +8,25 @@ environment:
   sdk: ^3.0.0
 
 dependencies:
-  equatable: ^2.0.5
-  http: ^1.1.0
-  logging: ^1.2.0
+  equatable: ^2.0.7
+  http: ^1.4.0
+  logging: ^1.3.0
   meta: ^1.9.1
   qs_dart: ^1.3.8
 
 dev_dependencies:
-  build_runner: ^2.4.9
-  build_test: ^3.1.0
-  build_verify: ^3.1.0
+  build_runner: ^2.6.0
+  build_test: ^3.3.0
+  build_verify: ^3.1.1
   collection: ^1.18.0
-  coverage: ^1.8.0
+  coverage: ^1.15.0
   data_fixture_dart: ^3.0.0
-  faker: ^2.1.0
-  http_parser: ^4.0.2
-  lints: ">=4.0.0 <7.0.0"
-  test: ^1.25.5
+  faker: ^2.2.0
+  http_parser: ^4.1.2
+  lints: ^6.0.0
+  test: ^1.26.3
   transparent_image: ^2.0.1
-  chopper_generator: ^8.1.0
+  chopper_generator: ^8.2.0
 
 topics:
   - api

--- a/chopper_built_value/CHANGELOG.md
+++ b/chopper_built_value/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1.0
+
+- Update analyzer and dependencies to use Element2 API ([#671](https://github.com/lejard-h/chopper/pull/671))
+
 ## 3.0.3
 
 - Update dependencies

--- a/chopper_built_value/pubspec.yaml
+++ b/chopper_built_value/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chopper_built_value
 description: A built_value based Converter for Chopper.
-version: 3.0.3
+version: 3.1.0
 documentation: https://hadrien-lejard.gitbook.io/chopper/converters/built-value-converter
 repository: https://github.com/lejard-h/chopper
 

--- a/chopper_built_value/pubspec.yaml
+++ b/chopper_built_value/pubspec.yaml
@@ -8,17 +8,17 @@ environment:
   sdk: ^3.0.0
 
 dependencies:
-  built_value: ^8.9.2
+  built_value: ^8.11.0
   built_collection: ^5.1.1
-  chopper: ^8.0.3
-  http: ^1.1.0
+  chopper: ^8.2.0
+  http: ^1.4.0
 
 dev_dependencies:
-  test: ^1.25.5
-  build_runner: ^2.4.9
-  build_test: ^3.1.0
-  built_value_generator: ^8.9.2
-  lints: ">=4.0.0 <7.0.0"
+  test: ^1.26.3
+  build_runner: ^2.6.0
+  build_test: ^3.3.0
+  built_value_generator: ^8.11.0
+  lints: ^6.0.0
 
 topics:
   - codegen

--- a/chopper_generator/CHANGELOG.md
+++ b/chopper_generator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 8.3.0
+
+- Update analyzer and dependencies to use Element2 API ([#671](https://github.com/lejard-h/chopper/pull/671))
+
 ## 8.2.0
 
 - Add `DateFormat` to enhance date serialization options ([#668](https://github.com/lejard-h/chopper/pull/668))

--- a/chopper_generator/lib/src/utils.dart
+++ b/chopper_generator/lib/src/utils.dart
@@ -2,7 +2,7 @@
 
 import 'dart:math' show max;
 
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:chopper/chopper.dart' show DateFormat, ListFormat;
 import 'package:chopper_generator/src/extensions.dart';
 import 'package:code_builder/code_builder.dart';
@@ -63,20 +63,20 @@ final class Utils {
   }
 
   /// All positional required params must support nullability
-  static Parameter buildRequiredPositionalParam(ParameterElement p) =>
+  static Parameter buildRequiredPositionalParam(FormalParameterElement p) =>
       Parameter(
         (ParameterBuilder pb) => pb
-          ..name = p.name
+          ..name = p.name3!
           ..type = Reference(
             p.type.getDisplayString(withNullability: p.type.isNullable),
           ),
       );
 
   /// All optional positional params must support nullability
-  static Parameter buildOptionalPositionalParam(ParameterElement p) =>
+  static Parameter buildOptionalPositionalParam(FormalParameterElement p) =>
       Parameter((ParameterBuilder pb) {
         pb
-          ..name = p.name
+          ..name = p.name3!
           ..type = Reference(
             p.type.getDisplayString(withNullability: p.type.isNullable),
           );
@@ -87,11 +87,11 @@ final class Utils {
       });
 
   /// Named params can be optional or required, they also need to support nullability
-  static Parameter buildNamedParam(ParameterElement p) =>
+  static Parameter buildNamedParam(FormalParameterElement p) =>
       Parameter((ParameterBuilder pb) {
         pb
           ..named = true
-          ..name = p.name
+          ..name = p.name3!
           ..required = p.isRequiredNamed
           ..type = Reference(
             p.type.getDisplayString(withNullability: p.type.isNullable),

--- a/chopper_generator/pubspec.yaml
+++ b/chopper_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chopper_generator
 description: Chopper is an http client generator using source_gen, inspired by Retrofit
-version: 8.2.0
+version: 8.3.0
 documentation: https://hadrien-lejard.gitbook.io/chopper
 repository: https://github.com/lejard-h/chopper
 

--- a/chopper_generator/pubspec.yaml
+++ b/chopper_generator/pubspec.yaml
@@ -8,23 +8,23 @@ environment:
   sdk: ^3.0.0
 
 dependencies:
-  analyzer: ">=6.9.0 <8.0.0"
-  build: ^2.4.1
+  analyzer: ">=7.4.0 <8.0.0"
+  build: ^3.0.0
   built_collection: ^5.1.1
-  chopper: ^8.1.0
-  code_builder: ^4.10.0
-  logging: ^1.2.0
+  chopper: ^8.2.0
+  code_builder: ^4.10.1
+  logging: ^1.3.0
   meta: ^1.9.1
-  source_gen: ">=1.5.0 <3.0.0"
-  yaml: ^3.1.2
+  source_gen: ^3.0.0
+  yaml: ^3.1.3
   collection: ^1.18.0
 
 dev_dependencies:
-  build_runner: ^2.4.9
-  build_verify: ^3.1.0
-  http: ^1.1.0
-  lints: ">=4.0.0 <7.0.0"
-  test: ^1.25.5
+  build_runner: ^2.6.0
+  build_verify: ^3.1.1
+  http: ^1.4.0
+  lints: ^6.0.0
+  test: ^1.26.3
 
 topics:
   - api


### PR DESCRIPTION
This pull request introduces updates to the Chopper library and its related packages to support the new Element2 API from the Dart analyzer. It also includes dependency updates and version bumps across the `chopper`, `chopper_built_value`, and `chopper_generator` packages. Below are the most significant changes grouped by their themes:

### API Updates for Element2 Support:
* Updated the `ChopperGenerator` implementation in `chopper_generator/lib/src/generator.dart` to replace `Element`, `ClassElement`, and related types with their corresponding `Element2` and `ClassElement2` counterparts. This includes changes to methods, parameters, and type checks to align with the Element2 API. [[1]](diffhunk://#diff-4ecb249f56dad1d5911519c4e273c8baec4af12f830ff29d138fa1f4c953167fL6-R6) [[2]](diffhunk://#diff-4ecb249f56dad1d5911519c4e273c8baec4af12f830ff29d138fa1f4c953167fL27-R34) [[3]](diffhunk://#diff-4ecb249f56dad1d5911519c4e273c8baec4af12f830ff29d138fa1f4c953167fL128-R175) and others)

### Dependency Updates:
* Updated dependencies in `chopper/pubspec.yaml` to newer versions, including `http` (from `^1.1.0` to `^1.4.0`), `equatable` (from `^2.0.5` to `^2.0.7`), and `logging` (from `^1.2.0` to `^1.3.0`). Dev dependencies like `build_runner` and `test` were also updated.
* Updated dependencies in `chopper_built_value/pubspec.yaml`, including `built_value` (from `^8.9.2` to `^8.11.0`) and `chopper` (from `^8.0.3` to `^8.2.0`). Dev dependencies were similarly updated.

### Version Bumps:
* Bumped the version of `chopper` to `8.3.0` and updated the changelog to reflect the migration to the Element2 API. [[1]](diffhunk://#diff-bf1702a19bd5925e6c580bc5dd7448547c90d381a25d9f493ead242c9f2cd4a7R3-R6) [[2]](diffhunk://#diff-c7bda5cb4208050349dcb19de97acd43bb7dfbc5eda9b87acc22e3193c1bc158L3-R29)
* Bumped the version of `chopper_built_value` to `3.1.0` and updated the changelog for the same reason. [[1]](diffhunk://#diff-e3f9de1d5bbbdb4ad46c2c045cd28e2afbfc9393e14e4aaa0251b1017d6df28dR3-R6) [[2]](diffhunk://#diff-0ffd7bfcac81d718b89496926d70952c8bbad1d6327fc46b5aebacb68dbb1197L3-R21)
* Bumped the version of `chopper_generator` to `8.3.0` and updated the changelog accordingly.

### Documentation Updates:
* Updated the `README.md` file to reflect the new version of `build_runner` (`^2.6.0`) in the setup instructions. [[1]](diffhunk://#diff-1f766deaa7fc9f7a4bf98818eef2632815057e66f0607ce19f1f5d2e68361bf2L18-R18) [[2]](diffhunk://#diff-1f766deaa7fc9f7a4bf98818eef2632815057e66f0607ce19f1f5d2e68361bf2L29-R29)

### Code Adjustments:
* Modified imports in `chopper_generator/lib/src/generator.dart` and `chopper_generator/lib/src/utils.dart` to use the `element2` package instead of the previous `element` package. [[1]](diffhunk://#diff-4ecb249f56dad1d5911519c4e273c8baec4af12f830ff29d138fa1f4c953167fL6-R6) [[2]](diffhunk://#diff-d9ba71c603f0fac78a2d611a0b75051c649a4cca0e7ac033c28cd95cb847ffbfL5-R5)

These changes ensure compatibility with the latest Dart analyzer while keeping dependencies up-to-date and maintaining the stability of the library.