### PR TITLE
:sparkles: add HTTP QUERY (RFC 10008) support

### DIFF
--- a/chopper/example/definition.chopper.dart
+++ b/chopper/example/definition.chopper.dart
@@ -50,6 +50,23 @@ final class _$MyService extends MyService {
   }
 
   @override
+  Future<Response<Map<String, dynamic>>> searchResources(
+    Map<String, dynamic> query,
+  ) {
+    final Uri $url = Uri.parse('/resources/search');
+    final Map<String, String> $headers = {'content-type': 'application/json'};
+    final $body = query;
+    final Request $request = Request(
+      'QUERY',
+      $url,
+      client.baseUrl,
+      body: $body,
+      headers: $headers,
+    );
+    return client.send<Map<String, dynamic>, Map<String, dynamic>>($request);
+  }
+
+  @override
   Future<Response<dynamic>> postResourceUrlEncoded(String toto, String b) {
     final Uri $url = Uri.parse('/resources/');
     final Map<String, String> $headers = {

--- a/chopper/example/definition.dart
+++ b/chopper/example/definition.dart
@@ -17,6 +17,11 @@ abstract class MyService extends ChopperService {
   @GET(path: '/resources')
   Future<Response<List<Map>>> getListResources();
 
+  @QUERY(path: '/search', headers: {contentTypeKey: jsonHeaders})
+  Future<Response<Map<String, dynamic>>> searchResources(
+    @Body() Map<String, dynamic> query,
+  );
+
   @POST(path: '/')
   @FormUrlEncoded()
   Future<Response> postResourceUrlEncoded(

--- a/chopper/example/main.dart
+++ b/chopper/example/main.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:chopper/chopper.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
@@ -9,6 +11,15 @@ Future<void> main() async {
     client: MockClient((request) async {
       if (request.url.path == '/resources/resources') {
         return http.Response('[{"id":"1","name":"Foo"}]', 200);
+      }
+      if (request.url.path == '/resources/search' &&
+          request.method == HttpMethod.Query) {
+        final query = jsonDecode(request.body) as Map<String, dynamic>;
+        return http.Response(
+          jsonEncode({'query': query, 'matches': 1}),
+          200,
+          headers: {contentTypeKey: jsonHeaders},
+        );
       }
 
       return http.Response('{"id":"1","name":"Foo"}', 200);
@@ -28,6 +39,12 @@ Future<void> main() async {
 
   final list = await myService.getListResources();
   print(list.body);
+
+  final search = await myService.searchResources({
+    'term': 'chopper',
+    'limit': 10,
+  });
+  print(search.body);
 
   chopper.dispose();
 }

--- a/chopper/lib/src/annotations.dart
+++ b/chopper/lib/src/annotations.dart
@@ -906,6 +906,9 @@ const header = Header();
 /// {@macro GET}
 const get = GET();
 
+/// {@macro QUERY}
+const httpQuery = QUERY();
+
 /// {@macro POST}
 const post = POST();
 

--- a/chopper/lib/src/annotations.dart
+++ b/chopper/lib/src/annotations.dart
@@ -110,7 +110,7 @@ final class QueryMap {
 }
 
 /// {@template Body}
-/// Declares the Body of [POST], [PUT], and [PATCH] requests
+/// Declares the Body of [QUERY], [POST], [PUT], and [PATCH] requests
 ///
 /// ```dart
 /// @POST()
@@ -158,7 +158,8 @@ final class Header {
 /// Must be used inside a [ChopperApi] definition.
 ///
 /// Recommended:
-/// [GET], [POST], [PUT], [DELETE], [PATCH], or [HEAD] should be used instead.
+/// [GET], [QUERY], [POST], [PUT], [DELETE], [PATCH], [HEAD], or [OPTIONS]
+/// should be used instead.
 ///
 /// ```dart
 /// @GET(headers: const {'foo': 'bar' })
@@ -302,6 +303,36 @@ final class Get extends GET {
     super.includeNullQueryVars,
     super.timeout,
   });
+}
+
+/// {@template QUERY}
+/// Defines a method as an HTTP QUERY request.
+///
+/// QUERY is distinct from GET with a body. It asks the target resource to
+/// process the enclosed content in a safe and idempotent manner, as defined by
+/// [RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html).
+///
+/// Use the [Body] annotation to provide the query content. The request must
+/// have a `Content-Type` header consistent with that content. Redirect, retry,
+/// cache, and CORS behavior is determined by the configured HTTP client.
+/// {@endtemplate}
+@immutable
+@Target({TargetKind.method})
+final class QUERY extends Method {
+  /// {@macro QUERY}
+  const QUERY({
+    super.optionalBody,
+    super.path,
+    super.headers,
+    super.listFormat,
+    super.useBrackets,
+    super.dateFormat,
+    super.includeNullQueryVars,
+    super.timeout,
+  })
+    // coverage:ignore-start
+    : super(HttpMethod.Query);
+  // coverage:ignore-end
 }
 
 /// {@template POST}

--- a/chopper/lib/src/base.dart
+++ b/chopper/lib/src/base.dart
@@ -213,6 +213,29 @@ base class ChopperClient {
     ),
   );
 
+  /// Makes an HTTP QUERY request using the [send] function.
+  ///
+  /// QUERY is a safe, idempotent method whose request content describes the
+  /// query to process. The request must have a `Content-Type` header consistent
+  /// with its content. Redirect, retry, cache, and CORS behavior is determined
+  /// by the configured [http.Client].
+  Future<Response<BodyType>> query<BodyType, InnerType>(
+    Uri url, {
+    Map<String, String> headers = const {},
+    Uri? baseUrl,
+    Map<String, dynamic> parameters = const {},
+    dynamic body,
+  }) => send<BodyType, InnerType>(
+    Request(
+      HttpMethod.Query,
+      url,
+      baseUrl ?? this.baseUrl,
+      body: body,
+      headers: headers,
+      parameters: parameters,
+    ),
+  );
+
   /// Makes a HTTP POST request using the [send] function
   Future<Response<BodyType>> post<BodyType, InnerType>(
     Uri url, {

--- a/chopper/lib/src/constants.dart
+++ b/chopper/lib/src/constants.dart
@@ -9,6 +9,7 @@ const String jsonApiHeaders = 'application/vnd.api+json';
 
 abstract final class HttpMethod {
   static const String Get = 'GET';
+  static const String Query = 'QUERY';
   static const String Post = 'POST';
   static const String Put = 'PUT';
   static const String Delete = 'DELETE';

--- a/chopper/lib/src/request.dart
+++ b/chopper/lib/src/request.dart
@@ -3,7 +3,7 @@ import 'dart:async' show Stream;
 import 'package:chopper/src/date_format.dart';
 import 'package:chopper/src/extensions.dart';
 import 'package:chopper/src/utils.dart';
-import 'package:equatable/equatable.dart' show EquatableMixin;
+import 'package:equatable/equatable.dart' show Equatable;
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 import 'package:qs_dart/qs_dart.dart' show ListFormat;
@@ -12,8 +12,7 @@ import 'package:qs_dart/qs_dart.dart' show ListFormat;
 /// This class represents an HTTP request that can be made with Chopper.
 /// {@endtemplate}
 // ignore: must_be_immutable
-base class Request extends http.BaseRequest
-    with http.Abortable, EquatableMixin {
+base class Request extends http.BaseRequest with http.Abortable, Equatable {
   final Uri uri;
   final Uri baseUri;
   final dynamic body;
@@ -298,7 +297,7 @@ base mixin MockRequestMixin implements Request {}
 
 /// Represents a part in a multipart request.
 @immutable
-final class PartValue<T> with EquatableMixin {
+final class PartValue<T> with Equatable {
   final T value;
   final String name;
 

--- a/chopper/lib/src/response.dart
+++ b/chopper/lib/src/response.dart
@@ -1,7 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:chopper/src/chopper_http_exception.dart';
-import 'package:equatable/equatable.dart' show EquatableMixin;
+import 'package:equatable/equatable.dart' show Equatable;
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 
@@ -19,7 +19,7 @@ import 'package:meta/meta.dart';
 /// ```
 /// {@endtemplate}
 @immutable
-base class Response<BodyType> with EquatableMixin {
+base class Response<BodyType> with Equatable {
   /// The [http.BaseResponse] from `package:http` that this [Response] wraps.
   final http.BaseResponse base;
 

--- a/chopper/pubspec.yaml
+++ b/chopper/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.9.0
 
 dependencies:
-  equatable: ^2.0.7
+  equatable: ^2.1.0
   http: ^1.6.0
   logging: ^1.3.0
   meta: ^1.17.0

--- a/chopper/test/annotations_test.chopper.dart
+++ b/chopper/test/annotations_test.chopper.dart
@@ -95,6 +95,19 @@ final class _$ShorthandAnnotationService extends ShorthandAnnotationService {
   }
 
   @override
+  Future<Response<dynamic>> testHttpQueryShorthand(dynamic body) {
+    final Uri $url = Uri.parse('/shorthand');
+    final $body = body;
+    final Request $request = Request(
+      'QUERY',
+      $url,
+      client.baseUrl,
+      body: $body,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
   Future<Response<dynamic>> testPostShorthand(dynamic body) {
     final Uri $url = Uri.parse('/shorthand');
     final $body = body;

--- a/chopper/test/annotations_test.dart
+++ b/chopper/test/annotations_test.dart
@@ -200,6 +200,41 @@ void main() {
       expect(annotation.timeout, null);
     });
 
+    test('QUERY with default arguments', () {
+      const annotation = QUERY();
+      expect(annotation.method, HttpMethod.Query);
+      expect(annotation.path, '');
+      expect(annotation.optionalBody, false);
+      expect(annotation.headers, const {});
+      expect(annotation.listFormat, null);
+      expect(annotation.useBrackets, null);
+      expect(annotation.dateFormat, null);
+      expect(annotation.includeNullQueryVars, null);
+      expect(annotation.timeout, null);
+    });
+
+    test('QUERY with all arguments', () {
+      const annotation = QUERY(
+        path: '/search',
+        optionalBody: true,
+        headers: {'content-type': 'application/json'},
+        listFormat: ListFormat.indices,
+        useBrackets: false,
+        dateFormat: DateFormat.date,
+        includeNullQueryVars: true,
+        timeout: Duration(seconds: 10),
+      );
+      expect(annotation.method, HttpMethod.Query);
+      expect(annotation.path, '/search');
+      expect(annotation.optionalBody, true);
+      expect(annotation.headers, const {'content-type': 'application/json'});
+      expect(annotation.listFormat, ListFormat.indices);
+      expect(annotation.useBrackets, false);
+      expect(annotation.dateFormat, DateFormat.date);
+      expect(annotation.includeNullQueryVars, true);
+      expect(annotation.timeout, const Duration(seconds: 10));
+    });
+
     test('Path with name', () {
       const p = Path('id');
       expect(p.name, 'id');

--- a/chopper/test/annotations_test.dart
+++ b/chopper/test/annotations_test.dart
@@ -35,6 +35,9 @@ abstract class ShorthandAnnotationService extends ChopperService {
   @get
   Future<Response<dynamic>> testGetShorthand();
 
+  @httpQuery
+  Future<Response<dynamic>> testHttpQueryShorthand(@body dynamic body);
+
   @post
   Future<Response<dynamic>> testPostShorthand(@body dynamic body);
 
@@ -113,6 +116,7 @@ void main() {
 
     test('Shorthand method annotations can be instantiated', () {
       expect(get, isA<GET>());
+      expect(httpQuery, isA<QUERY>());
       expect(post, isA<POST>());
       expect(put, isA<PUT>());
       expect(patch, isA<PATCH>());

--- a/chopper/test/base_test.dart
+++ b/chopper/test/base_test.dart
@@ -257,6 +257,38 @@ void main() {
       httpClient.close();
     });
 
+    test('QUERY generated service', () async {
+      final httpClient = MockClient((request) async {
+        expect(
+          request.url.toString(),
+          equals('$baseUrl/test/query_body?scope=articles'),
+        );
+        expect(request.method, equals('QUERY'));
+        expect(request.headers['content-type'], equals(jsonHeaders));
+        expect(request.body, equals('{"term":"chopper"}'));
+
+        return http.Response('query response', 200);
+      });
+
+      final chopper = ChopperClient(
+        baseUrl: baseUrl,
+        services: [HttpTestService.create()],
+        client: httpClient,
+        converter: const JsonConverter(),
+      );
+      final service = chopper.getService<HttpTestService>();
+
+      final response = await service.queryTest({
+        'term': 'chopper',
+      }, scope: 'articles');
+
+      expect(response.body, equals('query response'));
+      expect(response.statusCode, equals(200));
+
+      chopper.dispose();
+      httpClient.close();
+    });
+
     test('POST', () async {
       final httpClient = MockClient((request) async {
         expect(request.url.toString(), equals('$baseUrl/test/post'));

--- a/chopper/test/client_test.dart
+++ b/chopper/test/client_test.dart
@@ -41,6 +41,32 @@ void main() {
 
       httpClient.close();
     });
+
+    test('QUERY', () async {
+      final httpClient = MockClient((request) async {
+        expect(request.url.toString(), equals('$baseUrl/test/query?scope=all'));
+        expect(request.method, equals('QUERY'));
+        expect(request.headers['foo'], equals('bar'));
+        expect(request.headers['content-type'], equals('application/json'));
+        expect(request.body, json.encode({'content': 'body'}));
+
+        return http.Response('query response', 200);
+      });
+
+      final chopper = buildClient(httpClient);
+      final response = await chopper.query(
+        Uri(path: '/test/query'),
+        headers: {'content-type': 'application/json'},
+        parameters: {'scope': 'all'},
+        body: {'content': 'body'},
+      );
+
+      expect(response.body, equals('query response'));
+      expect(response.statusCode, equals(200));
+
+      httpClient.close();
+    });
+
     test('POST', () async {
       final httpClient = MockClient((request) async {
         expect(request.url.toString(), equals('$baseUrl/test/post?key=val'));

--- a/chopper/test/helpers/payload.dart
+++ b/chopper/test/helpers/payload.dart
@@ -1,6 +1,6 @@
 import 'package:equatable/equatable.dart';
 
-final class Payload with EquatableMixin {
+final class Payload with Equatable {
   const Payload({this.statusCode = 200, this.message = 'OK'});
 
   final int statusCode;

--- a/chopper/test/test_service.chopper.dart
+++ b/chopper/test/test_service.chopper.dart
@@ -181,6 +181,78 @@ final class _$HttpTestService extends HttpTestService {
   }
 
   @override
+  Future<Response<dynamic>> queryTest(
+    Map<String, dynamic> body, {
+    String? scope,
+  }) {
+    final Uri $url = Uri.parse('/test/query_body');
+    final Map<String, dynamic> $params = <String, dynamic>{'scope': scope};
+    final Map<String, String> $headers = {'content-type': 'application/json'};
+    final $body = body;
+    final Request $request = Request(
+      'QUERY',
+      $url,
+      client.baseUrl,
+      body: $body,
+      parameters: $params,
+      headers: $headers,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<String>> queryWithTimeout(String body) {
+    final Uri $url = Uri.parse('/test/query_timeout');
+    final Map<String, String> $headers = {'content-type': 'application/json'};
+    final $body = body;
+    final ChopperCompleter $abortTrigger = ChopperCompleter<void>();
+    final ChopperTimer $timeout = ChopperTimer(
+      const Duration(microseconds: 30000000),
+      () {
+        if (!$abortTrigger.isCompleted) $abortTrigger.complete();
+      },
+    );
+    final Request $request = Request(
+      'QUERY',
+      $url,
+      client.baseUrl,
+      body: $body,
+      headers: $headers,
+      abortTrigger: $abortTrigger.future,
+    );
+    return client
+        .send<String, String>($request)
+        .catchError(
+          (_) => Future<Response<String>>.error(
+            ChopperTimeoutException('Request timed out after 30 seconds'),
+          ),
+          test: (Object err) =>
+              err is ChopperRequestAbortedException &&
+              $abortTrigger.isCompleted,
+        )
+        .whenComplete($timeout.cancel);
+  }
+
+  @override
+  Future<Response<String>> queryWithAbortTrigger(
+    String body, {
+    Future<void>? abortTrigger,
+  }) {
+    final Uri $url = Uri.parse('/test/query_abort');
+    final Map<String, String> $headers = {'content-type': 'application/json'};
+    final $body = body;
+    final Request $request = Request(
+      'QUERY',
+      $url,
+      client.baseUrl,
+      body: $body,
+      headers: $headers,
+      abortTrigger: abortTrigger,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
   Future<Response<dynamic>> postTest(String data) {
     final Uri $url = Uri.parse('/test/post');
     final $body = data;

--- a/chopper/test/test_service.dart
+++ b/chopper/test/test_service.dart
@@ -72,6 +72,25 @@ abstract class HttpTestService extends ChopperService {
   @GET(path: 'get_body')
   Future<Response> getBody(@Body() dynamic body);
 
+  @QUERY(path: 'query_body', headers: {contentTypeKey: jsonHeaders})
+  Future<Response> queryTest(
+    @Body() Map<String, dynamic> body, {
+    @Query('scope') String? scope,
+  });
+
+  @QUERY(
+    path: 'query_timeout',
+    headers: {contentTypeKey: jsonHeaders},
+    timeout: Duration(seconds: 30),
+  )
+  Future<Response<String>> queryWithTimeout(@Body() String body);
+
+  @QUERY(path: 'query_abort', headers: {contentTypeKey: jsonHeaders})
+  Future<Response<String>> queryWithAbortTrigger(
+    @Body() String body, {
+    @AbortTrigger() Future<void>? abortTrigger,
+  });
+
   @POST(path: 'post')
   Future<Response> postTest(@Body() String data);
 

--- a/chopper_generator/test/test_service.chopper.dart
+++ b/chopper_generator/test/test_service.chopper.dart
@@ -181,6 +181,78 @@ final class _$HttpTestService extends HttpTestService {
   }
 
   @override
+  Future<Response<dynamic>> queryTest(
+    Map<String, dynamic> body, {
+    String? scope,
+  }) {
+    final Uri $url = Uri.parse('/test/query_body');
+    final Map<String, dynamic> $params = <String, dynamic>{'scope': scope};
+    final Map<String, String> $headers = {'content-type': 'application/json'};
+    final $body = body;
+    final Request $request = Request(
+      'QUERY',
+      $url,
+      client.baseUrl,
+      body: $body,
+      parameters: $params,
+      headers: $headers,
+    );
+    return client.send<dynamic, dynamic>($request);
+  }
+
+  @override
+  Future<Response<String>> queryWithTimeout(String body) {
+    final Uri $url = Uri.parse('/test/query_timeout');
+    final Map<String, String> $headers = {'content-type': 'application/json'};
+    final $body = body;
+    final ChopperCompleter $abortTrigger = ChopperCompleter<void>();
+    final ChopperTimer $timeout = ChopperTimer(
+      const Duration(microseconds: 30000000),
+      () {
+        if (!$abortTrigger.isCompleted) $abortTrigger.complete();
+      },
+    );
+    final Request $request = Request(
+      'QUERY',
+      $url,
+      client.baseUrl,
+      body: $body,
+      headers: $headers,
+      abortTrigger: $abortTrigger.future,
+    );
+    return client
+        .send<String, String>($request)
+        .catchError(
+          (_) => Future<Response<String>>.error(
+            ChopperTimeoutException('Request timed out after 30 seconds'),
+          ),
+          test: (Object err) =>
+              err is ChopperRequestAbortedException &&
+              $abortTrigger.isCompleted,
+        )
+        .whenComplete($timeout.cancel);
+  }
+
+  @override
+  Future<Response<String>> queryWithAbortTrigger(
+    String body, {
+    Future<void>? abortTrigger,
+  }) {
+    final Uri $url = Uri.parse('/test/query_abort');
+    final Map<String, String> $headers = {'content-type': 'application/json'};
+    final $body = body;
+    final Request $request = Request(
+      'QUERY',
+      $url,
+      client.baseUrl,
+      body: $body,
+      headers: $headers,
+      abortTrigger: abortTrigger,
+    );
+    return client.send<String, String>($request);
+  }
+
+  @override
   Future<Response<dynamic>> postTest(String data) {
     final Uri $url = Uri.parse('/test/post');
     final $body = data;

--- a/chopper_generator/test/test_service.dart
+++ b/chopper_generator/test/test_service.dart
@@ -71,6 +71,25 @@ abstract class HttpTestService extends ChopperService {
   @GET(path: 'get_body')
   Future<Response> getBody(@Body() dynamic body);
 
+  @QUERY(path: 'query_body', headers: {contentTypeKey: jsonHeaders})
+  Future<Response> queryTest(
+    @Body() Map<String, dynamic> body, {
+    @Query('scope') String? scope,
+  });
+
+  @QUERY(
+    path: 'query_timeout',
+    headers: {contentTypeKey: jsonHeaders},
+    timeout: Duration(seconds: 30),
+  )
+  Future<Response<String>> queryWithTimeout(@Body() String body);
+
+  @QUERY(path: 'query_abort', headers: {contentTypeKey: jsonHeaders})
+  Future<Response<String>> queryWithAbortTrigger(
+    @Body() String body, {
+    @AbortTrigger() Future<void>? abortTrigger,
+  });
+
   @POST(path: 'post')
   Future<Response> postTest(@Body() String data);
 

--- a/requests.md
+++ b/requests.md
@@ -11,7 +11,7 @@
 | `@DELETE()`, `@delete`                     | `DELETE`  | Defines a `DELETE` request.                             |
 | `@HEAD()`, `@head`                         | `HEAD`    | Defines a `HEAD` request.                               |
 | `@OPTIONS()`, `@options`                   | `OPTIONS` | Defines an `OPTIONS` request.                           |
-| `@QUERY()`                                 | `QUERY`   | Defines a `QUERY` request with content.                 |
+| `@QUERY()`, `@httpQuery`                   | `QUERY`   | Defines a `QUERY` request with content.                 |
 | `@Path()`, `@path`                         | -         | Defines a dynamic path parameter.                       |
 | `@Body()`, `@body`                         | -         | Defines the request's body.                             |
 | `@Header()`, `@header`                     | -         | Defines a dynamic request header.                       |
@@ -46,6 +46,10 @@ abstract class ResourceService extends ChopperService {
   );
 }
 ```
+
+For a request without method options, use `@httpQuery` as a shorthand for
+`@QUERY()`. The existing `@query` annotation continues to define a URL query
+parameter.
 
 The request must include a `Content-Type` consistent with its content. Chopper
 delegates redirects, retries, caching, and CORS behavior to the configured

--- a/requests.md
+++ b/requests.md
@@ -11,6 +11,7 @@
 | `@DELETE()`, `@delete`                     | `DELETE`  | Defines a `DELETE` request.                             |
 | `@HEAD()`, `@head`                         | `HEAD`    | Defines a `HEAD` request.                               |
 | `@OPTIONS()`, `@options`                   | `OPTIONS` | Defines an `OPTIONS` request.                           |
+| `@QUERY()`                                 | `QUERY`   | Defines a `QUERY` request with content.                 |
 | `@Path()`, `@path`                         | -         | Defines a dynamic path parameter.                       |
 | `@Body()`, `@body`                         | -         | Defines the request's body.                             |
 | `@Header()`, `@header`                     | -         | Defines a dynamic request header.                       |
@@ -27,6 +28,34 @@
 | `@PartFileMap()`, `@partFileMap`           | -         | Defines a multipart file part map.                      |
 | `@Tag()`, `@tag`                           | -         | Defines a tag parameter.                                |
 | `@AbortTrigger()`, `@abortTrigger`         | -         | Defines a request cancellation trigger.                 |
+
+## HTTP QUERY requests
+
+Chopper supports the HTTP `QUERY` method defined by
+[RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html). `QUERY` is a safe,
+idempotent method with request content; it is not a `GET` request with a body.
+
+Use `@QUERY` with `@Body()` in a generated service:
+
+```dart
+@ChopperApi(baseUrl: '/resources')
+abstract class ResourceService extends ChopperService {
+  @QUERY(path: '/search', headers: {contentTypeKey: jsonHeaders})
+  Future<Response<Map<String, dynamic>>> searchResources(
+    @Body() Map<String, dynamic> query,
+  );
+}
+```
+
+The request must include a `Content-Type` consistent with its content. Chopper
+delegates redirects, retries, caching, and CORS behavior to the configured
+`http.Client`. Cross-origin browser requests require a CORS preflight that
+permits `QUERY`, and Dart's default native client does not automatically follow
+`QUERY` redirects.
+
+See the
+[runnable package example](https://github.com/lejard-h/chopper/blob/master/chopper/example/main.dart)
+for a complete request.
 
 ## Path resolution
 

--- a/skills/chopper/references/core.md
+++ b/skills/chopper/references/core.md
@@ -71,6 +71,9 @@ Future<Response<List<dynamic>>> search(
 );
 ```
 
+Use `@httpQuery` as the parameterless shorthand for `@QUERY()`. The `@query`
+annotation is reserved for URL query parameters.
+
 QUERY request content must have a consistent `Content-Type`. Set it in the
 method headers or use a request converter that supplies it. Chopper delegates
 redirects, retries, caching, and CORS behavior to the configured `http.Client`:

--- a/skills/chopper/references/core.md
+++ b/skills/chopper/references/core.md
@@ -41,7 +41,7 @@ Use `Uri.parse(...)` for the client base URL. Mention custom `http.Client` only 
 
 Prefer uppercase annotations in examples:
 
-- HTTP methods: `@GET`, `@POST`, `@PUT`, `@PATCH`, `@DELETE`, `@HEAD`, `@OPTIONS`.
+- HTTP methods: `@GET`, `@QUERY`, `@POST`, `@PUT`, `@PATCH`, `@DELETE`, `@HEAD`, `@OPTIONS`.
 - URL values: `@Path`, `@Query`, `@QueryMap`.
 - Headers: `@Header`, method-level `headers: {...}`.
 - Bodies: `@Body`, `@Field`, `@FieldMap`, `@Part`, `@PartFile`, `@PartMap`, `@PartFileMap`.
@@ -57,6 +57,29 @@ Future<Response<List<dynamic>>> search({
   @Query('page') int page = 1,
 });
 ```
+
+### HTTP QUERY
+
+Use `@QUERY` for the safe, idempotent HTTP QUERY method defined by
+[RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html). QUERY is a distinct
+HTTP method, not a GET request with a body.
+
+```dart
+@QUERY(path: '/search', headers: {'content-type': 'application/json'})
+Future<Response<List<dynamic>>> search(
+  @Body() Map<String, dynamic> query,
+);
+```
+
+QUERY request content must have a consistent `Content-Type`. Set it in the
+method headers or use a request converter that supplies it. Chopper delegates
+redirects, retries, caching, and CORS behavior to the configured `http.Client`:
+
+- Cross-origin browser requests require a CORS preflight that permits `QUERY`.
+- Dart's default native `HttpClient` only automatically follows redirects for
+  GET and HEAD, plus POST-to-GET redirects for status 303. It does not
+  automatically follow QUERY redirects; use a suitable custom `http.Client` or
+  handle the 3xx response when strict RFC redirect behavior is required.
 
 ## Responses
 


### PR DESCRIPTION
This pull request introduces support for the HTTP QUERY method in the Chopper library, following [RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html). It adds new annotations, client methods, and test coverage for QUERY requests, and refactors several classes to use the latest `equatable` version. The changes enable Chopper services to define and send QUERY requests with bodies, headers, query parameters, and support for timeout and abort triggers.

**Support for HTTP QUERY method:**

- Added the `QUERY` annotation for service methods, allowing users to define QUERY endpoints with request bodies and custom headers. Also added the shorthand constant `httpQuery`. [[1]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6R308-R337) [[2]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6R909-R911) [[3]](diffhunk://#diff-4f628e5f70ce47d02f35e1da47074fbc9f0ea3933637b9bd2f77de2d36c03849R38-R40) [[4]](diffhunk://#diff-4f628e5f70ce47d02f35e1da47074fbc9f0ea3933637b9bd2f77de2d36c03849R119) [[5]](diffhunk://#diff-7607e3b3c28c2b2035640e70e8d223556fb51fe30608ab5fc6d702ba730a2f15R97-R109)
- Added the `HttpMethod.Query` constant and integrated QUERY into request generation and documentation. [[1]](diffhunk://#diff-d7dd25bf368c87fea8b08aa71fd07e44348a44008efcd4a09a8baf46a6f67314R12) [[2]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6L113-R113) [[3]](diffhunk://#diff-39e351fa55b03968cafd0d33b766f30573fd6c9e469dfb16be24269696ea21c6L161-R162)
- Implemented the `ChopperClient.query` method to send QUERY requests with support for headers, parameters, and body.
- Updated generated service code and example usage to include QUERY endpoints, and extended the example to demonstrate a QUERY request. [[1]](diffhunk://#diff-21d059db28290c3d399331c65bb63c2e961f5f23845fbf7f1239eb97332b2541R52-R68) [[2]](diffhunk://#diff-0f3ff20a35339e6e783c38f467c9175a6bf94b7a634ed5a194ed7de91441f4adR20-R24) [[3]](diffhunk://#diff-2b26668a51a0242fee5d099525032127acfb73cb4e59eb363ba0ed6e17f5072fR15-R23) [[4]](diffhunk://#diff-2b26668a51a0242fee5d099525032127acfb73cb4e59eb363ba0ed6e17f5072fR43-R48)

**Test coverage:**

- Added comprehensive tests for QUERY requests, including shorthand annotation instantiation, default/all arguments, timeout, abort triggers, and integration with the Chopper client. [[1]](diffhunk://#diff-4f628e5f70ce47d02f35e1da47074fbc9f0ea3933637b9bd2f77de2d36c03849R207-R241) [[2]](diffhunk://#diff-ac8c645000433726b9231ba2e1c2ebedd675d0c3108d341706acaadf1e58a457R260-R291) [[3]](diffhunk://#diff-c4a3c796cacdc64cc88ba9f432e7e3cb1b39ab1e401b88f28593d8cc27c304a4R44-R69) [[4]](diffhunk://#diff-9208d1cd8bf5194350aa65706d974792f0d07ff11177b4144b7c70686912a307R183-R254) [[5]](diffhunk://#diff-d0e4b11813c8876585f5c621bbc9167d82deb2d336556232ff7944ceb5a58ebfR75-R93)

**Internal refactoring:**

- Refactored all classes that previously used `EquatableMixin` to use the new `Equatable` mixin, and updated the `equatable` dependency to version 2.1.0. [[1]](diffhunk://#diff-2dc27a5036ef0c21dd7610b955335660b980abb03efbe31bd900159aa2fb4f6aL6-R6) [[2]](diffhunk://#diff-2dc27a5036ef0c21dd7610b955335660b980abb03efbe31bd900159aa2fb4f6aL15-R15) [[3]](diffhunk://#diff-2dc27a5036ef0c21dd7610b955335660b980abb03efbe31bd900159aa2fb4f6aL301-R300) [[4]](diffhunk://#diff-bcb5f3c428a90d12092824ada145b8f00d9150c1e28d6e13404e35925e06319eL4-R4) [[5]](diffhunk://#diff-bcb5f3c428a90d12092824ada145b8f00d9150c1e28d6e13404e35925e06319eL22-R22) [[6]](diffhunk://#diff-8627f78286f31e49f425dafbf1e71affb5a3d8d2d1f45838a3069942d8dd3f37L3-R3) [[7]](diffhunk://#diff-c7bda5cb4208050349dcb19de97acd43bb7dfbc5eda9b87acc22e3193c1bc158L11-R11)