### PR TITLE
:construction_worker: update mono_repo to version 6.7.2

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v6.6.3
+# Created with package:mono_repo v6.7.2
 name: Dart CI
 on:
   push:
@@ -37,8 +37,10 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: mono_repo self validate
-        run: dart pub global activate mono_repo 6.6.3
+        run: dart pub global activate mono_repo 6.7.2
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
@@ -62,6 +64,8 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - id: chopper_pub_upgrade
         name: chopper; dart pub upgrade
         run: dart pub upgrade
@@ -124,6 +128,8 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - id: chopper_pub_upgrade
         name: chopper; dart pub upgrade
         run: dart pub upgrade
@@ -196,6 +202,8 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - id: chopper_pub_upgrade
         name: chopper; dart pub upgrade
         run: dart pub upgrade

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Created with package:mono_repo v6.6.3
+# Created with package:mono_repo v6.7.2
 
 # Support built in commands on windows out of the box.
 


### PR DESCRIPTION
This pull request updates the CI configuration to use a newer version of the `mono_repo` package and improves security for repository checkouts in GitHub Actions workflows. The changes are mainly focused on keeping dependencies up to date and following best practices for CI workflows.

**CI/CD configuration updates:**

* Upgraded `mono_repo` from version 6.6.3 to 6.7.2 in both `.github/workflows/dart.yml` and `tool/ci.sh` to ensure the CI pipeline uses the latest features and bug fixes. [[1]](diffhunk://#diff-c6fe895eea1e566d8f6f9f7e5f045b702d9bff8e60bfaec2d412193bd802ab2aL1-R1) [[2]](diffhunk://#diff-c6fe895eea1e566d8f6f9f7e5f045b702d9bff8e60bfaec2d412193bd802ab2aR40-R43) [[3]](diffhunk://#diff-3ccfa73ca92e661eee25215d4fb32eeb727e2f9169c85d62c079a6e4999e323eL2-R2)

**Security improvements:**

* Updated all `actions/checkout@v7` steps in `.github/workflows/dart.yml` to set `persist-credentials: false`, which helps prevent the accidental leaking of repository credentials in subsequent workflow steps. [[1]](diffhunk://#diff-c6fe895eea1e566d8f6f9f7e5f045b702d9bff8e60bfaec2d412193bd802ab2aR40-R43) [[2]](diffhunk://#diff-c6fe895eea1e566d8f6f9f7e5f045b702d9bff8e60bfaec2d412193bd802ab2aR67-R68) [[3]](diffhunk://#diff-c6fe895eea1e566d8f6f9f7e5f045b702d9bff8e60bfaec2d412193bd802ab2aR131-R132) [[4]](diffhunk://#diff-c6fe895eea1e566d8f6f9f7e5f045b702d9bff8e60bfaec2d412193bd802ab2aR205-R206)