### PR TITLE
:sparkles: improve `JsonConverter` diagnostics for typed JSON collection responses

### DIFF
--- a/chopper/CHANGELOG.md
+++ b/chopper/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 8.5.3-dev
 
 - Add `ParameterConverter` for converting query parameters before requests are sent.
+- Improve `JsonConverter` errors for typed JSON collection responses.
 
 ## 8.5.2
 

--- a/chopper/lib/src/converters.dart
+++ b/chopper/lib/src/converters.dart
@@ -161,13 +161,78 @@ class JsonConverter implements Converter, ErrorConverter {
 
     body = await tryDecodeJson(body);
     if (isTypeOf<BodyType, Iterable<InnerType>>()) {
-      body = body.cast<InnerType>();
+      body = _decodeList<InnerType>(body);
     } else if (isTypeOf<BodyType, Map<String, InnerType>>()) {
-      body = body.cast<String, InnerType>();
+      body = _decodeMap<InnerType>(body);
     }
 
     return response.copyWith<BodyType>(body: body);
   }
+
+  static List<ItemType> _decodeList<ItemType>(Object? body) {
+    if (body is! Iterable) {
+      throw FormatException(
+        'JsonConverter expected response body to be Iterable<$ItemType>, '
+        'but got ${_typeName(body)}.',
+      );
+    }
+
+    final result = <ItemType>[];
+    var index = 0;
+    for (final item in body) {
+      if (item is! ItemType) {
+        throw FormatException(
+          'JsonConverter expected response body[$index] to be $ItemType, '
+          'but got ${_typeName(item)}.',
+        );
+      }
+
+      result.add(item);
+      index++;
+    }
+
+    return result;
+  }
+
+  static Map<String, ItemType> _decodeMap<ItemType>(Object? body) {
+    if (body is! Map) {
+      throw FormatException(
+        'JsonConverter expected response body to be Map<String, $ItemType>, '
+        'but got ${_typeName(body)}.',
+      );
+    }
+
+    final result = <String, ItemType>{};
+    for (final entry in body.entries) {
+      final key = entry.key;
+      if (key is! String) {
+        throw FormatException(
+          'JsonConverter expected response body key to be String, '
+          'but got ${_typeName(key)}.',
+        );
+      }
+
+      final value = entry.value;
+      if (value is! ItemType) {
+        throw FormatException(
+          'JsonConverter expected response body[${json.encode(key)}] '
+          'to be $ItemType, but got ${_typeName(value)}.',
+        );
+      }
+
+      result[key] = value;
+    }
+
+    return result;
+  }
+
+  static String _typeName(Object? value) => switch (value) {
+    null => 'Null',
+    Map() => 'Map',
+    List() => 'List',
+    Iterable() => 'Iterable',
+    _ => value.runtimeType.toString(),
+  };
 
   @override
   FutureOr<Response<BodyType>> convertResponse<BodyType, InnerType>(

--- a/chopper/lib/src/converters.dart
+++ b/chopper/lib/src/converters.dart
@@ -177,8 +177,8 @@ class JsonConverter implements Converter, ErrorConverter {
       );
     }
 
