### PR TITLE
:arrow_up: broaden version constraints for `build` and `source_gen` dependencies

### DIFF
--- a/chopper/example/definition.chopper.dart
+++ b/chopper/example/definition.chopper.dart
@@ -1,5 +1,5 @@
-// dart format width=80
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format width=80
 
 part of 'definition.dart';
 

--- a/chopper/example/tag.chopper.dart
+++ b/chopper/example/tag.chopper.dart
@@ -1,5 +1,5 @@
-// dart format width=80
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format width=80
 
 part of 'tag.dart';
 

--- a/chopper/test/annotations_test.chopper.dart
+++ b/chopper/test/annotations_test.chopper.dart
@@ -1,5 +1,5 @@
-// dart format width=80
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format width=80
 
 part of 'annotations_test.dart';
 

--- a/chopper/test/test_service.chopper.dart
+++ b/chopper/test/test_service.chopper.dart
@@ -1,5 +1,5 @@
-// dart format width=80
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format width=80
 
 part of 'test_service.dart';
 

--- a/chopper/test/test_service_base_url.chopper.dart
+++ b/chopper/test/test_service_base_url.chopper.dart
@@ -1,5 +1,5 @@
-// dart format width=80
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format width=80
 
 part of 'test_service_base_url.dart';
 

--- a/chopper/test/test_service_variable.chopper.dart
+++ b/chopper/test/test_service_variable.chopper.dart
@@ -1,5 +1,5 @@
-// dart format width=80
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format width=80
 
 part of 'test_service_variable.dart';
 

