### PR TITLE
:arrow_up: update dependencies

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v6.6.1
+# Created with package:mono_repo v6.6.3
 name: Dart CI
 on:
   push:
@@ -38,7 +38,7 @@ jobs:
         name: Checkout repository
         uses: actions/checkout@v6
       - name: mono_repo self validate
-        run: dart pub global activate mono_repo 6.6.1
+        run: dart pub global activate mono_repo 6.6.3
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
@@ -139,6 +139,7 @@ jobs:
           files: chopper/coverage/lcov.info
           fail_ci_if_error: true
           name: coverage_00
+          token: "${{ secrets.CODECOV_TOKEN }}"
       - id: chopper_built_value_pub_upgrade
         name: chopper_built_value; dart pub upgrade
         run: dart pub upgrade
@@ -154,6 +155,7 @@ jobs:
           files: chopper_built_value/coverage/lcov.info
           fail_ci_if_error: true
           name: coverage_01
+          token: "${{ secrets.CODECOV_TOKEN }}"
       - id: chopper_generator_pub_upgrade
         name: chopper_generator; dart pub upgrade
         run: dart pub upgrade
@@ -169,6 +171,7 @@ jobs:
           files: chopper_generator/coverage/lcov.info
           fail_ci_if_error: true
           name: coverage_02
+          token: "${{ secrets.CODECOV_TOKEN }}"
     needs:
       - job_001
       - job_002

--- a/chopper/pubspec.yaml
+++ b/chopper/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   http: ^1.6.0
   logging: ^1.3.0
   meta: ^1.17.0
-  qs_dart: ^1.6.0
+  qs_dart: ^1.7.3
 
 dev_dependencies:
   build_runner: ^2.10.4

--- a/chopper/pubspec.yaml
+++ b/chopper/pubspec.yaml
@@ -26,7 +26,7 @@ dev_dependencies:
   lints: ^6.0.0
   test: ^1.28.0
   transparent_image: ^2.0.1
-  chopper_generator: ^8.4.0
+  chopper_generator: ^8.6.0
 
 topics:
   - api

--- a/chopper_built_value/pubspec.yaml
+++ b/chopper_built_value/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   built_value: ^8.12.1
   built_collection: ^5.1.1
-  chopper: ^8.4.0
+  chopper: ^8.5.0
   http: ^1.6.0
 
 dev_dependencies:

--- a/chopper_generator/pubspec.yaml
+++ b/chopper_generator/pubspec.yaml
@@ -8,10 +8,10 @@ environment:
   sdk: ^3.9.0
 
 dependencies:
-  analyzer: ">=8.0.0 <11.0.0"
+  analyzer: ">=8.0.0 <13.0.0"
   build: ^4.0.3
   built_collection: ^5.1.1
-  chopper: ^8.4.0
+  chopper: ^8.5.0
   code_builder: ^4.11.0
   logging: ^1.3.0
   meta: ^1.17.0

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Created with package:mono_repo v6.6.1
+# Created with package:mono_repo v6.6.3
 
 # Support built in commands on windows out of the box.
 


### PR DESCRIPTION
This pull request updates dependencies and CI configuration across the project to ensure compatibility with newer versions and improve CI integration. The main changes include updating the `mono_repo` tool and related version references, bumping several Dart package dependencies, and enhancing Codecov integration in the GitHub Actions workflow.

**CI and Tooling Updates:**
* Updated `.github/workflows/dart.yml` and `tool/ci.sh` to use `mono_repo` version 6.6.3 instead of 6.6.1, ensuring the latest features and fixes are available in CI workflows. [[1]](diffhunk://#diff-c6fe895eea1e566d8f6f9f7e5f045b702d9bff8e60bfaec2d412193bd802ab2aL1-R1) [[2]](diffhunk://#diff-c6fe895eea1e566d8f6f9f7e5f045b702d9bff8e60bfaec2d412193bd802ab2aL41-R41) [[3]](diffhunk://#diff-3ccfa73ca92e661eee25215d4fb32eeb727e2f9169c85d62c079a6e4999e323eL2-R2)
* Added the `CODECOV_TOKEN` to the Codecov upload steps in the GitHub Actions workflow for improved coverage reporting security and reliability. [[1]](diffhunk://#diff-c6fe895eea1e566d8f6f9f7e5f045b702d9bff8e60bfaec2d412193bd802ab2aR142) [[2]](diffhunk://#diff-c6fe895eea1e566d8f6f9f7e5f045b702d9bff8e60bfaec2d412193bd802ab2aR158) [[3]](diffhunk://#diff-c6fe895eea1e566d8f6f9f7e5f045b702d9bff8e60bfaec2d412193bd802ab2aR174)

**Dependency Upgrades:**
* Bumped `qs_dart` from `^1.6.0` to `^1.7.3` and `chopper_generator` from `^8.4.0` to `^8.6.0` in `chopper/pubspec.yaml` for latest features and compatibility. [[1]](diffhunk://#diff-c7bda5cb4208050349dcb19de97acd43bb7dfbc5eda9b87acc22e3193c1bc158L15-R15) [[2]](diffhunk://#diff-c7bda5cb4208050349dcb19de97acd43bb7dfbc5eda9b87acc22e3193c1bc158L29-R29)
* Updated `chopper` dependency in `chopper_built_value/pubspec.yaml` and `chopper_generator/pubspec.yaml` from `^8.4.0` to `^8.5.0` for consistency and compatibility. [[1]](diffhunk://#diff-0ffd7bfcac81d718b89496926d70952c8bbad1d6327fc46b5aebacb68dbb1197L13-R13) [[2]](diffhunk://#diff-2a39a46354ec4530580cb03756c9040a10ca4cc61227a06b5fef9f3c4537833fL11-R14)
* Expanded `analyzer` version constraint in `chopper_generator/pubspec.yaml` to allow up to `<13.0.0`, supporting newer Dart SDKs.