-    final result = <ItemType>[];
-    var index = 0;
+    final List<ItemType> result = [];
+    int index = 0;
     for (final item in body) {
       if (item is! ItemType) {
         throw FormatException(
@@ -202,7 +202,7 @@ class JsonConverter implements Converter, ErrorConverter {
       );
     }
 
-    final result = <String, ItemType>{};
+    final Map<String, ItemType> result = {};
     for (final entry in body.entries) {
       final key = entry.key;
       if (key is! String) {

--- a/chopper/test/converter_test.dart
+++ b/chopper/test/converter_test.dart
@@ -122,6 +122,20 @@ void main() {
     });
 
     test('decode List reports bad item index', () async {
+      final res = Response(http.Response('["one"]', 200), '["one"]');
+
+      await expectLater(
+        jsonConverter.convertResponse<List<double>, double>(res),
+        throwsA(
+          isA<FormatException>()
+              .having((e) => e.message, 'message', contains('response body[0]'))
+              .having((e) => e.message, 'message', contains('double'))
+              .having((e) => e.message, 'message', contains('String')),
+        ),
+      );
+    });
+
+    test('decode List reports VM int/double mismatch', testOn: 'vm', () async {
       final res = Response(http.Response('[1]', 200), '[1]');
 
       await expectLater(
@@ -165,7 +179,10 @@ void main() {
     });
 
     test('decode Map reports bad field key', () async {
-      final res = Response(http.Response('{"xxxx":1}', 200), '{"xxxx":1}');
+      final res = Response(
+        http.Response('{"xxxx":"one"}', 200),
+        '{"xxxx":"one"}',
+      );
 
       await expectLater(
         jsonConverter.convertResponse<Map<String, double>, double>(res),
@@ -177,7 +194,7 @@ void main() {
                 contains('response body["xxxx"]'),
               )
               .having((e) => e.message, 'message', contains('double'))
-              .having((e) => e.message, 'message', contains('int')),
+              .having((e) => e.message, 'message', contains('String')),
         ),
       );
     });

--- a/chopper/test/converter_test.dart
+++ b/chopper/test/converter_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert' as dart_convert;
 
 import 'package:chopper/src/base.dart';
@@ -212,6 +213,24 @@ void main() {
                 contains('Map<String, String>'),
               )
               .having((e) => e.message, 'message', contains('List')),
+        ),
+      );
+    });
+
+    test('decode Map reports bad key type', () async {
+      final converter = _NonStringKeyJsonConverter();
+      final res = Response(http.Response('', 200), '');
+
+      await expectLater(
+        converter.decodeJson<Map<String, String>, String>(res),
+        throwsA(
+          isA<FormatException>()
+              .having(
+                (e) => e.message,
+                'message',
+                contains('response body key'),
+              )
+              .having((e) => e.message, 'message', contains('String')),
         ),
       );
     });
@@ -750,4 +769,9 @@ class _ConvertedError<T> {
   final T data;
 
   _ConvertedError(this.data);
+}
+
+class _NonStringKeyJsonConverter extends JsonConverter {
+  @override
+  FutureOr<dynamic> tryDecodeJson(String data) => {1: 'one'};
 }

