### PR TITLE
:construction_worker: add Minimum Dart CI workflow

### DIFF
--- a/.github/workflows/minimum_dart.yml
+++ b/.github/workflows/minimum_dart.yml
@@ -1,0 +1,103 @@
+name: Minimum Dart CI
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+    branches:
+      - master
+      - develop
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  PUB_ENVIRONMENT: bot.github
+
+permissions:
+  contents: read
+
+jobs:
+  minimum_dart:
+    name: "Minimum Dart (${{ matrix.package }}, ${{ matrix.platform }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: chopper
+            platform: vm
+          - package: chopper
+            platform: chrome
+          - package: chopper_built_value
+            platform: vm
+          - package: chopper_built_value
+            platform: chrome
+          - package: chopper_generator
+            platform: vm
+    steps:
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@v6
+      - id: read_min_dart
+        name: Read minimum Dart SDK from pubspec.yaml
+        run: |
+          set -euo pipefail
+
+          min_dart="$(yq -r '.environment.sdk | capture("(?<min>[0-9]+\.[0-9]+\.[0-9]+)").min' "${{ matrix.package }}/pubspec.yaml")"
+          if [[ -z "${min_dart}" ]]; then
+            echo 'failed to read minimum Dart SDK from ${{ matrix.package }}/pubspec.yaml' >&2
+            exit 1
+          fi
+          echo "min_dart=${min_dart}" >> "$GITHUB_OUTPUT"
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@v5
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:${{ steps.read_min_dart.outputs.min_dart }};packages:${{ matrix.package }};commands:analyze-test-${{ matrix.platform }}"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:${{ steps.read_min_dart.outputs.min_dart }};packages:${{ matrix.package }}
+            os:ubuntu-latest;pub-cache-hosted;sdk:${{ steps.read_min_dart.outputs.min_dart }}
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: ${{ steps.read_min_dart.outputs.min_dart }}
+      - id: install
+        name: Install dependencies
+        working-directory: ${{ matrix.package }}
+        run: dart pub upgrade
+      - name: Analyze package
+        if: ${{ matrix.platform == 'vm' }}
+        working-directory: ${{ matrix.package }}
+        run: dart analyze .
+      - name: Run package tests in Chrome
+        if: ${{ matrix.platform == 'chrome' }}
+        working-directory: ${{ matrix.package }}
+        run: dart test -p chrome
+      - name: Run package tests on the VM
+        if: ${{ matrix.platform == 'vm' }}
+        working-directory: ${{ matrix.package }}
+        run: dart test
+  minimum_dart_required:
+    name: "Minimum Dart Required"
+    if: ${{ always() }}
+    needs:
+      - minimum_dart
+    runs-on: ubuntu-latest
+    env:
+      MINIMUM_DART_RESULT: ${{ needs.minimum_dart.result }}
+    steps:
+      - name: Verify required job result
+        run: |
+          set -euo pipefail
+
+          echo "minimum_dart: ${MINIMUM_DART_RESULT}"
+          if [[ "${MINIMUM_DART_RESULT}" != "success" ]]; then
+            echo "::error::minimum_dart finished with result '${MINIMUM_DART_RESULT}'"
+            exit 1
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,8 @@ defaults:
     shell: bash
 env:
   PUB_ENVIRONMENT: bot.github
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   get_base_version:

--- a/.github/workflows/publish_dry_run.yml
+++ b/.github/workflows/publish_dry_run.yml
@@ -9,7 +9,8 @@ defaults:
     shell: bash
 env:
   PUB_ENVIRONMENT: bot.github
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   get_base_version:


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for testing packages against their minimum supported Dart SDK versions, and also updates permissions in existing workflow files for improved security.

**CI/CD Improvements:**

* Added a new workflow file `.github/workflows/minimum_dart.yml` to automatically test each package (`chopper`, `chopper_built_value`, `chopper_generator`) against its minimum Dart SDK version, across both VM and Chrome platforms. This ensures ongoing compatibility with the lowest supported Dart versions.

**Security Enhancements:**

* Updated the `permissions` in `.github/workflows/publish.yml` and `.github/workflows/publish_dry_run.yml` from `read-all` to a more restrictive `contents: read`, following GitHub's best practices for least privilege. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L12-R13) [[2]](diffhunk://#diff-14e3cc45334d9602c6ff72e3c8fd5bc809e3eb31d3a15672f47297e0b0076855L12-R13)