--- a/chopper/test/test_without_response_service.chopper.dart
+++ b/chopper/test/test_without_response_service.chopper.dart
@@ -1,5 +1,5 @@
-// dart format width=80
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format width=80
 
 part of 'test_without_response_service.dart';
 

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -628,7 +628,7 @@ final class ChopperGenerator
       );
       if (responseFactory != null) {
         if (responseFactory.objectValue.toFunctionValue2()
-            case final ExecutableElement func?) {
+            case final ExecutableElement2 func?) {
           namedArguments['responseConverter'] = refer(
             _factoryForFunction(func),
           );
@@ -1051,9 +1051,9 @@ final class ChopperGenerator
   /// True if the outer generic of `type` is [chopper.Response].
   static bool _isResponse(DartType type) => switch (_genericOf(type)) {
     InterfaceType(
-      element3: InterfaceElement(
+      element3: InterfaceElement2(
         name3: 'Response',
-        library2: final LibraryElement lib,
+        library2: final LibraryElement2 lib,
       ),
     ) =>
       lib.uri.toString().startsWith('package:chopper/'),

--- a/chopper_generator/lib/src/generator.dart
+++ b/chopper_generator/lib/src/generator.dart
@@ -274,15 +274,21 @@ final class ChopperGenerator
         // And null Typed parameters
         ..types.addAll(
           m.typeParameters2.map(
-            (TypeParameterElement2 t) => refer(switch (t.bound) {
-              final DartType type? => type.getDisplayString(
-                withNullability: false,
-              ),
-              null =>
-                throw InvalidGenerationSourceError(
-                  'Type parameter without a bound on method "${m.displayName}".',
-                  element: m.baseElement,
-                ),
+            (TypeParameterElement2 t) => TypeReference((
+              TypeReferenceBuilder b,
+            ) {
+              b.symbol = switch (t.name3) {
+                final String name? => name,
+                null =>
+                  throw InvalidGenerationSourceError(
+                    'Type parameter without a name on method "${m.displayName}".',
+                    element: m.baseElement,
+                  ),
+              };
+
+              if (t.bound case final DartType bound?) {
+                b.bound = refer(bound.getDisplayString(withNullability: false));
+              }
             }),
           ),
         )

--- a/chopper_generator/lib/src/utils.dart
+++ b/chopper_generator/lib/src/utils.dart
@@ -133,8 +133,9 @@ final class Utils {
           },
   );
 
-  static final TypeChecker _abortTriggerChecker = const TypeChecker.fromRuntime(
+  static final TypeChecker _abortTriggerChecker = const TypeChecker.typeNamed(
     AbortTrigger,
+    inPackage: 'chopper',
   );
 
   /// Locates the first parameter annotated with `@AbortTrigger`, or returns

--- a/chopper_generator/pubspec.yaml
+++ b/chopper_generator/pubspec.yaml
@@ -9,13 +9,13 @@ environment:
 
 dependencies:
   analyzer: ">=7.4.0 <9.0.0"
-  build: ^3.1.0
+  build: ">=3.1.0 <5.0.0"
   built_collection: ^5.1.1
   chopper: ^8.3.0
   code_builder: ^4.11.0
   logging: ^1.3.0
   meta: ^1.9.1
-  source_gen: ^3.1.0
+  source_gen: ">=3.1.0 <5.0.0"
   collection: ^1.19.0
 
 dev_dependencies:

--- a/chopper_generator/test/test_service.chopper.dart
+++ b/chopper_generator/test/test_service.chopper.dart
@@ -1,5 +1,5 @@
-// dart format width=80
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format width=80
 
 part of 'test_service.dart';
 

--- a/chopper_generator/test/test_service_variable.chopper.dart
+++ b/chopper_generator/test/test_service_variable.chopper.dart
@@ -1,5 +1,5 @@
-// dart format width=80
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format width=80
 
 part of 'test_service_variable.dart';
 

--- a/chopper_generator/test/test_without_response_service.chopper.dart
+++ b/chopper_generator/test/test_without_response_service.chopper.dart
@@ -1,5 +1,5 @@
-// dart format width=80
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format width=80
 
 part of 'test_without_response_service.dart';
 


### PR DESCRIPTION
This pull request improves type checking robustness and accuracy in the `chopper_generator` codebase by updating how `TypeChecker` is constructed and used throughout the generator logic. It also makes minor dependency version adjustments and updates generated file headers for consistency.

**Type checking improvements:**

* Updated the `_typeChecker` helper in `generator.dart` to use `TypeChecker.typeNamed` with explicit `inPackage` or `inSdk` parameters, improving accuracy when resolving types from external packages or the Dart SDK. This change is reflected in all usages of `_typeChecker`, including checks for `ChopperService`, `Body`, `FieldMap`, `FactoryConverter`, `Map`, `String`, and `Response` types. [[1]](diffhunk://#diff-4ecb249f56dad1d5911519c4e273c8baec4af12f830ff29d138fa1f4c953167fL53-R56) [[2]](diffhunk://#diff-4ecb249f56dad1d5911519c4e273c8baec4af12f830ff29d138fa1f4c953167fL392-R397) [[3]](diffhunk://#diff-4ecb249f56dad1d5911519c4e273c8baec4af12f830ff29d138fa1f4c953167fL417-R424) [[4]](diffhunk://#diff-4ecb249f56dad1d5911519c4e273c8baec4af12f830ff29d138fa1f4c953167fL968-R979) [[5]](diffhunk://#diff-4ecb249f56dad1d5911519c4e273c8baec4af12f830ff29d138fa1f4c953167fR999) [[6]](diffhunk://#diff-4ecb249f56dad1d5911519c4e273c8baec4af12f830ff29d138fa1f4c953167fL1018-R1060)
* Enhanced type checks for core Dart types (`Map`, `List`, `String`) to use the `isDartCoreMap`, `isDartCoreList`, and `isDartCoreString` properties for more reliable detection. [[1]](diffhunk://#diff-4ecb249f56dad1d5911519c4e273c8baec4af12f830ff29d138fa1f4c953167fL1018-R1060) [[2]](diffhunk://#diff-4ecb249f56dad1d5911519c4e273c8baec4af12f830ff29d138fa1f4c953167fL1052-R1086)
* Improved logic for identifying `chopper.Response` types by directly checking the library URI, ensuring only the correct types from the `chopper` package are matched.
* Modified the abort trigger checker in `utils.dart` to use `TypeChecker.typeNamed` with the `inPackage` parameter for better accuracy.

**Dependency updates:**

* Broadened version constraints for `build` and `source_gen` dependencies in `pubspec.yaml` to support newer versions.

**Generated file header consistency:**

* Standardized the header comment order in all generated `.chopper.dart` files to ensure the formatting directive appears after the "DO NOT MODIFY" notice. [[1]](diffhunk://#diff-21d059db28290c3d399331c65bb63c2e961f5f23845fbf7f1239eb97332b2541L1-R2) [[2]](diffhunk://#diff-1baca8bda3c75d5938c379948a3f5507b629739efee872512889c8ada0816fceL1-R2) [[3]](diffhunk://#diff-7607e3b3c28c2b2035640e70e8d223556fb51fe30608ab5fc6d702ba730a2f15L1-R2) [[4]](diffhunk://#diff-9208d1cd8bf5194350aa65706d974792f0d07ff11177b4144b7c70686912a307L1-R2) [[5]](diffhunk://#diff-6b5f3751ae468c26ed71791628283df37af08c5aa6b26d357c2c97e69b7a31adL1-R2) [[6]](diffhunk://#diff-8d6401771709f899198cf463c6b14d730520c9d9b0b5bb0988be4c48621ac92aL1-R2) [[7]](diffhunk://#diff-feaf4f196d90ff4b6607ab2106ea9e14508887c95cd1c368eb3f9f75c2e2dbe5L1-R2) [[8]](diffhunk://#diff-1c81fc78cc2943a566dd148c10e7d743dbfc55d6fa94870658f17eb28246d22fL1-R2) [[9]](diffhunk://#diff-8d6401771709f899198cf463c6b14d730520c9d9b0b5bb0988be4c48621ac92aL1-R2) [[10]](diffhunk://#diff-962fd1db57af8cf3d95f11e8cc9b52a7d810616bc57c2536f7f0256546307ed1L1-R2)

---

Fixes:
- https://github.com/lejard-h/chopper/issues/682
- https://github.com/lejard-h/chopper/issues/680

Supersedes::
- https://github.com/lejard-h/chopper/pull/681