--- a/chopper/test/converter_test.dart
+++ b/chopper/test/converter_test.dart
@@ -96,6 +96,8 @@ void main() {
           .convertResponse<List<String>, String>(res);
 
       expect(converted.body, equals(['foo', 'bar']));
+      converted.body!.add('baz');
+      expect(converted.body, equals(['foo', 'bar', 'baz']));
     });
 
     test('decode List int', () async {
@@ -107,6 +109,48 @@ void main() {
       expect(converted.body, equals([1, 2]));
     });
 
+    test('decode Iterable String', () async {
+      final res = Response(
+        http.Response('["foo","bar"]', 200),
+        '["foo","bar"]',
+      );
+      final converted = await jsonConverter
+          .convertResponse<Iterable<String>, String>(res);
+
+      expect(converted.body, isA<List<String>>());
+      expect(converted.body, equals(['foo', 'bar']));
+    });
+
+    test('decode List reports bad item index', () async {
+      final res = Response(http.Response('[1]', 200), '[1]');
+
+      await expectLater(
+        jsonConverter.convertResponse<List<double>, double>(res),
+        throwsA(
+          isA<FormatException>()
+              .having((e) => e.message, 'message', contains('response body[0]'))
+              .having((e) => e.message, 'message', contains('double'))
+              .having((e) => e.message, 'message', contains('int')),
+        ),
+      );
+    });
+
+    test('decode List reports wrong top-level shape', () async {
+      final res = Response(
+        http.Response('{"foo":"bar"}', 200),
+        '{"foo":"bar"}',
+      );
+
+      await expectLater(
+        jsonConverter.convertResponse<List<String>, String>(res),
+        throwsA(
+          isA<FormatException>()
+              .having((e) => e.message, 'message', contains('Iterable<String>'))
+              .having((e) => e.message, 'message', contains('Map')),
+        ),
+      );
+    });
+
     test('decode Map', () async {
       final res = Response(
         http.Response('{"foo":"bar"}', 200),
@@ -116,6 +160,43 @@ void main() {
           .convertResponse<Map<String, String>, String>(res);
 
       expect(converted.body, equals({'foo': 'bar'}));
+      converted.body!['baz'] = 'qux';
+      expect(converted.body, equals({'foo': 'bar', 'baz': 'qux'}));
+    });
+
+    test('decode Map reports bad field key', () async {
+      final res = Response(http.Response('{"xxxx":1}', 200), '{"xxxx":1}');
+
+      await expectLater(
+        jsonConverter.convertResponse<Map<String, double>, double>(res),
+        throwsA(
+          isA<FormatException>()
+              .having(
+                (e) => e.message,
+                'message',
+                contains('response body["xxxx"]'),
+              )
+              .having((e) => e.message, 'message', contains('double'))
+              .having((e) => e.message, 'message', contains('int')),
+        ),
+      );
+    });
+
+    test('decode Map reports wrong top-level shape', () async {
+      final res = Response(http.Response('["foo"]', 200), '["foo"]');
+
+      await expectLater(
+        jsonConverter.convertResponse<Map<String, String>, String>(res),
+        throwsA(
+          isA<FormatException>()
+              .having(
+                (e) => e.message,
+                'message',
+                contains('Map<String, String>'),
+              )
+              .having((e) => e.message, 'message', contains('List')),
+        ),
+      );
     });
 
     test('decodeJson with bodyBytes and application/json content type', () async {

--- a/example/bin/main_built_value.dart
+++ b/example/bin/main_built_value.dart
@@ -48,10 +48,9 @@ Future<void> main() async {
   print('response 3: ${response3.body}');
 
   try {
-    final builder =
-        ResourceBuilder()
-          ..id = '3'
-          ..name = 'Super Name';
+    final builder = ResourceBuilder()
+      ..id = '3'
+      ..name = 'Super Name';
     await myService.newResource(builder.build());
   } on Response catch (error) {
     print(error.body);

--- a/example/build.yaml
+++ b/example/build.yaml
@@ -11,7 +11,7 @@ targets:
           # For usage information, reference the corresponding field in
           # `JsonSerializableGenerator`.
           any_map: false
-          checked: false
+          checked: true
           explicit_to_json: true
           create_to_json: true
       squadron_builder:worker_builder:

--- a/example/build_serializers.yaml
+++ b/example/build_serializers.yaml
@@ -17,6 +17,6 @@ targets:
           # `JsonSerializableGenerator`.
           use_wrappers: false
           any_map: false
-          checked: false
+          checked: true
           explicit_to_json: true
           generate_to_json_function: true

--- a/example/lib/built_value_resource.chopper.dart
+++ b/example/lib/built_value_resource.chopper.dart
@@ -1,5 +1,5 @@
-// dart format width=80
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format width=80
 
 part of 'built_value_resource.dart';
 

--- a/example/lib/json_decode_service.activator.g.dart
+++ b/example/lib/json_decode_service.activator.g.dart
@@ -1,8 +1,8 @@
-// dart format width=80
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format width=80
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.6 (Squadron 7.1.2+1)
+// Generator: WorkerGenerator 9.2.0 (Squadron 7.4.3)
 // **************************************************************************
 
 import 'json_decode_service.vm.g.dart';

--- a/example/lib/json_decode_service.dart
+++ b/example/lib/json_decode_service.dart
@@ -3,7 +3,10 @@
 import 'dart:async';
 import 'dart:convert' show json;
 
+import 'package:cancelation_token/cancelation_token.dart';
+import 'package:logger/web.dart';
 import 'package:squadron/squadron.dart';
+import 'package:using/using.dart';
 
 import 'json_decode_service.activator.g.dart';
 

--- a/example/lib/json_decode_service.vm.g.dart
+++ b/example/lib/json_decode_service.vm.g.dart
@@ -1,8 +1,8 @@
-// dart format width=80
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format width=80
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.6 (Squadron 7.1.2+1)
+// Generator: WorkerGenerator 9.2.0 (Squadron 7.4.3)
 // **************************************************************************
 
 import 'package:squadron/squadron.dart';

--- a/example/lib/json_decode_service.worker.g.dart
+++ b/example/lib/json_decode_service.worker.g.dart
@@ -1,12 +1,13 @@
-// dart format width=80
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format width=80
 
 part of 'json_decode_service.dart';
 
 // **************************************************************************
-// Generator: WorkerGenerator 7.1.6 (Squadron 7.1.2+1)
+// Generator: WorkerGenerator 9.2.0 (Squadron 7.4.3)
 // **************************************************************************
 
+// dart format width=80
 /// Command ids used in operations map
 const int _$jsonDecodeId = 1;
 
@@ -35,6 +36,22 @@ mixin _$JsonDecodeService$Invoker on Invoker implements JsonDecodeService {
 /// Facade for JsonDecodeService, implements other details of the service unrelated to
 /// invoking the remote service.
 mixin _$JsonDecodeService$Facade implements JsonDecodeService {}
+
+/// WorkerClient for JsonDecodeService
+final class $JsonDecodeService$Client extends WorkerClient
+    with _$JsonDecodeService$Invoker, _$JsonDecodeService$Facade
+    implements JsonDecodeService {
+  $JsonDecodeService$Client(PlatformChannel channelInfo)
+    : super(Channel.deserialize(channelInfo)!);
+}
+
+/// Local worker extension for JsonDecodeService
+extension $JsonDecodeServiceLocalWorkerExt on JsonDecodeService {
+  // Get a fresh local worker instance.
+  LocalWorker<JsonDecodeService> getLocalWorker([
+    ExceptionManager? exceptionManager,
+  ]) => LocalWorker.create(this, _$getOperations(), exceptionManager);
+}
 
 /// WorkerService class for JsonDecodeService
 class _$JsonDecodeService$WorkerService extends JsonDecodeService
@@ -147,10 +164,6 @@ base class JsonDecodeServiceWorker
 
   @override
   bool get isStopped => _$worker.isStopped;
-
-  @override
-  // ignore: deprecated_member_use
-  WorkerStat get stats => _$worker.stats;
 
   @override
   WorkerStat getStats() => _$worker.getStats();
@@ -336,7 +349,7 @@ base class JsonDecodeServiceWorkerPool
   void cancel(Task task, [String? message]) => _$pool.cancel(task, message);
 
   @override
-  FutureOr<void> start() => _$pool.start();
+  Future<void> start() => _$pool.start();
 
   @override
   int stop([bool Function(JsonDecodeServiceWorker worker)? predicate]) =>

--- a/example/lib/json_serializable.chopper.dart
+++ b/example/lib/json_serializable.chopper.dart
@@ -1,5 +1,5 @@
-// dart format width=80
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format width=80
 
 part of 'json_serializable.dart';
 

--- a/example/lib/json_serializable.g.dart
+++ b/example/lib/json_serializable.g.dart
@@ -7,7 +7,13 @@ part of 'json_serializable.dart';
 // **************************************************************************
 
 Resource _$ResourceFromJson(Map<String, dynamic> json) =>
-    Resource(json['id'] as String, json['name'] as String);
+    $checkedCreate('Resource', json, ($checkedConvert) {
+      final val = Resource(
+        $checkedConvert('id', (v) => v as String),
+        $checkedConvert('name', (v) => v as String),
+      );
+      return val;
+    });
 
 Map<String, dynamic> _$ResourceToJson(Resource instance) => <String, dynamic>{
   'id': instance.id,
@@ -15,7 +21,13 @@ Map<String, dynamic> _$ResourceToJson(Resource instance) => <String, dynamic>{
 };
 
 ResourceError _$ResourceErrorFromJson(Map<String, dynamic> json) =>
-    ResourceError(json['type'] as String, json['message'] as String);
+    $checkedCreate('ResourceError', json, ($checkedConvert) {
+      final val = ResourceError(
+        $checkedConvert('type', (v) => v as String),
+        $checkedConvert('message', (v) => v as String),
+      );
+      return val;
+    });
 
 Map<String, dynamic> _$ResourceErrorToJson(ResourceError instance) =>
     <String, dynamic>{'type': instance.type, 'message': instance.message};

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,24 +5,27 @@ documentation: https://hadrien-lejard.gitbook.io/chopper/
 #author: Hadrien Lejard <hadrien.lejard@gmail.com>
 
 environment:
-  sdk: ^3.7.0
+  sdk: ^3.9.0
 
 dependencies:
-  chopper: ^8.4.0
-  json_annotation: ^4.9.0
+  chopper: ^8.5.2
+  json_annotation: ^4.12.0
   built_value: ^8.11.0
-  analyzer: ">=7.4.0 <9.0.0"
-  http: ^1.5.0
+  analyzer: ">=8.0.0 <14.0.0"
+  http: ^1.6.0
   built_collection: ^5.1.1
-  squadron: ^7.1.2+1
+  cancelation_token: ^1.1.0
+  logger: ^2.7.0
+  squadron: ^7.4.3
+  using: ^1.0.5
 
 dev_dependencies:
-  build_runner: ^2.4.9
+  build_runner: ^2.15.0
   chopper_generator:
-  json_serializable: ^6.8.0
-  built_value_generator: ^8.9.2
-  lints: ^6.0.0
-  squadron_builder: ^7.1.6
+  json_serializable: ^6.14.0
+  built_value_generator: ^8.12.5
+  lints: ^6.1.0
+  squadron_builder: ^9.2.0
 
 dependency_overrides:
  chopper:

--- a/faq.md
+++ b/faq.md
@@ -353,6 +353,13 @@ Extracted from the [full example here](example/lib/json_decode_service.dart).
 Using [json_serializable](https://pub.dev/packages/json_serializable) we'll create a [JsonConverter](https://github.com/lejard-h/chopper/blob/master/chopper/lib/src/interceptor.dart#L228)
 which works with or without a [WorkerPool](https://github.com/d-markey/squadron#features).
 
+When `JsonConverter` decodes directly into typed JSON collections, such as
+`Response<List<double>>` or `Response<Map<String, double>>`, Chopper can report
+the list index or map key that failed conversion. Model fields are decoded by
+your serializer factory, so enable `checked: true` for `json_serializable` to
+get `CheckedFromJsonException` errors with field context from generated
+`fromJson` methods.
+
 ```dart
 import 'dart:async' show FutureOr;
 import 'dart:convert' show jsonDecode;


### PR DESCRIPTION
## Summary

Fixes #351 by improving `JsonConverter` diagnostics for typed JSON collection responses.

When Chopper owns the typed conversion for responses like `Response<List<double>>` or `Response<Map<String, double>>`, conversion failures now include the failing list index or map key instead of surfacing a vague cast error.

## Changes

- Eagerly validates typed JSON `Iterable` and `Map<String, T>` responses in `JsonConverter`
- Throws `FormatException` with clearer key/index context for invalid collection values
- Adds regression tests for list index, map key, wrong top-level shape, and existing valid conversions
- Enables `json_serializable` checked mode in the example config
- Updates the FAQ to explain that DTO field-name diagnostics come from serializer support, such as `json_serializable` `checked: true`
- Refreshes example generator dependencies and generated files so example codegen/analyze works cleanly