### PR TITLE
:sparkles: add `ParameterConverter` for query parameter transformation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ chopper_generator/doc/
 .vscode/
 pubspec.temp.yaml
 .DS_Store
+.history

--- a/chopper/CHANGELOG.md
+++ b/chopper/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 8.5.3-dev
+
+- Add `ParameterConverter` for converting query parameters before requests are sent.
+
 ## 8.5.2
 
 - Update dependencies ([#708](https://github.com/lejard-h/chopper/pull/708))

--- a/chopper/lib/src/base.dart
+++ b/chopper/lib/src/base.dart
@@ -27,6 +27,10 @@ base class ChopperClient {
   /// the request and response interceptors are called respectively.
   final Converter? converter;
 
+  /// The [ParameterConverter] that handles query parameter transformation
+  /// before request interceptors are called.
+  final ParameterConverter? parameterConverter;
+
   /// The [Authenticator] that can provide reactive authentication for a
   /// request.
   final Authenticator? authenticator;
@@ -83,13 +87,16 @@ base class ChopperClient {
   /// );
   /// ```
   ///
-  /// [Converter]s can be added to the client with the [converter]
-  /// parameter.
+  /// [Converter]s can be added to the client with the [converter] parameter.
   /// [Converter]s are used to convert the body of requests and responses to and
   /// from the HTTP format.
   ///
+  /// Query parameters can be converted with the [parameterConverter] parameter.
+  /// If omitted, [converter] is used when it implements [ParameterConverter].
+  ///
   /// A different converter can be used to handle error responses
-  /// (when [Response.isSuccessful] == false)) with tche [errorConverter] parameter.
+  /// (when [Response.isSuccessful] == false) with the [errorConverter]
+  /// parameter.
   ///
   /// See [Converter], [JsonConverter]
   ///
@@ -106,9 +113,15 @@ base class ChopperClient {
     this.interceptors = const [],
     this.authenticator,
     this.converter,
+    ParameterConverter? parameterConverter,
     this.errorConverter,
     Iterable<ChopperService>? services,
-  }) : assert(
+  }) : parameterConverter =
+           parameterConverter ??
+           (converter is ParameterConverter
+               ? converter as ParameterConverter
+               : null),
+       assert(
          baseUrl == null || !baseUrl.hasQuery,
          'baseUrl should not contain query parameters. '
          'Use a request interceptor to add default query parameters',

--- a/chopper/lib/src/chain/call.dart
+++ b/chopper/lib/src/chain/call.dart
@@ -35,7 +35,11 @@ class Call {
     ConvertResponse<BodyType>? responseConverter,
   ) async {
     final interceptors = <Interceptor>[
-      RequestConverterInterceptor(client.converter, requestConverter),
+      RequestConverterInterceptor(
+        client.converter,
+        requestConverter,
+        client.parameterConverter,
+      ),
       ...client.interceptors,
       RequestStreamInterceptor(requestCallback),
       if (client.authenticator != null)

--- a/chopper/lib/src/converters.dart
+++ b/chopper/lib/src/converters.dart
@@ -36,6 +36,56 @@ abstract interface class Converter {
   );
 }
 
+/// An interface for converting request parameters before the request is sent.
+///
+/// Implement this when values used by annotations like `@Query` need to be
+/// converted to their HTTP representation before query strings are encoded.
+@immutable
+abstract interface class ParameterConverter {
+  /// Converts [parameter] for the location described by [context].
+  Object? convertParameter(
+    Object? parameter,
+    ParameterConversionContext context,
+  );
+}
+
+/// Information about a parameter being converted.
+@immutable
+final class ParameterConversionContext {
+  /// Creates context for a parameter conversion.
+  const ParameterConversionContext({
+    required this.name,
+    required this.location,
+  });
+
+  /// Parameter name or path within a structured parameter value.
+  final String name;
+
+  /// Location where the parameter will be used in the request.
+  final ParameterLocation location;
+}
+
+/// Locations where request parameters can appear.
+///
+/// Currently only [query] is converted by Chopper. The remaining values are
+/// reserved for future parameter conversion support.
+enum ParameterLocation {
+  /// Query parameters passed with `@Query` or `@QueryMap`.
+  query,
+
+  /// Path parameters passed with `@Path`.
+  path,
+
+  /// Header parameters passed with `@Header`.
+  header,
+
+  /// Form fields passed with `@Field` or `@FieldMap`.
+  field,
+
+  /// Multipart parts passed with `@Part` or related annotations.
+  part,
+}
+
 /// An interface for implementing error response converters.
 ///
 /// An `ErrorConverter` is called only on error responses

--- a/chopper/lib/src/converters.dart
+++ b/chopper/lib/src/converters.dart
@@ -40,9 +40,19 @@ abstract interface class Converter {
 ///
 /// Implement this when values used by annotations like `@Query` need to be
 /// converted to their HTTP representation before query strings are encoded.
+///
+/// `convertParameter` is invoked **only for leaf values** during query
+/// parameter conversion. When a parameter value is a `Map` or an `Iterable`,
+/// Chopper recurses into it and calls `convertParameter` on each contained
+/// leaf, never on the container itself. As a result, implementers do not need
+/// to handle nested containers themselves — they only need to return the HTTP
+/// representation of an individual scalar value.
 @immutable
 abstract interface class ParameterConverter {
-  /// Converts [parameter] for the location described by [context].
+  /// Converts the leaf [parameter] for the location described by [context].
+  ///
+  /// This is never called with a `Map` or `Iterable` value; Chopper walks
+  /// those structures and invokes this method once per leaf.
   Object? convertParameter(
     Object? parameter,
     ParameterConversionContext context,

--- a/chopper/lib/src/interceptors/request_converter_interceptor.dart
+++ b/chopper/lib/src/interceptors/request_converter_interceptor.dart
@@ -10,6 +10,7 @@ import 'package:chopper/src/response.dart';
 import 'package:meta/meta.dart';
 
 part 'request_converter_interceptor_frames.dart';
+part 'request_converter_interceptor_conversion_result.dart';
 
 /// {@template RequestConverterInterceptor}
 /// Internal interceptor that converts query parameters with
@@ -67,22 +68,48 @@ class RequestConverterInterceptor implements InternalInterceptor {
   Request _convertQueryParameters(Request request) {
     final ParameterConverter? converter = _parameterConverter;
 
-    return converter == null || request.parameters.isEmpty
-        ? request
-        : request.copyWith(
-            parameters: convertQueryParameterMap(request.parameters, converter),
-          );
+    if (converter == null || request.parameters.isEmpty) {
+      return request;
+    }
+
+    final _ConversionResult result = _convertQueryParameterMap(
+      request.parameters,
+      converter,
+    );
+
+    // Avoid allocating a new Request when no leaf value actually changed.
+    return result.changed
+        ? request.copyWith(parameters: result.parameters)
+        : request;
   }
 }
 
 /// Converts query parameters before they are serialized to a query string.
+///
+/// Recurses into nested `Map` and `Iterable` values and calls
+/// [ParameterConverter.convertParameter] on each leaf, preserving the original
+/// nesting structure so that chopper's existing query encoder
+/// (`mapToQuery`, `ListFormat`, etc.) keeps working unchanged.
+///
+/// Nested maps are rebuilt as `Map<String, dynamic>`; non-`String` map keys
+/// are stringified via `toString()`, matching how chopper's query encoder
+/// already serializes them.
 @visibleForTesting
 Map<String, dynamic> convertQueryParameterMap(
+  Map<String, dynamic> parameters,
+  ParameterConverter converter,
+) => _convertQueryParameterMap(parameters, converter).parameters;
+
+/// Internal worker that also reports whether any leaf value was actually
+/// changed by [converter]. Used by [RequestConverterInterceptor] to avoid
+/// allocating a new [Request] when no leaf was modified.
+_ConversionResult _convertQueryParameterMap(
   Map<String, dynamic> parameters,
   ParameterConverter converter,
 ) {
   final Map<String, dynamic> converted = {};
   final HashSet<Object> activePath = HashSet<Object>.identity();
+  bool changed = false;
   final List<_ParameterConversionFrame> stack = [
     for (final MapEntry<String, dynamic> entry
         in parameters.entries.toList(growable: false).reversed)
@@ -109,10 +136,13 @@ Map<String, dynamic> convertQueryParameterMap(
 
     if (value is Map) {
       if (!activePath.add(value)) {
-        throw _cyclicQueryParameterValue(enterFrame.name);
+        throw _cyclicQueryParameterValue(
+          enterFrame.name,
+          ParameterLocation.query,
+        );
       }
 
-      final Map<dynamic, dynamic> childMap = {};
+      final Map<String, dynamic> childMap = {};
       enterFrame.assign(childMap);
       stack.add(_ParameterConversionFrame.exit(value));
 
@@ -121,12 +151,13 @@ Map<String, dynamic> convertQueryParameterMap(
       );
       for (int i = entries.length - 1; i >= 0; i--) {
         final MapEntry<dynamic, dynamic> entry = entries[i];
+        final String childKey = entry.key.toString();
         stack.add(
           _ParameterConversionFrame.enter(
             value: entry.value,
-            name: '${enterFrame.name}.${entry.key}',
+            name: '${enterFrame.name}.$childKey',
             assign: (value) {
-              childMap[entry.key] = value;
+              childMap[childKey] = value;
             },
           ),
         );
@@ -136,7 +167,10 @@ Map<String, dynamic> convertQueryParameterMap(
 
     if (value is Iterable) {
       if (!activePath.add(value)) {
-        throw _cyclicQueryParameterValue(enterFrame.name);
+        throw _cyclicQueryParameterValue(
+          enterFrame.name,
+          ParameterLocation.query,
+        );
       }
 
       final List<dynamic> values = value.toList(growable: false);
@@ -158,20 +192,25 @@ Map<String, dynamic> convertQueryParameterMap(
       continue;
     }
 
-    enterFrame.assign(
-      converter.convertParameter(
-        value,
-        ParameterConversionContext(
-          name: enterFrame.name,
-          location: ParameterLocation.query,
-        ),
+    final Object? convertedValue = converter.convertParameter(
+      value,
+      ParameterConversionContext(
+        name: enterFrame.name,
+        location: ParameterLocation.query,
       ),
     );
+    if (!identical(convertedValue, value)) {
+      changed = true;
+    }
+    enterFrame.assign(convertedValue);
   }
 
-  return converted;
+  return _ConversionResult(converted, changed);
 }
 
-/// Creates an [ArgumentError] for a cyclic query parameter value with the given [name].
-ArgumentError _cyclicQueryParameterValue(String name) =>
-    ArgumentError('Cyclic query parameter value at "$name".');
+/// Creates an [ArgumentError] for a cyclic query parameter value at [name]
+/// in the parameter [location].
+ArgumentError _cyclicQueryParameterValue(
+  String name,
+  ParameterLocation location,
+) => ArgumentError('Cyclic ${location.name} parameter value at "$name".');

--- a/chopper/lib/src/interceptors/request_converter_interceptor.dart
+++ b/chopper/lib/src/interceptors/request_converter_interceptor.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 
 import 'package:chopper/src/annotations.dart';
 import 'package:chopper/src/chain/chain.dart';
@@ -6,19 +7,34 @@ import 'package:chopper/src/converters.dart';
 import 'package:chopper/src/interceptors/internal_interceptor.dart';
 import 'package:chopper/src/request.dart';
 import 'package:chopper/src/response.dart';
+import 'package:meta/meta.dart';
+
+part 'request_converter_interceptor_frames.dart';
 
 /// {@template RequestConverterInterceptor}
-/// Internal interceptor that handles request conversion provided by [_requestConverter] or [_converter].
+/// Internal interceptor that converts query parameters with
+/// [_parameterConverter], then handles request conversion provided by
+/// [_requestConverter] or [_converter].
+///
+/// Query parameters are converted before user request interceptors and request
+/// stream events see the request.
 /// {@endtemplate}
 class RequestConverterInterceptor implements InternalInterceptor {
   /// {@macro RequestConverterInterceptor}
-  RequestConverterInterceptor(this._converter, this._requestConverter);
+  RequestConverterInterceptor(
+    this._converter,
+    this._requestConverter, [
+    this._parameterConverter,
+  ]);
 
   /// Converter to be used for request conversion.
   final Converter? _converter;
 
   /// Request converter to be used for request conversion.
   final ConvertRequest? _requestConverter;
+
+  /// Parameter converter to be used for query parameter conversion.
+  final ParameterConverter? _parameterConverter;
 
   @override
   FutureOr<Response<BodyType>> intercept<BodyType>(
@@ -31,13 +47,131 @@ class RequestConverterInterceptor implements InternalInterceptor {
   Future<Request> _handleRequestConverter(
     Request request,
     ConvertRequest? requestConverter,
-  ) async => request.body != null || request.parts.isNotEmpty
-      ? requestConverter != null
-            ? await requestConverter(request)
-            : await _encodeRequest(request)
-      : request;
+  ) async {
+    final Request requestWithConvertedParameters = _convertQueryParameters(
+      request,
+    );
+
+    return requestWithConvertedParameters.body != null ||
+            requestWithConvertedParameters.parts.isNotEmpty
+        ? requestConverter != null
+              ? await requestConverter(requestWithConvertedParameters)
+              : await _encodeRequest(requestWithConvertedParameters)
+        : requestWithConvertedParameters;
+  }
 
   /// Encodes the [request] using [_converter] if not null.
   Future<Request> _encodeRequest(Request request) async =>
       _converter?.convertRequest(request) ?? request;
+
+  Request _convertQueryParameters(Request request) {
+    final ParameterConverter? converter = _parameterConverter;
+
+    return converter == null || request.parameters.isEmpty
+        ? request
+        : request.copyWith(
+            parameters: convertQueryParameterMap(request.parameters, converter),
+          );
+  }
 }
+
+/// Converts query parameters before they are serialized to a query string.
+@visibleForTesting
+Map<String, dynamic> convertQueryParameterMap(
+  Map<String, dynamic> parameters,
+  ParameterConverter converter,
+) {
+  final Map<String, dynamic> converted = {};
+  final HashSet<Object> activePath = HashSet<Object>.identity();
+  final List<_ParameterConversionFrame> stack = [
+    for (final MapEntry<String, dynamic> entry
+        in parameters.entries.toList(growable: false).reversed)
+      _ParameterConversionFrame.enter(
+        value: entry.value,
+        name: entry.key,
+        assign: (value) {
+          converted[entry.key] = value;
+        },
+      ),
+  ];
+
+  while (stack.isNotEmpty) {
+    final _ParameterConversionFrame frame = stack.removeLast();
+
+    if (frame case _ExitParameterConversionFrame(:final value)) {
+      activePath.remove(value);
+      continue;
+    }
+
+    final _EnterParameterConversionFrame enterFrame =
+        frame as _EnterParameterConversionFrame;
+    final Object? value = enterFrame.value;
+
+    if (value is Map) {
+      if (!activePath.add(value)) {
+        throw _cyclicQueryParameterValue(enterFrame.name);
+      }
+
+      final Map<dynamic, dynamic> childMap = {};
+      enterFrame.assign(childMap);
+      stack.add(_ParameterConversionFrame.exit(value));
+
+      final List<MapEntry<dynamic, dynamic>> entries = value.entries.toList(
+        growable: false,
+      );
+      for (int i = entries.length - 1; i >= 0; i--) {
+        final MapEntry<dynamic, dynamic> entry = entries[i];
+        stack.add(
+          _ParameterConversionFrame.enter(
+            value: entry.value,
+            name: '${enterFrame.name}.${entry.key}',
+            assign: (value) {
+              childMap[entry.key] = value;
+            },
+          ),
+        );
+      }
+      continue;
+    }
+
+    if (value is Iterable) {
+      if (!activePath.add(value)) {
+        throw _cyclicQueryParameterValue(enterFrame.name);
+      }
+
+      final List<dynamic> values = value.toList(growable: false);
+      final List<dynamic> childList = List<dynamic>.filled(values.length, null);
+      enterFrame.assign(childList);
+      stack.add(_ParameterConversionFrame.exit(value));
+
+      for (int i = values.length - 1; i >= 0; i--) {
+        stack.add(
+          _ParameterConversionFrame.enter(
+            value: values[i],
+            name: '${enterFrame.name}[$i]',
+            assign: (value) {
+              childList[i] = value;
+            },
+          ),
+        );
+      }
+      continue;
+    }
+
+    enterFrame.assign(
+      converter.convertParameter(
+        value,
+        ParameterConversionContext(
+          name: enterFrame.name,
+          location: ParameterLocation.query,
+        ),
+      ),
+    );
+  }
+
+  return converted;
+}
+
+/// Creates an [ArgumentError] for a cyclic query parameter value with the given [name].
+ArgumentError _cyclicQueryParameterValue(String name) =>
+    ArgumentError('Cyclic query parameter value at "$name".');

--- a/chopper/lib/src/interceptors/request_converter_interceptor_conversion_result.dart
+++ b/chopper/lib/src/interceptors/request_converter_interceptor_conversion_result.dart
@@ -1,0 +1,14 @@
+part of 'request_converter_interceptor.dart';
+
+/// Internal carrier returned by [_convertQueryParameterMap].
+///
+/// [changed] is `true` if at least one leaf value was replaced by
+/// [ParameterConverter.convertParameter] with a value that is not
+/// `identical` to the input.
+@immutable
+class _ConversionResult {
+  const _ConversionResult(this.parameters, this.changed);
+
+  final Map<String, dynamic> parameters;
+  final bool changed;
+}

--- a/chopper/lib/src/interceptors/request_converter_interceptor_frames.dart
+++ b/chopper/lib/src/interceptors/request_converter_interceptor_frames.dart
@@ -1,6 +1,7 @@
 part of 'request_converter_interceptor.dart';
 
 /// Stack frame used for iterative query parameter traversal.
+@immutable
 sealed class _ParameterConversionFrame {
   const _ParameterConversionFrame();
 
@@ -14,6 +15,7 @@ sealed class _ParameterConversionFrame {
       _ExitParameterConversionFrame;
 }
 
+@immutable
 final class _EnterParameterConversionFrame extends _ParameterConversionFrame {
   const _EnterParameterConversionFrame({
     required this.value,
@@ -26,6 +28,7 @@ final class _EnterParameterConversionFrame extends _ParameterConversionFrame {
   final void Function(Object? value) assign;
 }
 
+@immutable
 final class _ExitParameterConversionFrame extends _ParameterConversionFrame {
   const _ExitParameterConversionFrame(this.value);
 

--- a/chopper/lib/src/interceptors/request_converter_interceptor_frames.dart
+++ b/chopper/lib/src/interceptors/request_converter_interceptor_frames.dart
@@ -1,0 +1,33 @@
+part of 'request_converter_interceptor.dart';
+
+/// Stack frame used for iterative query parameter traversal.
+sealed class _ParameterConversionFrame {
+  const _ParameterConversionFrame();
+
+  factory _ParameterConversionFrame.enter({
+    required Object? value,
+    required String name,
+    required void Function(Object? value) assign,
+  }) = _EnterParameterConversionFrame;
+
+  factory _ParameterConversionFrame.exit(Object value) =
+      _ExitParameterConversionFrame;
+}
+
+final class _EnterParameterConversionFrame extends _ParameterConversionFrame {
+  const _EnterParameterConversionFrame({
+    required this.value,
+    required this.name,
+    required this.assign,
+  });
+
+  final Object? value;
+  final String name;
+  final void Function(Object? value) assign;
+}
+
+final class _ExitParameterConversionFrame extends _ParameterConversionFrame {
+  const _ExitParameterConversionFrame(this.value);
+
+  final Object value;
+}

--- a/chopper/test/chain/request_converter_interceptor_test.dart
+++ b/chopper/test/chain/request_converter_interceptor_test.dart
@@ -2,12 +2,14 @@ import 'dart:async';
 
 import 'package:chopper/src/chain/chain.dart';
 import 'package:chopper/src/chain/interceptor_chain.dart';
+import 'package:chopper/src/base.dart';
 import 'package:chopper/src/converters.dart';
 import 'package:chopper/src/interceptors/interceptor.dart';
 import 'package:chopper/src/interceptors/request_converter_interceptor.dart';
 import 'package:chopper/src/request.dart';
 import 'package:chopper/src/response.dart';
 import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -31,6 +33,178 @@ void main() {
     await interceptorChain.proceed(testRequest);
 
     expect(converter.called, 0);
+  });
+
+  test(
+    'query-only request is converted by parameterConverter, not converter',
+    () async {
+      final testRequest = Request(
+        'GET',
+        Uri.parse('/foo'),
+        Uri.parse('https://example.com'),
+        parameters: {'value': const _ParameterValue('raw')},
+      );
+      final converter = RequestConverter();
+      final parameterConverter = _TestParameterConverter();
+      interceptorChain = InterceptorChain(
+        interceptors: [
+          RequestConverterInterceptor(converter, null, parameterConverter),
+          RequestInterceptor(
+            onRequest: (request) {
+              expect(request.url.queryParameters['value'], 'converted-raw');
+              expect(request.parameters['value'], 'converted-raw');
+            },
+          ),
+        ],
+        request: testRequest,
+      );
+
+      await interceptorChain.proceed(testRequest);
+
+      expect(converter.called, 0);
+      expect(parameterConverter.called, 1);
+    },
+  );
+
+  test(
+    'converter is used as parameterConverter when no explicit converter exists',
+    () async {
+      final converter = _RequestAndParameterConverter();
+      final httpClient = MockClient((request) async {
+        expect(request.url.queryParameters['value'], 'converted-raw');
+
+        return http.Response('TestResponse', 200);
+      });
+      final client = ChopperClient(
+        baseUrl: Uri.parse('https://example.com'),
+        client: httpClient,
+        converter: converter,
+      );
+
+      await client.get<String, String>(
+        Uri.parse('/foo'),
+        parameters: {'value': const _ParameterValue('raw')},
+      );
+
+      expect(converter.called, 0);
+      expect(converter.parameterCalled, 1);
+      httpClient.close();
+    },
+  );
+
+  test('explicit parameterConverter takes precedence over converter', () async {
+    final converter = _RequestAndParameterConverter();
+    final parameterConverter = _TestParameterConverter();
+    final httpClient = MockClient((request) async {
+      expect(request.url.queryParameters['value'], 'converted-raw');
+
+      return http.Response('TestResponse', 200);
+    });
+    final client = ChopperClient(
+      baseUrl: Uri.parse('https://example.com'),
+      client: httpClient,
+      converter: converter,
+      parameterConverter: parameterConverter,
+    );
+
+    await client.get<String, String>(
+      Uri.parse('/foo'),
+      parameters: {'value': const _ParameterValue('raw')},
+    );
+
+    expect(converter.parameterCalled, 0);
+    expect(parameterConverter.called, 1);
+    httpClient.close();
+  });
+
+  test('onRequest stream emits converted query parameters', () async {
+    final httpClient = MockClient((request) async {
+      return http.Response('TestResponse', 200);
+    });
+    final client = ChopperClient(
+      baseUrl: Uri.parse('https://example.com'),
+      client: httpClient,
+      parameterConverter: _TestParameterConverter(),
+    );
+    addTearDown(client.dispose);
+    addTearDown(httpClient.close);
+
+    final emittedRequest = client.onRequest.first;
+
+    await client.get<String, String>(
+      Uri.parse('/foo'),
+      parameters: {'value': const _ParameterValue('raw')},
+    );
+
+    final request = await emittedRequest;
+    expect(request.url.queryParameters['value'], 'converted-raw');
+    expect(request.parameters['value'], 'converted-raw');
+  });
+
+  test('query parameter conversion preserves nested query formatting', () {
+    final converted = convertQueryParameterMap({
+      'filters': {
+        'items': [const _ParameterValue('a'), const _ParameterValue('b')],
+      },
+    }, _TestParameterConverter());
+    final request = Request(
+      'GET',
+      Uri.parse('/foo'),
+      Uri.parse('https://example.com'),
+      parameters: converted,
+    );
+
+    expect(request.url.queryParametersAll['filters.items'], [
+      'converted-a',
+      'converted-b',
+    ]);
+  });
+
+  test('query parameter conversion detects cycles', () {
+    final cyclic = <String, dynamic>{};
+    cyclic['self'] = cyclic;
+
+    expect(
+      () => convertQueryParameterMap({
+        'value': cyclic,
+      }, _TestParameterConverter()),
+      throwsA(
+        isA<ArgumentError>().having(
+          (error) => error.message,
+          'message',
+          'Cyclic query parameter value at "value.self".',
+        ),
+      ),
+    );
+  });
+
+  test('query parameter conversion detects iterable cycles', () {
+    final cyclic = <dynamic>[];
+    cyclic.add(cyclic);
+
+    expect(
+      () => convertQueryParameterMap({
+        'value': cyclic,
+      }, _TestParameterConverter()),
+      throwsA(
+        isA<ArgumentError>().having(
+          (error) => error.message,
+          'message',
+          'Cyclic query parameter value at "value[0]".',
+        ),
+      ),
+    );
+  });
+
+  test('query parameter conversion allows shared non-cyclic values', () {
+    final shared = {'value': const _ParameterValue('shared')};
+    final converted = convertQueryParameterMap({
+      'left': shared,
+      'right': shared,
+    }, _TestParameterConverter());
+
+    expect(converted['left'], {'value': 'converted-shared'});
+    expect(converted['right'], {'value': 'converted-shared'});
   });
 
   test(
@@ -60,6 +234,40 @@ void main() {
       expect(converter.called, 1);
     },
   );
+
+  test('request with body converts query parameters and body', () async {
+    final testRequest = Request(
+      'POST',
+      Uri.parse('/foo'),
+      Uri.parse('https://example.com'),
+      body: 'not converted',
+      parameters: {'value': const _ParameterValue('raw')},
+    );
+    final converter = RequestConverter(
+      onConvertRequest: (request) {
+        expect(request.url.queryParameters['value'], 'converted-raw');
+        expect(request.parameters['value'], 'converted-raw');
+      },
+    );
+    final parameterConverter = _TestParameterConverter();
+    interceptorChain = InterceptorChain(
+      interceptors: [
+        RequestConverterInterceptor(converter, null, parameterConverter),
+        RequestInterceptor(
+          onRequest: (request) {
+            expect(request.body, 'converted');
+            expect(request.url.queryParameters['value'], 'converted-raw');
+          },
+        ),
+      ],
+      request: testRequest,
+    );
+
+    await interceptorChain.proceed(testRequest);
+
+    expect(converter.called, 1);
+    expect(parameterConverter.called, 1);
+  });
 
   test(
     'request body is null and parts is not empty, requestConverter is not provided, request is converted by converter',
@@ -123,13 +331,56 @@ void main() {
   );
 }
 
+final class _ParameterValue {
+  const _ParameterValue(this.value);
+
+  final String value;
+}
+
+// ignore: must_be_immutable
+class _TestParameterConverter implements ParameterConverter {
+  int called = 0;
+
+  @override
+  Object? convertParameter(
+    Object? parameter,
+    ParameterConversionContext context,
+  ) {
+    called++;
+    if (parameter is _ParameterValue) return 'converted-${parameter.value}';
+
+    return parameter;
+  }
+}
+
+// ignore: must_be_immutable
+class _RequestAndParameterConverter extends RequestConverter
+    implements ParameterConverter {
+  int parameterCalled = 0;
+
+  @override
+  Object? convertParameter(
+    Object? parameter,
+    ParameterConversionContext context,
+  ) {
+    parameterCalled++;
+    if (parameter is _ParameterValue) return 'converted-${parameter.value}';
+
+    return parameter;
+  }
+}
+
 // ignore mutability warning for test class.
 //ignore: must_be_immutable
 class RequestConverter implements Converter {
+  RequestConverter({this.onConvertRequest});
+
+  final void Function(Request request)? onConvertRequest;
   int called = 0;
   @override
   FutureOr<Request> convertRequest(Request request) {
     called++;
+    onConvertRequest?.call(request);
     return request.copyWith(body: 'converted');
   }
 

--- a/chopper/test/chain/request_converter_interceptor_test.dart
+++ b/chopper/test/chain/request_converter_interceptor_test.dart
@@ -208,6 +208,46 @@ void main() {
   });
 
   test(
+    'request is not reallocated when parameterConverter returns identical values',
+    () async {
+      final testRequest = Request(
+        'GET',
+        Uri.parse('/foo'),
+        Uri.parse('https://example.com'),
+        parameters: const {'value': 'plain'},
+      );
+      final parameterConverter = _IdentityParameterConverter();
+      interceptorChain = InterceptorChain(
+        interceptors: [
+          RequestConverterInterceptor(null, null, parameterConverter),
+          RequestInterceptor(
+            onRequest: (request) {
+              // The interceptor must observe the same Request instance because
+              // no leaf value actually changed.
+              expect(identical(request, testRequest), isTrue);
+            },
+          ),
+        ],
+        request: testRequest,
+      );
+
+      await interceptorChain.proceed(testRequest);
+
+      expect(parameterConverter.called, 1);
+    },
+  );
+
+  test('non-String nested map keys are stringified', () {
+    final converted = convertQueryParameterMap({
+      'filters': {1: const _ParameterValue('a'), 2: const _ParameterValue('b')},
+    }, _TestParameterConverter());
+
+    expect(converted, {
+      'filters': {'1': 'converted-a', '2': 'converted-b'},
+    });
+  });
+
+  test(
     'request body is not null and parts is empty, requestConverter is not provided, request is converted by converter',
     () async {
       final testRequest = Request(
@@ -349,6 +389,22 @@ class _TestParameterConverter implements ParameterConverter {
     called++;
     if (parameter is _ParameterValue) return 'converted-${parameter.value}';
 
+    return parameter;
+  }
+}
+
+// ignore: must_be_immutable
+class _IdentityParameterConverter implements ParameterConverter {
+  int called = 0;
+
+  @override
+  Object? convertParameter(
+    Object? parameter,
+    ParameterConversionContext context,
+  ) {
+    called++;
+    // Return the same reference — the interceptor must short-circuit and
+    // reuse the original Request.
     return parameter;
   }
 }

--- a/chopper_built_value/CHANGELOG.md
+++ b/chopper_built_value/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.3.2-dev
+
+- Convert serializer-backed query parameters with `BuiltValueConverter`.
+
 ## 3.3.1
 
 - Update dependencies ([#703](https://github.com/lejard-h/chopper/pull/703))

--- a/chopper_built_value/lib/chopper_built_value.dart
+++ b/chopper_built_value/lib/chopper_built_value.dart
@@ -6,7 +6,8 @@ import 'package:chopper/chopper.dart';
 
 /// A custom [Converter] and [ErrorConverter] that handles conversion for classes
 /// having a serializer implementation made with the built_value package.
-class BuiltValueConverter implements Converter, ErrorConverter {
+class BuiltValueConverter
+    implements Converter, ErrorConverter, ParameterConverter {
   final Serializers serializers;
   static const JsonConverter jsonConverter = JsonConverter();
   final Type? errorType;
@@ -54,6 +55,31 @@ class BuiltValueConverter implements Converter, ErrorConverter {
   Request convertRequest(Request request) => jsonConverter.convertRequest(
     request.copyWith(body: serializers.serialize(request.body)),
   );
+
+  @override
+  Object? convertParameter(
+    Object? parameter,
+    ParameterConversionContext context,
+  ) {
+    if (parameter == null ||
+        parameter is String ||
+        parameter is num ||
+        parameter is bool ||
+        parameter is DateTime ||
+        parameter is Duration ||
+        parameter is Uri ||
+        parameter is Enum) {
+      return parameter;
+    }
+
+    final Serializer<dynamic>? serializer = serializers.serializerForType(
+      parameter.runtimeType,
+    );
+
+    return serializer == null
+        ? parameter
+        : serializers.serializeWith(serializer, parameter);
+  }
 
   @override
   FutureOr<Response<BodyType>> convertResponse<BodyType, InnerType>(

--- a/chopper_built_value/pubspec.yaml
+++ b/chopper_built_value/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   built_value: ^8.12.1
   built_collection: ^5.1.1
-  chopper: ^8.5.0
+  chopper: ^8.5.0  # TODO(@techouse): make sure to bump to the very latest version before release
   http: ^1.6.0
 
 dev_dependencies:

--- a/chopper_built_value/test/converter_test.dart
+++ b/chopper_built_value/test/converter_test.dart
@@ -3,6 +3,7 @@ import 'package:built_value/standard_json_plugin.dart';
 import 'package:chopper/chopper.dart';
 import 'package:chopper_built_value/chopper_built_value.dart';
 import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:test/test.dart';
 
 import 'data.dart';
@@ -31,6 +32,79 @@ void main() {
       );
       request = converter.convertRequest(request);
       expect(request.body, '{"\$":"DataModel","id":42,"name":"foo"}');
+    });
+
+    test('convert query parameter with primitive serializer', () {
+      final parameter = converter.convertParameter(
+        VisitType.faceToFace,
+        const ParameterConversionContext(
+          name: 'visitType',
+          location: ParameterLocation.query,
+        ),
+      );
+
+      expect(parameter, 'face_to_face');
+    });
+
+    test('convert query parameter keeps built-in scalar values unchanged', () {
+      final dateTime = DateTime.utc(2026, 5, 10, 12, 30);
+      final uri = Uri.parse('https://foo/path');
+      final values = <Object?>[
+        null,
+        'faceToFace',
+        42,
+        4.2,
+        true,
+        dateTime,
+        const Duration(seconds: 42),
+        uri,
+        _DartVisitType.faceToFace,
+      ];
+
+      for (final value in values) {
+        final converted = converter.convertParameter(
+          value,
+          const ParameterConversionContext(
+            name: 'value',
+            location: ParameterLocation.query,
+          ),
+        );
+
+        expect(converted, same(value));
+      }
+    });
+
+    test('converts EnumClass query parameter in request URL', () async {
+      final httpClient = MockClient((request) async {
+        expect(request.url.queryParameters['visity_type'], 'face_to_face');
+
+        return http.Response('TestResponse', 200);
+      });
+      final client = ChopperClient(
+        baseUrl: Uri.parse('https://foo'),
+        client: httpClient,
+        converter: converter,
+      );
+
+      await client.get<String, String>(
+        Uri.parse('/api/v1/available_turn_schedules/42'),
+        parameters: {'visity_type': VisitType.faceToFace},
+      );
+
+      httpClient.close();
+    });
+
+    test('convert query parameter falls back when serializer is missing', () {
+      final parameter = Object();
+      final converted = converter.convertParameter(
+        parameter,
+        const ParameterConversionContext(
+          name: 'unknown',
+          location: ParameterLocation.query,
+        ),
+      );
+
+      expect(identical(converted, parameter), isTrue);
     });
 
     test('convert response with wireName', () async {
@@ -119,3 +193,5 @@ void main() {
     );
   });
 }
+
+enum _DartVisitType { faceToFace }

--- a/chopper_built_value/test/data.dart
+++ b/chopper_built_value/test/data.dart
@@ -1,3 +1,4 @@
+import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 
@@ -18,4 +19,17 @@ abstract class ErrorModel implements Built<ErrorModel, ErrorModelBuilder> {
   static Serializer<ErrorModel> get serializer => _$errorModelSerializer;
   factory ErrorModel([Function(ErrorModelBuilder b) updates]) = _$ErrorModel;
   ErrorModel._();
+}
+
+class VisitType extends EnumClass {
+  const VisitType._(super.name);
+
+  @BuiltValueEnumConst(wireName: 'face_to_face')
+  static const VisitType faceToFace = _$faceToFace;
+
+  static const VisitType phone = _$phone;
+
+  static BuiltSet<VisitType> get values => _$visitTypeValues;
+  static VisitType valueOf(String name) => _$visitTypeValueOf(name);
+  static Serializer<VisitType> get serializer => _$visitTypeSerializer;
 }

--- a/chopper_built_value/test/data.g.dart
+++ b/chopper_built_value/test/data.g.dart
@@ -6,8 +6,27 @@ part of 'data.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
+const VisitType _$faceToFace = const VisitType._('faceToFace');
+const VisitType _$phone = const VisitType._('phone');
+
+VisitType _$visitTypeValueOf(String name) {
+  switch (name) {
+    case 'faceToFace':
+      return _$faceToFace;
+    case 'phone':
+      return _$phone;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<VisitType> _$visitTypeValues = BuiltSet<VisitType>(
+  const <VisitType>[_$faceToFace, _$phone],
+);
+
 Serializer<DataModel> _$dataModelSerializer = _$DataModelSerializer();
 Serializer<ErrorModel> _$errorModelSerializer = _$ErrorModelSerializer();
+Serializer<VisitType> _$visitTypeSerializer = _$VisitTypeSerializer();
 
 class _$DataModelSerializer implements StructuredSerializer<DataModel> {
   @override
@@ -118,6 +137,36 @@ class _$ErrorModelSerializer implements StructuredSerializer<ErrorModel> {
 
     return result.build();
   }
+}
+
+class _$VisitTypeSerializer implements PrimitiveSerializer<VisitType> {
+  static const Map<String, Object> _toWire = const <String, Object>{
+    'faceToFace': 'face_to_face',
+  };
+  static const Map<Object, String> _fromWire = const <Object, String>{
+    'face_to_face': 'faceToFace',
+  };
+
+  @override
+  final Iterable<Type> types = const <Type>[VisitType];
+  @override
+  final String wireName = 'VisitType';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    VisitType object, {
+    FullType specifiedType = FullType.unspecified,
+  }) => _toWire[object.name] ?? object.name;
+
+  @override
+  VisitType deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) => VisitType.valueOf(
+    _fromWire[serialized] ?? (serialized is String ? serialized : ''),
+  );
 }
 
 class _$DataModel extends DataModel {

--- a/chopper_built_value/test/serializers.dart
+++ b/chopper_built_value/test/serializers.dart
@@ -7,5 +7,5 @@ import 'data.dart';
 part 'serializers.g.dart';
 
 /// Collection of generated serializers for the built_value
-@SerializersFor([DataModel, ErrorModel])
+@SerializersFor([DataModel, ErrorModel, VisitType])
 final Serializers serializers = _$serializers;

--- a/chopper_built_value/test/serializers.g.dart
+++ b/chopper_built_value/test/serializers.g.dart
@@ -9,7 +9,8 @@ part of 'serializers.dart';
 Serializers _$serializers =
     (Serializers().toBuilder()
           ..add(DataModel.serializer)
-          ..add(ErrorModel.serializer))
+          ..add(ErrorModel.serializer)
+          ..add(VisitType.serializer))
         .build();
 
 // ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/converters/built-value-converter.md
+++ b/converters/built-value-converter.md
@@ -64,6 +64,24 @@ final converter = BuiltValueConverter(jsonSerializers);
 final client = ChopperClient(converter: converter);
 ```
 
+`BuiltValueConverter` also converts query parameters when used as the Chopper
+client's `converter`. This lets built_value enum classes use their wire names
+in URLs.
+
+```dart
+class VisitType extends EnumClass {
+  @BuiltValueEnumConst(wireName: 'face_to_face')
+  static const VisitType faceToFace = _$faceToFace;
+
+  static Serializer<VisitType> get serializer => _$visitTypeSerializer;
+}
+
+@Get(path: '/visits')
+Future<Response> visits(@Query('type') VisitType type);
+```
+
+Calling `visits(VisitType.faceToFace)` sends `type=face_to_face`.
+
 #### Error converter
 
 `BuiltValueConverter` is also an error converter. It will try to decode error response bodies using the `wireName` inside JSON `{"$":"ErrorModel"}`, if available.
@@ -75,6 +93,5 @@ final jsonSerializers = ...
 
 final converter = BuiltValueConverter(jsonSerializers, errorType: ErrorModel);
 ```
-
 
 

--- a/converters/converters.md
+++ b/converters/converters.md
@@ -51,6 +51,21 @@ class MyConverter implements Converter {
 
 If `BodyType` is a `List` or a `BuiltList`, `InnerType` is the type of the generic parameter \(e.g., `convertResponse<List<CustomObject>, CustomObject>(response)`).
 
+## Parameter conversion
+
+Use `ParameterConverter` when query parameters need to be converted before the
+request URL is sent. This is useful for custom scalar types, such as generated
+enum classes with wire names.
+
+```dart
+final chopper = ChopperClient(
+  parameterConverter: MyParameterConverter(),
+);
+```
+
+If `parameterConverter` is not provided, Chopper will use `converter` when it
+also implements `ParameterConverter`.
+
 ## Using different converters for specific endpoints
 
 If you want to apply specific converters only to a single endpoint, you can do so by using the `@FactoryConverter` annotation:


### PR DESCRIPTION
## Summary

Fixes #332.

This PR adds first-class query parameter conversion to Chopper, so converters can serialize `@Query` / `@QueryMap` values before the request URL is sent.

```dart
/// An interface for converting request parameters before the request is sent.
///
/// Implement this when values used by annotations like `@Query` need to be
/// converted to their HTTP representation before query strings are encoded.
///
/// `convertParameter` is invoked **only for leaf values** during query
/// parameter conversion. When a parameter value is a `Map` or an `Iterable`,
/// Chopper recurses into it and calls `convertParameter` on each contained
/// leaf, never on the container itself. As a result, implementers do not need
/// to handle nested containers themselves — they only need to return the HTTP
/// representation of an individual scalar value.
@immutable
abstract interface class ParameterConverter {
  /// Converts the leaf [parameter] for the location described by [context].
  ///
  /// This is never called with a `Map` or `Iterable` value; Chopper walks
  /// those structures and invokes this method once per leaf.
  Object? convertParameter(
    Object? parameter,
    ParameterConversionContext context,
  );
}
```

This removes the need for users to write interceptors just to convert query enum values.

It also updates `BuiltValueConverter` so built_value `EnumClass` values use their serializer wire names in query parameters.

## What Changed

- Added `ParameterConverter` to Chopper core.
- Added `ChopperClient(parameterConverter: ...)`.
- If no explicit `parameterConverter` is provided, Chopper uses `converter` when it implements `ParameterConverter`.
- Query parameter values are converted before user request interceptors and request stream events.
- Query keys are preserved.
- Nested `Map` / `Iterable` query shapes are preserved for existing `qs_dart` formatting behavior.
- Cyclic query parameter values now throw an `ArgumentError` with the parameter path.
- `BuiltValueConverter` now implements `ParameterConverter`.
- Request body conversion behavior is unchanged.

## Usage

### Custom ParameterConverter

```dart
class MyParameterConverter implements ParameterConverter {
  const MyParameterConverter();

  @override
  Object? convertParameter(
    Object? parameter,
    ParameterConversionContext context,
  ) {
    if (parameter is MyApiEnum) {
      return parameter.wireName;
    }

    return parameter;
  }
}
```

Then pass it to `ChopperClient`:

```dart
final client = ChopperClient(
  baseUrl: Uri.parse('https://api.example.com'),
  parameterConverter: const MyParameterConverter(),
);
```

### Converter Fallback

If the main body converter also implements `ParameterConverter`, it is used automatically:

```dart
final client = ChopperClient(
  baseUrl: Uri.parse('https://api.example.com'),
  converter: MyConverter(),
);
```

An explicit `parameterConverter` takes precedence over this fallback.

### built_value EnumClass Query Parameters

Given a built_value enum with a wire name:

```dart
class VisitType extends EnumClass {
  const VisitType._(super.name);

  @BuiltValueEnumConst(wireName: 'face_to_face')
  static const VisitType faceToFace = _$faceToFace;

  static Serializer<VisitType> get serializer => _$visitTypeSerializer;
}
```

And a Chopper call:

```dart
@Get(path: '/available_turn_schedules')
Future<Response> schedules(
  @Query('visity_type') VisitType visitType,
);
```

Using `BuiltValueConverter` now sends the wire value:

```dart
final client = ChopperClient(
  converter: BuiltValueConverter(serializers),
);

await service.schedules(VisitType.faceToFace);
```

Resulting URL query:

```text
?visity_type=face_to_face
```

## Tests

Added coverage for:

- explicit `parameterConverter`
- fallback to `converter is ParameterConverter`
- explicit converter precedence
- converted query values visible to request interceptors
- converted query values visible to `onRequest`
- nested map/list query formatting preservation
- shared non-cyclic containers
- cyclic map/list detection
- body + query conversion ordering
- built_value generated `EnumClass` serializer wire names
- built-in scalar passthrough behavior
- missing serializer fallback behavior