### PR TITLE
:arrow_up: update analyzer dependency range to allow versions up to v14.0.0

### DIFF
--- a/chopper_generator/pubspec.yaml
+++ b/chopper_generator/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.9.0
 
 dependencies:
-  analyzer: ">=8.0.0 <13.0.0"
+  analyzer: ">=8.0.0 <14.0.0"
   build: ^4.0.3
   built_collection: ^5.1.1
   chopper: ^8.5.0


### PR DESCRIPTION
This pull request makes a minor update to the `chopper_generator/pubspec.yaml` file, expanding the allowed version range for the `analyzer` dependency to support versions up to, but not including, 14.0.0.